### PR TITLE
Enhance filter command/tool to include the schema by default

### DIFF
--- a/internal/agent/commands/help_command.go
+++ b/internal/agent/commands/help_command.go
@@ -53,7 +53,7 @@ func (h *HelpCommand) showGeneralHelp() {
 	h.output.OutputLine("  list resources               - List all available resources")
 	h.output.OutputLine("  list prompts                 - List all available prompts")
 	h.output.OutputLine("  list core-tools              - List core muster tools (built-in functionality)")
-	h.output.OutputLine("  filter tools [pattern] [desc] - Filter tools by name pattern or description")
+	h.output.OutputLine("  filter tools [pattern] [desc] [case] [brief] - Filter tools with full specifications")
 	h.output.OutputLine("  describe tool <name>         - Show detailed information about a tool")
 	h.output.OutputLine("  describe resource <uri>      - Show detailed information about a resource")
 	h.output.OutputLine("  describe prompt <name>       - Show detailed information about a prompt")

--- a/internal/agent/server_mcp.go
+++ b/internal/agent/server_mcp.go
@@ -188,7 +188,7 @@ func (m *MCPServer) registerTools() {
 
 	// Filter tools
 	filterToolsTool := mcp.NewTool("filter_tools",
-		mcp.WithDescription("Filter available tools based on name patterns or descriptions"),
+		mcp.WithDescription("Filter available tools based on name patterns or descriptions with full specifications"),
 		mcp.WithString("pattern",
 			mcp.Description("Pattern to match against tool names (supports wildcards like *)"),
 		),
@@ -197,6 +197,9 @@ func (m *MCPServer) registerTools() {
 		),
 		mcp.WithBoolean("case_sensitive",
 			mcp.Description("Whether pattern matching should be case-sensitive (default: false)"),
+		),
+		mcp.WithBoolean("include_schema",
+			mcp.Description("Whether to include full tool specifications with input schemas (default: true)"),
 		),
 	)
 	m.mcpServer.AddTool(filterToolsTool, m.handleFilterTools)


### PR DESCRIPTION
The filter command previously only responded with tool names and descriptions. But now the inputSchema is included as well. Making it easier for the agent to call the tools right away.