### PR TITLE
Feat/systemd socket activation

### DIFF
--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -27,7 +27,7 @@ echo "📦 Building and installing muster..."
 go install .
 
 echo "🚀 Starting muster socket..."
-systemctl --user start muster.socket
+systemctl --user restart muster.socket
 
 echo "📊 Socket status:"
 systemctl --user status muster.socket --no-pager


### PR DESCRIPTION
Follows up https://github.com/giantswarm/muster/pull/65

### What does this PR do?

Fix multiple listeners use-case required for out-of-the-box platform compatibility.

### What is the effect of this change to users?

Muster works on all platforms after running setup scripts, without systemd socket listener configuration required.

### Should this change be mentioned in the release notes?

- no, it's just a fix for the linked PR
