### PR TITLE
Removes SBOM and sign options from goreleaser dry-run and add cache for go build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,16 @@ jobs:
         with:
           go-version: '1.24'  # Match the version used in auto-release
 
+      - name: Cache Go build and mod cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Install Python for yamllint
         uses: actions/setup-python@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install: build ## Install the binary
 
 .PHONY: release-dry-run
 release-dry-run: ## Test the release process without publishing
-	goreleaser release --snapshot --clean --skip=announce,publish,validate
+	goreleaser release --snapshot --clean --skip=announce,archive,publish,sbom,sign,validate
 
 .PHONY: release-local
 release-local: ## Create a release locally


### PR DESCRIPTION
- Removes unnecessary goreleaser steps
- Adds cache for golang build cache (safe between builds)