### PR TITLE
Increases parallel execution and decreases times generally

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -94,7 +94,7 @@ alwaysApply: true
 - **When ever you get a "Finish this up":**
   - **Run the tests:** `make test`
   - **Update the binary:** `go install`
-  - **Run the scenarios:** `muster test --parallel 20`
+  - **Run the scenarios:** `muster test --parallel 50`
   - **Format the code:** `goimports -w . && go fmt ./...`
   - **Commit & Push & Pull Request**: Check the github workflow
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         run: make build
 
       - name: Run muster integration tests
-        run: ./muster test --parallel 10
+        run: ./muster test --parallel 50
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -123,7 +123,7 @@ Example usage:
   muster test --scenario=basic-create     # Run specific scenario
   muster test --verbose --debug           # Detailed output and debugging
   muster test --fail-fast                 # Stop on first failure
-  muster test --parallel=4                # Run with 4 parallel workers
+  muster test --parallel=50               # Run with 50 parallel workers
   muster test --base-port=19000           # Use port 19000+ for test instances
   muster test --mcp-server                # Run as MCP server (stdio transport)
   muster test --generate-schema           # Generate API schema from muster serve
@@ -236,8 +236,8 @@ func init() {
 
 	// Validate parallel flag
 	testCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if !testMCPServer && !testMockMCPServer && !testGenerateSchema && !testValidateScenarios && (testParallel < 1 || testParallel > 20) {
-			return fmt.Errorf("parallel workers must be between 1 and 20, got %d", testParallel)
+		if !testMCPServer && !testMockMCPServer && !testGenerateSchema && !testValidateScenarios && (testParallel < 1 || testParallel > 50) {
+			return fmt.Errorf("parallel workers must be between 1 and 50, got %d", testParallel)
 		}
 		if testMockMCPServer && testMockConfig == "" {
 			return fmt.Errorf("--mock-config is required when using --mock-mcp-server")

--- a/internal/testing/doc.go
+++ b/internal/testing/doc.go
@@ -269,7 +269,7 @@
 // ## Advanced Configuration
 //
 //	```bash
-//	muster test --parallel=4 --timeout=10m --fail-fast
+//	muster test --parallel=50 --timeout=10m --fail-fast
 //	muster test --verbose --debug --output-format=json
 //	```
 //

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -329,11 +329,8 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
-
-	// Give the process a moment to start
-	time.Sleep(2 * time.Second)
 
 	// First wait for port to be available
 	portReady := false
@@ -383,7 +380,7 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 			// If we can't connect to MCP, fall back to the old behavior
 			time.Sleep(3 * time.Second)
 			return nil
-		case <-time.After(1 * time.Second):
+		case <-time.After(100 * time.Millisecond):
 			err := mcpClient.Connect(connectCtx, instance.Endpoint)
 			if err == nil {
 				connected = true
@@ -425,7 +422,6 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 		if len(expectedWorkflows) > 0 {
 			m.logger.Debug("🎯 Waiting for %d expected Workflows: %v\n", len(expectedWorkflows), expectedWorkflows)
 		}
-
 	}
 
 	// Wait for all expected resources to be available
@@ -433,7 +429,7 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 	resourceCtx, resourceCancel := context.WithTimeout(readyCtx, resourceTimeout)
 	defer resourceCancel()
 
-	resourceTicker := time.NewTicker(2 * time.Second) // Reduced from 2s to 1s for more frequent checks
+	resourceTicker := time.NewTicker(100 * time.Millisecond)
 	defer resourceTicker.Stop()
 
 	for {
@@ -536,8 +532,7 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 				if m.debug {
 					m.logger.Debug("✅ All expected resources are available!\n")
 				}
-				// Wait a little bit more to ensure everything is fully stable
-				time.Sleep(2 * time.Second)
+
 				return nil
 			}
 


### PR DESCRIPTION
- Increases number of workers for tests running in parallel
- Generally removes / decreases waits and timeouts

Changes test execution from ~1m30 to ~20s