### PR TITLE
Moves logging to stderr and improves standalone logging

### DIFF
--- a/cmd/standalone.go
+++ b/cmd/standalone.go
@@ -22,8 +22,6 @@ It enforces the MCP server mode for the agent and disables serve logging.`,
 func runStandalone(cmd *cobra.Command, args []string) error {
 	// Enable agent MCP server mode
 	agentMCPServer = true
-	// Disable serve logging
-	serveSilent = true
 
 	errCh := make(chan error, 1)
 
@@ -54,4 +52,6 @@ func init() {
 	// Inherit flags from agent and serve commands
 	standaloneCmd.Flags().AddFlagSet(agentCmd.Flags())
 	standaloneCmd.Flags().AddFlagSet(serveCmd.Flags())
+
+	standaloneCmd.Flags().Lookup("silent").DefValue = "true"
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -61,7 +61,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 	}
 
 	// Initialize logging for CLI output (will be replaced for TUI mode)
-	var logOutput io.Writer = os.Stdout
+	var logOutput io.Writer = os.Stderr
 	if cfg.Silent {
 		// If silent mode is enabled, suppress all output
 		logOutput = io.Discard


### PR DESCRIPTION
- Moves log output to stderr
- Allows for `standalone` mode to print stderr if needed (very helpful for debugging)