### PR TITLE
refactor NewToolExecutor, DetectAggregatorEndpointWithConfig

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -50,7 +50,13 @@ func DetectAggregatorEndpointWithConfig(cfg *config.MusterConfig) (string, error
 		// from here, this is a connectable port, not a bind port
 		port = 8090
 	}
-	endpoint := fmt.Sprintf("http://%s:%d/mcp", host, port)
+
+	endpoint := ""
+	if actualCfg.Aggregator.Transport == "sse" {
+		endpoint = fmt.Sprintf("http://%s:%d/sse", host, port)
+	} else {
+		endpoint = fmt.Sprintf("http://%s:%d/mcp", host, port)
+	}
 
 	return endpoint, nil
 }
@@ -67,7 +73,7 @@ func DetectAggregatorEndpointWithConfig(cfg *config.MusterConfig) (string, error
 func DetectAggregatorEndpointFromPath(configPath string) (string, error) {
 
 	if configPath == "" {
-		panic("Logic error: empty agent configPath")
+		panic("Logic error: empty configPath")
 	}
 
 	cfg, err := config.LoadConfigFromPath(configPath)
@@ -83,12 +89,7 @@ func DetectAggregatorEndpointFromPath(configPath string) (string, error) {
 //
 // Returns:
 //   - error: nil if server is running and responsive, otherwise an error with guidance
-func CheckServerRunning() error {
-	endpoint, err := DetectAggregatorEndpoint()
-	if err != nil {
-		return fmt.Errorf("failed to detect endpoint: %w", err)
-	}
-
+func CheckServerRunning(endpoint string) error {
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -102,7 +102,8 @@ func TestCheckServerRunning_WithMockServer(t *testing.T) {
 			// or a more sophisticated mocking approach
 
 			// For now, just test that the function exists and can be called
-			err := CheckServerRunning()
+			endpoint, err := DetectAggregatorEndpoint()
+			err = CheckServerRunning(endpoint)
 			// The actual result depends on whether a real server is running
 			// but we can at least verify the function doesn't panic
 			_ = err // Ignore the actual result for unit tests
@@ -113,7 +114,8 @@ func TestCheckServerRunning_WithMockServer(t *testing.T) {
 func TestCheckServerRunning_ServerDown(t *testing.T) {
 	// Test with no server running - this will likely fail unless a server is actually running
 	// In a real test environment, we'd mock the HTTP client or use dependency injection
-	err := CheckServerRunning()
+	endpoint, err := DetectAggregatorEndpoint()
+	err = CheckServerRunning(endpoint)
 	// We can't assert the exact error without knowing the test environment
 	// but we can verify the function returns an error type
 	_ = err

--- a/internal/cli/executor_test.go
+++ b/internal/cli/executor_test.go
@@ -31,6 +31,7 @@ func TestNewToolExecutor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.options.ConfigPath = "/tmp/muster-test"
 			executor, err := NewToolExecutor(tt.options)
 
 			// The test can pass or fail depending on whether the server is running


### PR DESCRIPTION
### Summary

Minor re-factoring of `cli.executor.NewToolExecutor()` and correctness fix in `common.DetectAggregatorEndpointWithConfig()`.
