### PR TITLE
Set config directory early to avoid bugs handling the empty string (those should be fixed with this change as well)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ All notable changes to this project will be documented in this file.
   - When a K8s connection transitions to Failed state (e.g., due to network issues), all dependent services (port forwards and MCP servers) are now properly stopped
   - This prevents orphaned services from continuing to run when their underlying K8s connection is no longer healthy
   - Services will automatically restart when the K8s connection recovers
+- Set config directory early to avoid bugs handling the empty string (those should be fixed with this change as well)
 
 ### Documentation
 - Added comprehensive documentation about dependency graph implementation
@@ -212,6 +213,6 @@ All notable changes to this project will be documented in this file.
 
 ### Technical Details
 - Streamlined MCP server architecture by removing container support
-- Simplified MCP server lifecycle management 
+- Simplified MCP server lifecycle management
 
-## [0.6.0] - 2025-01-15 
+## [0.6.0] - 2025-01-15

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -10,6 +10,7 @@ import (
 
 	"muster/internal/agent"
 	"muster/internal/cli"
+	"muster/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,7 @@ var (
 var agentCmd = &cobra.Command{
 	Use:   "agent",
 	Short: "MCP Client for the muster aggregator server",
-	Long: `The agent command connects to the MCP aggregator as a client agent, 
+	Long: `The agent command connects to the MCP aggregator as a client agent,
 logs all JSON-RPC communication, and demonstrates dynamic tool updates.
 
 This is useful for connecting the aggregator's behavior, filtering
@@ -78,7 +79,7 @@ func init() {
 	agentCmd.Flags().BoolVar(&agentREPL, "repl", false, "Start interactive REPL mode")
 	agentCmd.Flags().BoolVar(&agentMCPServer, "mcp-server", false, "Run as MCP server (stdio transport)")
 	agentCmd.Flags().StringVar(&agentTransport, "transport", string(agent.TransportStreamableHTTP), "Transport to use (streamable-http, sse)")
-	agentCmd.Flags().StringVar(&agentConfigPath, "config-path", "", "Custom configuration directory path")
+	agentCmd.Flags().StringVar(&agentConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 
 	// Mark flags as mutually exclusive
 	agentCmd.MarkFlagsMutuallyExclusive("repl", "mcp-server")

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"muster/internal/cli"
+	"muster/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -74,7 +75,7 @@ func init() {
 	// Add flags to the command
 	checkCmd.PersistentFlags().StringVarP(&checkOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	checkCmd.PersistentFlags().BoolVarP(&checkQuiet, "quiet", "q", false, "Suppress non-essential output")
-	checkCmd.PersistentFlags().StringVar(&checkConfigPath, "config-path", "", "Custom configuration directory path")
+	checkCmd.PersistentFlags().StringVar(&checkConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"muster/internal/cli"
+	"muster/internal/config"
 	"os"
 	"strings"
 
@@ -110,7 +111,7 @@ func init() {
 	// Add flags to the command
 	createCmd.PersistentFlags().StringVarP(&createOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	createCmd.PersistentFlags().BoolVarP(&createQuiet, "quiet", "q", false, "Suppress non-essential output")
-	createCmd.PersistentFlags().StringVar(&createConfigPath, "config-path", "", "Custom configuration directory path")
+	createCmd.PersistentFlags().StringVar(&createConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 }
 
 // parseServiceParameters extracts service parameters from raw command line arguments

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"muster/internal/cli"
+	"muster/internal/config"
 	"sort"
 	"strings"
 
@@ -177,7 +178,7 @@ func init() {
 	// Add flags to the command
 	getCmd.PersistentFlags().StringVarP(&getOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	getCmd.PersistentFlags().BoolVarP(&getQuiet, "quiet", "q", false, "Suppress non-essential output")
-	getCmd.PersistentFlags().StringVar(&getConfigPath, "config-path", "", "Custom configuration directory path")
+	getCmd.PersistentFlags().StringVar(&getConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 }
 
 func runGet(cmd *cobra.Command, args []string) error {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"muster/internal/cli"
+	"muster/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,7 @@ var listCmd = &cobra.Command{
 
 Available resource types:
   service             - List all services with their status
-  serviceclass        - List all ServiceClass definitions  
+  serviceclass        - List all ServiceClass definitions
   mcpserver           - List all MCP server definitions
   workflow            - List all workflow definitions
   workflow-execution  - List all workflow execution history
@@ -64,7 +65,7 @@ func init() {
 	// Add flags to the command
 	listCmd.PersistentFlags().StringVarP(&listOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	listCmd.PersistentFlags().BoolVarP(&listQuiet, "quiet", "q", false, "Suppress non-essential output")
-	listCmd.PersistentFlags().StringVar(&listConfigPath, "config-path", "", "Custom configuration directory path")
+	listCmd.PersistentFlags().StringVar(&listConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 }
 
 func runList(cmd *cobra.Command, args []string) error {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"muster/internal/app"
+	"muster/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -20,8 +21,7 @@ var serveSilent bool
 // When enabled, all MCP tools can be executed without restrictions.
 var serveYolo bool
 
-// configPath specifies a custom configuration directory path.
-// When set, loads all config from this directory instead of the default ~/.config/muster.
+// configPath specifies the configuration directory.
 // The directory should contain config.yaml and subdirectories: mcpservers/, workflows/, serviceclasses/, services/
 var serveConfigPath string
 
@@ -44,11 +44,11 @@ muster agent --mcp-server
 
 Configuration:
   muster loads configuration from ~/.config/muster by default.
-  
+
   Use --config-path to specify a custom directory containing all configuration files:
   - config.yaml (main configuration)
   - mcpservers/ (MCP server definitions)
-  - workflows/ (workflow definitions)  
+  - workflows/ (workflow definitions)
 
   - serviceclasses/ (service class definitions)
   - services/ (service instance definitions)`,
@@ -84,5 +84,5 @@ func init() {
 	serveCmd.Flags().BoolVar(&serveDebug, "debug", false, "Enable general debug logging")
 	serveCmd.Flags().BoolVar(&serveSilent, "silent", false, "Disable all output to the console")
 	serveCmd.Flags().BoolVar(&serveYolo, "yolo", false, "Disable denylist for destructive tool calls (use with caution)")
-	serveCmd.Flags().StringVar(&serveConfigPath, "config-path", "", "Custom configuration directory path")
+	serveCmd.Flags().StringVar(&serveConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"muster/internal/cli"
+	"muster/internal/config"
 	"os"
 	"strings"
 
@@ -123,7 +124,7 @@ func init() {
 	// Add flags to the command
 	startCmd.PersistentFlags().StringVarP(&startOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	startCmd.PersistentFlags().BoolVarP(&startQuiet, "quiet", "q", false, "Suppress non-essential output")
-	startCmd.PersistentFlags().StringVar(&startConfigPath, "config-path", "", "Custom configuration directory path")
+	startCmd.PersistentFlags().StringVar(&startConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 }
 
 // parseWorkflowParameters extracts workflow parameters from raw command line arguments

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"muster/internal/cli"
+	"muster/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -67,7 +68,7 @@ func init() {
 	// Add flags to the command
 	stopCmd.PersistentFlags().StringVarP(&stopOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	stopCmd.PersistentFlags().BoolVarP(&stopQuiet, "quiet", "q", false, "Suppress non-essential output")
-	stopCmd.PersistentFlags().StringVar(&stopConfigPath, "config-path", "", "Custom configuration directory path")
+	stopCmd.PersistentFlags().StringVar(&stopConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 }
 
 func runStop(cmd *cobra.Command, args []string) error {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"muster/internal/agent"
 	"muster/internal/cli"
+	"muster/internal/config"
 	"muster/internal/testing"
 	"muster/internal/testing/mock"
 	"os"
@@ -187,7 +188,7 @@ func init() {
 	testCmd.Flags().StringVar(&testSchemaInput, "schema-input", "schema.json", "Input schema file for validation")
 
 	// Muster configuration path flag
-	testCmd.Flags().StringVar(&testMusterConfigPath, "config-path", "", "Custom configuration directory path")
+	testCmd.Flags().StringVar(&testMusterConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 
 	// Flag to keep temporary config for debugging
 	testCmd.Flags().BoolVar(&testKeepTempConfig, "keep-temp-config", false, "Keep temporary config directory after test execution for debugging")

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -72,22 +72,14 @@ func NewApplication(cfg *Config) (*Application, error) {
 	var musterCfg config.MusterConfig
 	var err error
 
-	if cfg.ConfigPath != "" {
-		// Use single directory configuration loading
-		musterCfg, err = config.LoadConfigFromPath(cfg.ConfigPath)
-		if err != nil {
-			logging.Error("Bootstrap", err, "Failed to load muster configuration from path: %s", cfg.ConfigPath)
-			return nil, fmt.Errorf("failed to load muster configuration from path %s: %w", cfg.ConfigPath, err)
-		}
-		logging.Info("Bootstrap", "Loaded configuration from custom path: %s", cfg.ConfigPath)
-	} else {
-		// Use layered configuration loading (default behavior)
-		musterCfg, err = config.LoadConfig()
-		if err != nil {
-			logging.Error("Bootstrap", err, "Failed to load muster configuration")
-			return nil, fmt.Errorf("failed to load muster configuration: %w", err)
-		}
-		logging.Info("Bootstrap", "Loaded configuration using layered approach")
+	if cfg.ConfigPath == "" {
+		panic("Logic error: empty ConfigPath")
+	}
+
+	musterCfg, err = config.LoadConfigFromPath(cfg.ConfigPath)
+	if err != nil {
+		logging.Error("Bootstrap", err, "Failed to load muster configuration from path: %s", cfg.ConfigPath)
+		return nil, fmt.Errorf("failed to load muster configuration from path %s: %w", cfg.ConfigPath, err)
 	}
 
 	cfg.MusterConfig = &musterCfg

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -29,6 +29,7 @@ func TestNewApplication_ConfigValidation(t *testing.T) {
 						Enabled: false,
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			expectError: false,
 			errorReason: "valid config should succeed",
@@ -45,6 +46,7 @@ func TestNewApplication_ConfigValidation(t *testing.T) {
 						Enabled: false,
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			expectError: false,
 			errorReason: "no-tui config should work",
@@ -61,6 +63,7 @@ func TestNewApplication_ConfigValidation(t *testing.T) {
 						Enabled: false,
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			expectError: false,
 			errorReason: "minimal config should work",
@@ -174,6 +177,7 @@ func TestConfigureLogging(t *testing.T) {
 						Enabled: false,
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			}
 
 			// Verify debug flag is set correctly

--- a/internal/app/config_adapter.go
+++ b/internal/app/config_adapter.go
@@ -163,10 +163,7 @@ func (a *ConfigAdapter) ExecuteTool(ctx context.Context, toolName string, args m
 func (a *ConfigAdapter) saveConfig() error {
 	if a.configPath == "" {
 		// Use the standard user configuration path
-		userConfigDir, err := config.GetUserConfigDir()
-		if err != nil {
-			return fmt.Errorf("unable to determine user config directory: %w", err)
-		}
+		userConfigDir := config.GetDefaultConfigPathOrPanic()
 
 		// Create directory if it doesn't exist
 		if err := os.MkdirAll(userConfigDir, 0755); err != nil {

--- a/internal/app/modes_test.go
+++ b/internal/app/modes_test.go
@@ -19,6 +19,7 @@ func TestConfigValidation(t *testing.T) {
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			wantError: false,
 		},
@@ -32,6 +33,7 @@ func TestConfigValidation(t *testing.T) {
 						Host: "localhost",
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			wantError: false,
 		},
@@ -63,6 +65,7 @@ func TestConfigDefaults(t *testing.T) {
 				Enabled: false,
 			},
 		},
+		ConfigPath: config.GetDefaultConfigPathOrPanic(),
 	}
 
 	// Verify the config structure is valid

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -134,17 +134,18 @@ func InitializeServices(cfg *Config) (*Services, error) {
 	serviceClassAdapter.Register()
 
 	// Load ServiceClass definitions to ensure they're available
-	if cfg.ConfigPath != "" {
-		// Trigger ServiceClass loading by calling ListServiceClasses
-		// This ensures filesystem-based ServiceClasses are loaded into memory
-		serviceClasses := serviceClassAdapter.ListServiceClasses()
-		if len(serviceClasses) > 0 {
-			logging.Info("Services", "Loaded %d ServiceClass definitions from filesystem", len(serviceClasses))
-		}
+	if cfg.ConfigPath == "" {
+		panic("Logic error: empty ConfigPath")
+	}
+	// Trigger ServiceClass loading by calling ListServiceClasses
+	// This ensures filesystem-based ServiceClasses are loaded into memory
+	serviceClasses := serviceClassAdapter.ListServiceClasses()
+	if len(serviceClasses) > 0 {
+		logging.Info("Services", "Loaded %d ServiceClass definitions from filesystem", len(serviceClasses))
 	}
 
 	// Create and register Workflow adapter using the muster client
-	workflowAdapter := workflow.NewAdapterWithClient(musterClient, "default", toolCaller, toolChecker)
+	workflowAdapter := workflow.NewAdapterWithClient(musterClient, "default", toolCaller, toolChecker, cfg.ConfigPath)
 	workflowAdapter.Register()
 
 	// Initialize and register MCPServer adapter using the muster client
@@ -175,18 +176,8 @@ func InitializeServices(cfg *Config) (*Services, error) {
 		// Need to get the service registry handler from the registry adapter
 		registryHandler := api.GetServiceRegistry()
 		if registryHandler != nil {
-			// Auto-detect config directory or use custom path
-			var configDir string
-			if cfg.ConfigPath != "" {
-				configDir = cfg.ConfigPath
-			} else {
-				userConfigDir, err := config.GetUserConfigDir()
-				if err != nil {
-					// Fallback to empty string if auto-detection fails
-					configDir = ""
-				} else {
-					configDir = userConfigDir
-				}
+			if cfg.ConfigPath == "" {
+				panic("Logic error: empty ConfigPath")
 			}
 
 			// Convert config types
@@ -196,7 +187,7 @@ func InitializeServices(cfg *Config) (*Services, error) {
 				Transport:    cfg.MusterConfig.Aggregator.Transport,
 				MusterPrefix: cfg.MusterConfig.Aggregator.MusterPrefix,
 				Yolo:         cfg.Yolo,
-				ConfigDir:    configDir,
+				ConfigDir:    cfg.ConfigPath,
 			}
 
 			// Set defaults if not specified

--- a/internal/app/services_test.go
+++ b/internal/app/services_test.go
@@ -24,6 +24,7 @@ func TestInitializeServices(t *testing.T) {
 						Port:    0,
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			expectError: false,
 			checkServices: func(t *testing.T, s *Services) {
@@ -49,6 +50,7 @@ func TestInitializeServices(t *testing.T) {
 						Host:    "localhost",
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			expectError: false,
 			checkServices: func(t *testing.T, s *Services) {
@@ -68,6 +70,7 @@ func TestInitializeServices(t *testing.T) {
 						Host:    "",
 					},
 				},
+				ConfigPath: config.GetDefaultConfigPathOrPanic(),
 			},
 			expectError: false,
 			checkServices: func(t *testing.T, s *Services) {
@@ -106,6 +109,7 @@ func TestInitializeServices_OrchestratorConfig(t *testing.T) {
 				Port: 9090,
 			},
 		},
+		ConfigPath: config.GetDefaultConfigPathOrPanic(),
 	}
 
 	// We can't easily test the full initialization without mocking orchestrator.New
@@ -129,6 +133,7 @@ func TestServices_Creation(t *testing.T) {
 		MusterConfig: &config.MusterConfig{
 			Aggregator: config.AggregatorConfig{Enabled: false},
 		},
+		ConfigPath: config.GetDefaultConfigPathOrPanic(),
 	}
 
 	services, err := InitializeServices(cfg)

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -71,14 +71,11 @@ func DetectAggregatorEndpointFromPath(configPath string) (string, error) {
 	var actualCfg config.MusterConfig
 	var err error
 
-	if configPath != "" {
-		// Load configuration from custom path
-		actualCfg, err = config.LoadConfigFromPath(configPath)
-	} else {
-		// Load configuration using default method
-		actualCfg, err = config.LoadConfig()
+	if configPath == "" {
+		panic("Logic error: empty agent configPath")
 	}
 
+	actualCfg, err = config.LoadConfigFromPath(configPath)
 	if err != nil {
 		// Use default if config cannot be loaded
 		endpoint := "http://localhost:8090/mcp"

--- a/internal/cli/executor.go
+++ b/internal/cli/executor.go
@@ -73,12 +73,11 @@ func NewToolExecutor(options ExecutorOptions) (*ToolExecutor, error) {
 	var cfg config.MusterConfig
 	var err error
 
-	if options.ConfigPath != "" {
-		cfg, err = config.LoadConfigFromPath(options.ConfigPath)
-	} else {
-		cfg, err = config.LoadConfig()
+	if options.ConfigPath == "" {
+		panic("Logic error: empty tool executor ConfigPath")
 	}
 
+	cfg, err = config.LoadConfigFromPath(options.ConfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -91,7 +91,6 @@
 //	    log.Fatal(err)
 //	}
 //
-//	// Load configuration from custom path
 //	cfg, err := config.LoadConfigFromPath("/custom/config/path")
 //	if err != nil {
 //	    log.Fatal(err)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -18,14 +18,17 @@ const (
 	configFileName = "config.yaml"
 )
 
-// LoadConfig loads the muster configuration from the default directory (~/.config/muster).
-func LoadConfig() (MusterConfig, error) {
+func GetDefaultConfigPathOrPanic() string {
 	userConfigDir, err := GetUserConfigDir()
 	if err != nil {
-		return MusterConfig{}, fmt.Errorf("could not determine user config directory: %w", err)
+		panic(fmt.Errorf("could not determine user config directory: %w", err))
 	}
+	return userConfigDir
+}
 
-	return LoadConfigFromPath(userConfigDir)
+// LoadConfig loads the muster configuration from the default directory (~/.config/muster).
+func LoadConfig() (MusterConfig, error) {
+	return LoadConfigFromPath(GetDefaultConfigPathOrPanic())
 }
 
 // LoadConfigFromPath loads configuration from a single specified directory.

--- a/internal/config/storage_test.go
+++ b/internal/config/storage_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewStorage(t *testing.T) {
-	ds := NewStorage()
+	ds := NewStorageWithPath(GetDefaultConfigPathOrPanic())
 	if ds == nil {
 		t.Fatal("NewStorage returned nil")
 	}
@@ -375,7 +375,7 @@ func TestStorage_DefaultBehavior(t *testing.T) {
 	}
 
 	// Test default storage behavior (should use ~/.config/muster)
-	ds := NewStorage()
+	ds := NewStorageWithPath(GetDefaultConfigPathOrPanic())
 
 	// Create config directory structure
 	configDir := filepath.Join(tempDir, userConfigDir, "workflows")
@@ -425,7 +425,7 @@ func TestStorage_DefaultBehavior(t *testing.T) {
 }
 
 func TestStorage_sanitizeFilename(t *testing.T) {
-	ds := NewStorage()
+	ds := NewStorageWithPath(GetDefaultConfigPathOrPanic())
 
 	tests := []struct {
 		name  string

--- a/internal/testing/test_reporter.go
+++ b/internal/testing/test_reporter.go
@@ -57,9 +57,7 @@ func (r *testReporter) ReportStart(config TestConfiguration) {
 		fmt.Printf("   • Verbose mode: %t\n", r.verbose)
 		fmt.Printf("   • Timeout: %v\n", config.Timeout)
 		fmt.Printf("   • Base port: %d\n", config.BasePort)
-		if config.ConfigPath != "" {
-			fmt.Printf("   • Config path: %s\n", config.ConfigPath)
-		}
+		fmt.Printf("   • Config path: %s\n", config.ConfigPath)
 		if config.ReportPath != "" {
 			fmt.Printf("   • Report path: %s\n", config.ReportPath)
 		}

--- a/internal/workflow/api_adapter.go
+++ b/internal/workflow/api_adapter.go
@@ -38,34 +38,12 @@ type ToolAvailabilityChecker interface {
 	IsToolAvailable(toolName string) bool
 }
 
-// NewAdapter creates a new workflow adapter
-func NewAdapter(toolCaller ToolCaller, toolChecker ToolAvailabilityChecker) (*Adapter, error) {
-	musterClient, err := client.NewMusterClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create muster client: %w", err)
-	}
-
-	executor := NewWorkflowExecutor(toolCaller)
-
-	// Initialize execution storage and tracker
-	executionStorage := NewExecutionStorage("")
-	executionTracker := NewExecutionTracker(executionStorage)
-
-	return &Adapter{
-		client:           musterClient,
-		namespace:        "default",
-		executor:         executor,
-		executionTracker: executionTracker,
-		toolChecker:      toolChecker,
-	}, nil
-}
-
 // NewAdapterWithClient creates a new workflow adapter with a pre-configured client
-func NewAdapterWithClient(musterClient client.MusterClient, namespace string, toolCaller ToolCaller, toolChecker ToolAvailabilityChecker) *Adapter {
+func NewAdapterWithClient(musterClient client.MusterClient, namespace string, toolCaller ToolCaller, toolChecker ToolAvailabilityChecker, configPath string) *Adapter {
 	executor := NewWorkflowExecutor(toolCaller)
 
 	// Initialize execution storage and tracker
-	executionStorage := NewExecutionStorage("")
+	executionStorage := NewExecutionStorage(configPath)
 	executionTracker := NewExecutionTracker(executionStorage)
 
 	if namespace == "" {

--- a/internal/workflow/execution_storage.go
+++ b/internal/workflow/execution_storage.go
@@ -50,12 +50,10 @@ type ExecutionStorageImpl struct {
 // The storage follows the established precedence of project directory over
 // user directory and supports custom configuration paths for standalone mode.
 func NewExecutionStorage(configPath string) ExecutionStorage {
-	var storage *config.Storage
-	if configPath != "" {
-		storage = config.NewStorageWithPath(configPath)
-	} else {
-		storage = config.NewStorage()
+	if configPath == "" {
+		panic("Logic error: empty execution storage configPath")
 	}
+	storage := config.NewStorageWithPath(configPath)
 
 	return &ExecutionStorageImpl{
 		storage: storage,


### PR DESCRIPTION
### What does this PR do?

Some `if` branches in the code treated an empty config path differently which caused hard-to-trace bugs like not loading any services. This sets the config path early to avoid even having an empty value.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
