### PR TITLE
server: bail out if using incompatible config

### DIFF
--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -213,6 +213,10 @@ func (a *AggregatorServer) Start(ctx context.Context) error {
 		}
 
 	case config.MCPTransportStdio:
+		if useSystemdActivation {
+			return fmt.Errorf("stdio transport cannot be used with systemd socket activation")
+		}
+
 		// Standard I/O transport for CLI integration
 		logging.Info("Aggregator", "Starting MCP aggregator server with stdio transport")
 		a.stdioServer = server.NewStdioServer(a.server)


### PR DESCRIPTION
### Summary

Bail out if the server was started using systemd socket activation but stdio mode is configured.

Unlikely misconfiguration, but would otherwise lead to user confusion. Please merge, no changelog entry required.
