### PR TITLE
Fix updatedAt field and remove id field from services

### DIFF
--- a/internal/api/orchestrator_test.go
+++ b/internal/api/orchestrator_test.go
@@ -265,13 +265,13 @@ func (m *mockOrchestratorHandler) GetAllServices() []ServiceStatus {
 // ServiceClass-based dynamic service instance management methods (for test compatibility)
 func (m *mockOrchestratorHandler) CreateServiceClassInstance(ctx context.Context, req CreateServiceInstanceRequest) (*ServiceInstance, error) {
 	return &ServiceInstance{
-		ID:               "test-service-id",
 		Name:             req.Name,
 		ServiceClassName: req.ServiceClassName,
 		ServiceClassType: "test",
 		State:            StateStopped,
 		Health:           HealthUnknown,
 		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
 		ServiceData:      make(map[string]interface{}),
 	}, nil
 }
@@ -282,26 +282,26 @@ func (m *mockOrchestratorHandler) DeleteServiceClassInstance(ctx context.Context
 
 func (m *mockOrchestratorHandler) GetServiceClassInstance(serviceID string) (*ServiceInstance, error) {
 	return &ServiceInstance{
-		ID:               serviceID,
 		Name:             "test-name",
 		ServiceClassName: "test-class",
 		ServiceClassType: "test",
 		State:            StateRunning,
 		Health:           HealthHealthy,
 		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
 		ServiceData:      make(map[string]interface{}),
 	}, nil
 }
 
 func (m *mockOrchestratorHandler) GetServiceClassInstanceByName(name string) (*ServiceInstance, error) {
 	return &ServiceInstance{
-		ID:               "test-service-id",
 		Name:             name,
 		ServiceClassName: "test-class",
 		ServiceClassType: "test",
 		State:            StateRunning,
 		Health:           HealthHealthy,
 		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
 		ServiceData:      make(map[string]interface{}),
 	}, nil
 }
@@ -309,13 +309,13 @@ func (m *mockOrchestratorHandler) GetServiceClassInstanceByName(name string) (*S
 func (m *mockOrchestratorHandler) ListServiceClassInstances() []ServiceInstance {
 	return []ServiceInstance{
 		{
-			ID:               "test-service-id-1",
 			Name:             "test-name-1",
 			ServiceClassName: "test-class",
 			ServiceClassType: "test",
 			State:            StateRunning,
 			Health:           HealthHealthy,
 			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
 			ServiceData:      make(map[string]interface{}),
 		},
 	}
@@ -329,26 +329,26 @@ func (m *mockOrchestratorHandler) SubscribeToServiceInstanceEvents() <-chan Serv
 // Add missing ServiceManagerHandler methods
 func (m *mockOrchestratorHandler) GetService(name string) (*ServiceInstance, error) {
 	return &ServiceInstance{
-		ID:               "test-service-id",
 		Name:             name,
 		ServiceClassName: "test-class",
 		ServiceClassType: "test",
 		State:            StateRunning,
 		Health:           HealthHealthy,
 		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
 		ServiceData:      make(map[string]interface{}),
 	}, nil
 }
 
 func (m *mockOrchestratorHandler) CreateService(ctx context.Context, req CreateServiceInstanceRequest) (*ServiceInstance, error) {
 	return &ServiceInstance{
-		ID:               "test-service-id",
 		Name:             req.Name,
 		ServiceClassName: req.ServiceClassName,
 		ServiceClassType: "test",
 		State:            StateRunning,
 		Health:           HealthHealthy,
 		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
 		ServiceData:      make(map[string]interface{}),
 	}, nil
 }

--- a/internal/api/serviceinstance.go
+++ b/internal/api/serviceinstance.go
@@ -12,10 +12,6 @@ import (
 // The struct is designed to support both YAML serialization for persistence and JSON serialization
 // for API responses, with some fields excluded from YAML when they represent transient runtime state.
 type ServiceInstance struct {
-	// ID is the unique identifier for this service instance.
-	// This is typically generated automatically when the instance is created.
-	ID string `json:"id" yaml:"id"`
-
 	// Name is the human-readable name for this service instance.
 	// If not provided, it may be derived from the ServiceClass defaultName or ID.
 	Name string `json:"name,omitempty" yaml:"name"`

--- a/internal/orchestrator/api_adapter.go
+++ b/internal/orchestrator/api_adapter.go
@@ -205,6 +205,7 @@ func (a *Adapter) convertToAPIServiceInstance(internalInfo *ServiceInstanceInfo)
 		Health:           api.HealthStatus(internalInfo.Health),
 		LastError:        internalInfo.LastError,
 		CreatedAt:        internalInfo.CreatedAt,
+		UpdatedAt:        internalInfo.UpdatedAt,
 		LastChecked:      internalInfo.LastChecked,
 		ServiceData:      internalInfo.ServiceData,
 		Args:             internalInfo.CreationArgs,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -57,6 +57,7 @@ type ServiceInstanceInfo struct {
 	Health           string                 `json:"health"`
 	LastError        string                 `json:"lastError,omitempty"`
 	CreatedAt        time.Time              `json:"createdAt"`
+	UpdatedAt        time.Time              `json:"updatedAt"`
 	LastChecked      *time.Time             `json:"lastChecked,omitempty"`
 	ServiceData      map[string]interface{} `json:"serviceData,omitempty"`
 	CreationArgs     map[string]interface{} `json:"creationArgs"`
@@ -503,7 +504,8 @@ func (o *Orchestrator) CreateServiceClassInstance(ctx context.Context, req Creat
 		ServiceClassType: "serviceclass", // Default since Type field removed from API in Phase 3
 		State:            string(instance.GetState()),
 		Health:           string(instance.GetHealth()),
-		CreatedAt:        time.Now(),
+		CreatedAt:        instance.GetCreatedAt(),
+		UpdatedAt:        time.Now(),
 		ServiceData:      instance.GetServiceData(),
 		CreationArgs:     req.Args,
 		Outputs:          resolvedOutputs,
@@ -609,6 +611,7 @@ func (o *Orchestrator) serviceInstanceToInfo(serviceName string, instance *servi
 		Health:           string(instance.GetHealth()),
 		LastError:        "",
 		CreatedAt:        instance.GetCreatedAt(),
+		UpdatedAt:        instance.GetUpdatedAt(),
 		ServiceData:      instance.GetServiceData(),
 		CreationArgs:     instance.GetCreationArgs(),
 		Outputs:          instance.GetOutputs(), // Now available from the instance

--- a/internal/services/instance.go
+++ b/internal/services/instance.go
@@ -458,6 +458,13 @@ func (gsi *GenericServiceInstance) GetCreatedAt() time.Time {
 	return gsi.createdAt
 }
 
+// GetUpdatedAt returns the last update time for this instance
+func (gsi *GenericServiceInstance) GetUpdatedAt() time.Time {
+	gsi.mu.RLock()
+	defer gsi.mu.RUnlock()
+	return gsi.updatedAt
+}
+
 // UpdateState implements the StateUpdater interface
 func (gsi *GenericServiceInstance) UpdateState(state ServiceState, health HealthStatus, err error) {
 	gsi.mu.Lock()


### PR DESCRIPTION
This pull request introduces changes to improve the tracking of service instance updates by adding an `UpdatedAt` field across the codebase. It also removes the `ID` field from the `ServiceInstance` struct, simplifying the representation of service instances. Below is a summary of the most important changes grouped by theme.

### Improved tracking of service instance updates:

* Added an `UpdatedAt` field to the `ServiceInstanceInfo` struct in `internal/orchestrator/orchestrator.go` to track the last update time of service instances.
* Updated the `CreateServiceClassInstance` and `serviceInstanceToInfo` methods in `internal/orchestrator/orchestrator.go` to populate the `UpdatedAt` field appropriately. [[1]](diffhunk://#diff-638a5da264133dbb27fa6365043fedbc908d8926e58fcd22f9616d13a8c406e5L506-R508) [[2]](diffhunk://#diff-638a5da264133dbb27fa6365043fedbc908d8926e58fcd22f9616d13a8c406e5R614)
* Added a `GetUpdatedAt` method to the `GenericServiceInstance` struct in `internal/services/instance.go` to retrieve the last update time.
* Modified the `convertToAPIServiceInstance` method in `internal/orchestrator/api_adapter.go` to include the `UpdatedAt` field in API conversions.

### Simplification of service instance representation:

* Removed the `ID` field from the `ServiceInstance` struct in `internal/api/serviceinstance.go` to simplify service instance representation.
* Updated test methods in `internal/api/orchestrator_test.go` to remove references to the `ID` field and ensure compatibility with the updated `ServiceInstance` struct. [[1]](diffhunk://#diff-aae9d73a8e830ddcb37b346eadee856f70d32302d0510424c35b974c6de68327L268-R274) [[2]](diffhunk://#diff-aae9d73a8e830ddcb37b346eadee856f70d32302d0510424c35b974c6de68327L285-R318) [[3]](diffhunk://#diff-aae9d73a8e830ddcb37b346eadee856f70d32302d0510424c35b974c6de68327L332-R351)