### PR TITLE
fix default config: AggregatorConfig.Enabled=true

### DIFF
--- a/.muster/config.yaml.example
+++ b/.muster/config.yaml.example
@@ -6,5 +6,4 @@
 aggregator:
   port: 8090
   host: localhost
-  # enabled: true
   # musterPrefix: "x"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ All notable changes to this project will be documented in this file.
   - Documented dependency management, state management, and message flow in detail
 
 ### Changed
+- **Aggregator Config**
+  - Drop the "Enabled" field (always enabled in modes where it's used)
 - **Service Manager Refactoring**
   - ServiceManager now accepts an optional KubeManager parameter for K8s connection services
   - Added support for K8s connection services in the service lifecycle management

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -113,8 +113,8 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	endpoint := agentEndpoint
 	if endpoint == "" {
 		// Use the same endpoint detection logic as CLI commands
-		var err error = nil
-		endpoint, err = cli.DetectAggregatorEndpointFromPath(agentConfigPath)
+		config, err := config.LoadConfig(agentConfigPath)
+		endpoint = cli.GetAggregatorEndpoint(&config)
 		if err != nil {
 			// Use fallback default that matches system defaults
 			if !agentMCPServer && agentVerbose {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -279,7 +279,8 @@ func runTest(cmd *cobra.Command, args []string) error {
 		logger := agent.NewLogger(testVerbose, true, testDebug)
 
 		// For MCP server mode, we still need an endpoint for existing functionality
-		endpoint, err := cli.DetectAggregatorEndpointFromPath(testMusterConfigPath)
+		config, err := config.LoadConfig(testMusterConfigPath)
+		endpoint := cli.GetAggregatorEndpoint(&config)
 		if err != nil {
 			logger.Info("Warning: Could not detect endpoint (%v), using default: %s\n", err, endpoint)
 		}

--- a/docs/explanation/decisions/003-configuration-management.md
+++ b/docs/explanation/decisions/003-configuration-management.md
@@ -42,9 +42,9 @@ Implementation uses `gopkg.in/yaml.v3` for direct YAML parsing without additiona
 
 ```go
 // Configuration loading
-func LoadConfig() (MusterConfig, error) {
-    userConfigDir, err := GetUserConfigDir() // ~/.config/muster
-    return LoadConfigFromPath(userConfigDir)
+// configPath   The config structure path, e.g. ~/.config/muster
+func LoadConfig(configPath string) (MusterConfig, error) {
+    // load config or return default values, if not found
 }
 
 // Entity storage

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -76,7 +76,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 		panic("Logic error: empty ConfigPath")
 	}
 
-	musterCfg, err = config.LoadConfigFromPath(cfg.ConfigPath)
+	musterCfg, err = config.LoadConfig(cfg.ConfigPath)
 	if err != nil {
 		logging.Error("Bootstrap", err, "Failed to load muster configuration from path: %s", cfg.ConfigPath)
 		return nil, fmt.Errorf("failed to load muster configuration from path %s: %w", cfg.ConfigPath, err)

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1,8 +1,9 @@
 package app
 
 import (
-	"muster/internal/config"
 	"testing"
+
+	"muster/internal/config"
 )
 
 // Note: Testing NewApplication fully requires mocking global dependencies
@@ -24,9 +25,8 @@ func TestNewApplication_ConfigValidation(t *testing.T) {
 				// Pre-populate MusterConfig to avoid LoadConfig call
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{
-						Port:    8090,
-						Host:    "localhost",
-						Enabled: false,
+						Port: 8090,
+						Host: "localhost",
 					},
 				},
 				ConfigPath: config.GetDefaultConfigPathOrPanic(),
@@ -41,9 +41,8 @@ func TestNewApplication_ConfigValidation(t *testing.T) {
 				// Pre-populate MusterConfig to avoid LoadConfig call
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{
-						Port:    8090,
-						Host:    "localhost",
-						Enabled: false,
+						Port: 8090,
+						Host: "localhost",
 					},
 				},
 				ConfigPath: config.GetDefaultConfigPathOrPanic(),
@@ -58,9 +57,8 @@ func TestNewApplication_ConfigValidation(t *testing.T) {
 				// Pre-populate MusterConfig to avoid LoadConfig call
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{
-						Port:    8090,
-						Host:    "localhost",
-						Enabled: false,
+						Port: 8090,
+						Host: "localhost",
 					},
 				},
 				ConfigPath: config.GetDefaultConfigPathOrPanic(),
@@ -105,9 +103,8 @@ func TestApplication_Structure(t *testing.T) {
 		Debug: true,
 		MusterConfig: &config.MusterConfig{
 			Aggregator: config.AggregatorConfig{
-				Port:    8090,
-				Host:    "localhost",
-				Enabled: false,
+				Port: 8090,
+				Host: "localhost",
 			},
 		},
 	}
@@ -136,9 +133,8 @@ func TestConfig_WithMusterConfig(t *testing.T) {
 		Debug: false,
 		MusterConfig: &config.MusterConfig{
 			Aggregator: config.AggregatorConfig{
-				Port:    9090,
-				Host:    "0.0.0.0",
-				Enabled: true,
+				Port: 9090,
+				Host: "0.0.0.0",
 			},
 		},
 	}
@@ -172,9 +168,8 @@ func TestConfigureLogging(t *testing.T) {
 				// Pre-populate MusterConfig to avoid LoadConfig call
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{
-						Port:    8090,
-						Host:    "localhost",
-						Enabled: false,
+						Port: 8090,
+						Host: "localhost",
 					},
 				},
 				ConfigPath: config.GetDefaultConfigPathOrPanic(),

--- a/internal/app/config_adapter.go
+++ b/internal/app/config_adapter.go
@@ -91,7 +91,7 @@ func (a *ConfigAdapter) ReloadConfig(ctx context.Context) error {
 	defer a.mu.Unlock()
 
 	// Load config using the centralized loader
-	musterConfig, err := config.LoadConfig()
+	musterConfig, err := config.LoadConfig(a.configPath)
 	if err != nil {
 		return fmt.Errorf("failed to reload configuration: %w", err)
 	}

--- a/internal/app/config_adapter_integration_test.go
+++ b/internal/app/config_adapter_integration_test.go
@@ -86,7 +86,7 @@ func TestConfigReloadTool(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create adapter
-	adapter := NewConfigAdapter(initialConfig, configPath)
+	adapter := NewConfigAdapter(initialConfig, tmpDir)
 	api.RegisterConfig(adapter)
 
 	// Test that config_reload tool exists

--- a/internal/app/modes_test.go
+++ b/internal/app/modes_test.go
@@ -1,8 +1,9 @@
 package app
 
 import (
-	"muster/internal/config"
 	"testing"
+
+	"muster/internal/config"
 )
 
 func TestConfigValidation(t *testing.T) {
@@ -60,9 +61,8 @@ func TestConfigDefaults(t *testing.T) {
 		Debug: true,
 		MusterConfig: &config.MusterConfig{
 			Aggregator: config.AggregatorConfig{
-				Port:    0, // Should get default
-				Host:    "",
-				Enabled: false,
+				Port: 0, // Should get default
+				Host: "",
 			},
 		},
 		ConfigPath: config.GetDefaultConfigPathOrPanic(),

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+
 	"muster/internal/aggregator"
 	"muster/internal/api"
 	"muster/internal/client"
@@ -26,7 +27,6 @@ import (
 // Field descriptions:
 //   - Orchestrator: Core service orchestrator responsible for service lifecycle management
 //   - OrchestratorAPI: API interface for orchestrator operations (start, stop, status)
-//   - ConfigAPI: API interface for configuration management and persistence
 //   - AggregatorPort: Port number where the MCP aggregator service is listening
 //
 // Service Dependencies:
@@ -164,54 +164,44 @@ func InitializeServices(cfg *Config) (*Services, error) {
 	// Note: Service creation (including MCPServer services) is handled by the orchestrator
 	// during its Start() method. The orchestrator manages dependencies and lifecycle.
 
-	// Create aggregator service - enable by default unless explicitly disabled
-	// This ensures the aggregator starts even with no MCP servers configured
-	aggregatorEnabled := true
-	if cfg.MusterConfig.Aggregator.Port != 0 || cfg.MusterConfig.Aggregator.Host != "" {
-		// If aggregator config exists, respect the enabled flag
-		aggregatorEnabled = cfg.MusterConfig.Aggregator.Enabled
-	}
-
-	if aggregatorEnabled {
-		// Need to get the service registry handler from the registry adapter
-		registryHandler := api.GetServiceRegistry()
-		if registryHandler != nil {
-			if cfg.ConfigPath == "" {
-				panic("Logic error: empty ConfigPath")
-			}
-
-			// Convert config types
-			aggConfig := aggregator.AggregatorConfig{
-				Port:         cfg.MusterConfig.Aggregator.Port,
-				Host:         cfg.MusterConfig.Aggregator.Host,
-				Transport:    cfg.MusterConfig.Aggregator.Transport,
-				MusterPrefix: cfg.MusterConfig.Aggregator.MusterPrefix,
-				Yolo:         cfg.Yolo,
-				ConfigDir:    cfg.ConfigPath,
-			}
-
-			// Set defaults if not specified
-			if aggConfig.Port == 0 {
-				aggConfig.Port = 8090
-			}
-			if aggConfig.Host == "" {
-				aggConfig.Host = "localhost"
-			}
-			if aggConfig.Transport == "" {
-				aggConfig.Transport = config.MCPTransportStreamableHTTP
-			}
-
-			aggService := aggregatorService.NewAggregatorService(
-				aggConfig,
-				orchestratorAPI,
-				registryHandler,
-			)
-			registry.Register(aggService)
-
-			// Create aggregator API adapter
-			aggAdapter := aggregatorService.NewAPIAdapter(aggService)
-			aggAdapter.Register()
+	// Need to get the service registry handler from the registry adapter
+	registryHandler := api.GetServiceRegistry()
+	if registryHandler != nil {
+		if cfg.ConfigPath == "" {
+			panic("Logic error: empty ConfigPath")
 		}
+
+		// Convert config types
+		aggConfig := aggregator.AggregatorConfig{
+			Port:         cfg.MusterConfig.Aggregator.Port,
+			Host:         cfg.MusterConfig.Aggregator.Host,
+			Transport:    cfg.MusterConfig.Aggregator.Transport,
+			MusterPrefix: cfg.MusterConfig.Aggregator.MusterPrefix,
+			Yolo:         cfg.Yolo,
+			ConfigDir:    cfg.ConfigPath,
+		}
+
+		// Set defaults if not specified
+		if aggConfig.Port == 0 {
+			aggConfig.Port = 8090
+		}
+		if aggConfig.Host == "" {
+			aggConfig.Host = "localhost"
+		}
+		if aggConfig.Transport == "" {
+			aggConfig.Transport = config.MCPTransportStreamableHTTP
+		}
+
+		aggService := aggregatorService.NewAggregatorService(
+			aggConfig,
+			orchestratorAPI,
+			registryHandler,
+		)
+		registry.Register(aggService)
+
+		// Create aggregator API adapter
+		aggAdapter := aggregatorService.NewAPIAdapter(aggService)
+		aggAdapter.Register()
 	}
 
 	return &Services{

--- a/internal/app/services_test.go
+++ b/internal/app/services_test.go
@@ -1,10 +1,11 @@
 package app
 
 import (
-	"muster/internal/config"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"muster/internal/config"
 )
 
 func TestInitializeServices(t *testing.T) {
@@ -20,8 +21,7 @@ func TestInitializeServices(t *testing.T) {
 				Debug: true,
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{
-						Enabled: false,
-						Port:    0,
+						Port: 0,
 					},
 				},
 				ConfigPath: config.GetDefaultConfigPathOrPanic(),
@@ -34,9 +34,6 @@ func TestInitializeServices(t *testing.T) {
 				if s.OrchestratorAPI == nil {
 					t.Error("OrchestratorAPI should not be nil")
 				}
-				if s.ConfigAPI == nil {
-					t.Error("ConfigAPI should not be nil")
-				}
 			},
 		},
 		{
@@ -45,9 +42,8 @@ func TestInitializeServices(t *testing.T) {
 				Debug: false,
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{
-						Enabled: true,
-						Port:    8090,
-						Host:    "localhost",
+						Port: 8090,
+						Host: "localhost",
 					},
 				},
 				ConfigPath: config.GetDefaultConfigPathOrPanic(),
@@ -65,9 +61,8 @@ func TestInitializeServices(t *testing.T) {
 				Debug: false,
 				MusterConfig: &config.MusterConfig{
 					Aggregator: config.AggregatorConfig{
-						Enabled: true,
-						Port:    0, // Should default to 8080
-						Host:    "",
+						Port: 0, // Should default to 8080
+						Host: "",
 					},
 				},
 				ConfigPath: config.GetDefaultConfigPathOrPanic(),
@@ -131,7 +126,7 @@ func TestServices_Creation(t *testing.T) {
 	cfg := &Config{
 		Debug: false,
 		MusterConfig: &config.MusterConfig{
-			Aggregator: config.AggregatorConfig{Enabled: false},
+			Aggregator: config.AggregatorConfig{},
 		},
 		ConfigPath: config.GetDefaultConfigPathOrPanic(),
 	}
@@ -142,5 +137,4 @@ func TestServices_Creation(t *testing.T) {
 	// Test that services are created
 	assert.NotNil(t, services.Orchestrator)
 	assert.NotNil(t, services.OrchestratorAPI)
-	assert.NotNil(t, services.ConfigAPI)
 }

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDetectAggregatorEndpoint(t *testing.T) {
+func TestGetAggregatorEndpoint(t *testing.T) {
 	tests := []struct {
 		name     string
 		config   *config.MusterConfig
@@ -41,18 +41,16 @@ func TestDetectAggregatorEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			endpoint, err := DetectAggregatorEndpointWithConfig(tt.config)
-			assert.NoError(t, err)
+			endpoint := GetAggregatorEndpoint(tt.config)
 			assert.Equal(t, tt.expected, endpoint)
 		})
 	}
 }
 
-func TestDetectAggregatorEndpointWithoutConfig(t *testing.T) {
+func GetAggregatorEndpointWithoutConfig(t *testing.T) {
 	// Test default behavior when no config is found
 	// With the new single directory approach, this will load from user config if available
-	endpoint, err := DetectAggregatorEndpoint()
-	assert.NoError(t, err)
+	endpoint := GetAggregatorEndpoint(nil)
 	// Since we may have user config, just verify the format is correct
 	assert.Contains(t, endpoint, "http://localhost:")
 	assert.Contains(t, endpoint, "/mcp")
@@ -102,8 +100,8 @@ func TestCheckServerRunning_WithMockServer(t *testing.T) {
 			// or a more sophisticated mocking approach
 
 			// For now, just test that the function exists and can be called
-			endpoint, err := DetectAggregatorEndpoint()
-			err = CheckServerRunning(endpoint)
+			endpoint := GetAggregatorEndpoint(nil)
+			err := CheckServerRunning(endpoint)
 			// The actual result depends on whether a real server is running
 			// but we can at least verify the function doesn't panic
 			_ = err // Ignore the actual result for unit tests
@@ -114,8 +112,8 @@ func TestCheckServerRunning_WithMockServer(t *testing.T) {
 func TestCheckServerRunning_ServerDown(t *testing.T) {
 	// Test with no server running - this will likely fail unless a server is actually running
 	// In a real test environment, we'd mock the HTTP client or use dependency injection
-	endpoint, err := DetectAggregatorEndpoint()
-	err = CheckServerRunning(endpoint)
+	endpoint := GetAggregatorEndpoint(nil)
+	err := CheckServerRunning(endpoint)
 	// We can't assert the exact error without knowing the test environment
 	// but we can verify the function returns an error type
 	_ = err

--- a/internal/cli/executor.go
+++ b/internal/cli/executor.go
@@ -72,7 +72,7 @@ func NewToolExecutor(options ExecutorOptions) (*ToolExecutor, error) {
 		return nil, fmt.Errorf("Logic error: empty tool executor ConfigPath")
 	}
 
-	cfg, err := config.LoadConfigFromPath(options.ConfigPath)
+	cfg, err := config.LoadConfig(options.ConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +86,7 @@ func NewToolExecutor(options ExecutorOptions) (*ToolExecutor, error) {
 	}
 
 	// Check if server is running first
-	endpoint, err := DetectAggregatorEndpointWithConfig(&cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to detect endpoint: %w", err)
-	}
-
+	endpoint := GetAggregatorEndpoint(&cfg)
 	if err := CheckServerRunning(endpoint); err != nil {
 		return nil, err
 	}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -7,7 +7,6 @@ func GetDefaultConfigWithRoles() MusterConfig {
 			Port:      8090,
 			Host:      "localhost",
 			Transport: MCPTransportStreamableHTTP,
-			Enabled:   true,
 		},
 	}
 }

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -86,12 +86,7 @@
 // # Usage Examples
 //
 //	// Load configuration from default location
-//	cfg, err := config.LoadConfig()
-//	if err != nil {
-//	    log.Fatal(err)
-//	}
-//
-//	cfg, err := config.LoadConfigFromPath("/custom/config/path")
+//	cfg, err := config.LoadConfig(config.GetDefaultConfigPathOrPanic())
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,92 +11,42 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// For mocking in tests
-var osUserHomeDir = os.UserHomeDir
-
 const (
 	userConfigDir  = ".config/muster"
 	configFileName = "config.yaml"
 )
 
 func GetDefaultConfigPathOrPanic() string {
-	userConfigDir, err := GetUserConfigDir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(fmt.Errorf("could not determine user config directory: %w", err))
 	}
-	return userConfigDir
+
+	return filepath.Join(homeDir, userConfigDir)
 }
 
-// LoadConfig loads the muster configuration from the default directory (~/.config/muster).
-func LoadConfig() (MusterConfig, error) {
-	return LoadConfigFromPath(GetDefaultConfigPathOrPanic())
-}
-
-// LoadConfigFromPath loads configuration from a single specified directory.
+// LoadConfig loads configuration from a single specified directory.
 // The directory should contain config.yaml and subdirectories for other configuration types.
-func LoadConfigFromPath(configPath string) (MusterConfig, error) {
-	// Validate that the directory exists
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		// If directory doesn't exist, return default config (create directories as needed)
-		logging.Info("ConfigLoader", "Configuration directory %s does not exist, using defaults", configPath)
-		return GetDefaultConfigWithRoles(), nil
-	}
-
-	// Start with default configuration
-	config := GetDefaultConfigWithRoles()
-
+func LoadConfig(configPath string) (MusterConfig, error) {
 	// Load main config.yaml from the specified path
 	configFilePath := filepath.Join(configPath, configFileName)
-	if _, err := os.Stat(configFilePath); err == nil {
-		fileConfig, err := loadConfigFromFile(configFilePath)
-		if err != nil {
-			return MusterConfig{}, fmt.Errorf("error loading config from %s: %w", configFilePath, err)
+	config := GetDefaultConfigWithRoles() // Start with default config
+
+	// Start with default config
+	data, err := os.ReadFile(configFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			logging.Info("ConfigLoader", "No config.yaml found at %s, using defaults", configFilePath)
+			return config, nil
 		}
-		config = mergeConfigs(config, fileConfig)
-		logging.Info("ConfigLoader", "Loaded configuration from %s", configFilePath)
-	} else {
-		logging.Info("ConfigLoader", "No config.yaml found at %s, using defaults", configFilePath)
-	}
-
-	return config, nil
-}
-
-// GetUserConfigDir returns the user configuration directory path
-func GetUserConfigDir() (string, error) {
-	homeDir, err := osUserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(homeDir, userConfigDir), nil
-}
-
-// loadConfigFromFile loads an MusterConfig from a YAML file.
-func loadConfigFromFile(filePath string) (MusterConfig, error) {
-	var config MusterConfig
-	data, err := os.ReadFile(filePath)
-	if err != nil {
+		logging.Info("ConfigLoader", "Error loading config.yaml from %s: %s", configFilePath, err)
 		return MusterConfig{}, err
 	}
 	err = yaml.Unmarshal(data, &config)
 	if err != nil {
-		return MusterConfig{}, err
+		// config malformed
+		return MusterConfig{}, fmt.Errorf("error loading config from %s: %w", configFilePath, err)
 	}
+	logging.Info("ConfigLoader", "Loaded configuration from %s", configFilePath)
 	return config, nil
-}
-
-// mergeConfigs merges 'overlay' config into 'base' config.
-func mergeConfigs(base, overlay MusterConfig) MusterConfig {
-	mergedConfig := base
-
-	// Merge Aggregator settings
-	if overlay.Aggregator.Port != 0 {
-		mergedConfig.Aggregator.Port = overlay.Aggregator.Port
-	}
-	if overlay.Aggregator.Host != "" {
-		mergedConfig.Aggregator.Host = overlay.Aggregator.Host
-	}
-	// Merge Enabled field - only if explicitly set in overlay
-	mergedConfig.Aggregator.Enabled = overlay.Aggregator.Enabled
-
-	return mergedConfig
 }

--- a/internal/config/storage_test.go
+++ b/internal/config/storage_test.go
@@ -363,23 +363,15 @@ func TestStorage_List(t *testing.T) {
 }
 
 func TestStorage_DefaultBehavior(t *testing.T) {
-	// Save original function
-	originalUserHomeDir := osUserHomeDir
-	defer func() {
-		osUserHomeDir = originalUserHomeDir
-	}()
-
 	tempDir := t.TempDir()
-	osUserHomeDir = func() (string, error) {
-		return tempDir, nil
-	}
+	configDir := filepath.Join(tempDir, userConfigDir)
 
 	// Test default storage behavior (should use ~/.config/muster)
-	ds := NewStorageWithPath(GetDefaultConfigPathOrPanic())
+	ds := NewStorageWithPath(configDir)
 
 	// Create config directory structure
-	configDir := filepath.Join(tempDir, userConfigDir, "workflows")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	workflowDir := filepath.Join(configDir, "workflows")
+	if err := os.MkdirAll(workflowDir, 0755); err != nil {
 		t.Fatalf("Failed to create config directory: %v", err)
 	}
 
@@ -391,7 +383,7 @@ func TestStorage_DefaultBehavior(t *testing.T) {
 	}
 
 	// Verify file was created in the correct location
-	expectedPath := filepath.Join(configDir, "test-workflow.yaml")
+	expectedPath := filepath.Join(workflowDir, "test-workflow.yaml")
 	if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
 		t.Errorf("Expected file %s was not created", expectedPath)
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -28,13 +28,5 @@ type AggregatorConfig struct {
 	Port         int    `yaml:"port,omitempty"`         // Port for the aggregator SSE endpoint (default: 8080)
 	Host         string `yaml:"host,omitempty"`         // Host to bind to (default: localhost)
 	Transport    string `yaml:"transport,omitempty"`    // Transport to use (default: streamable-http)
-	Enabled      bool   `yaml:"enabled,omitempty"`      // Whether the aggregator is enabled (default: true if MCP servers exist)
 	MusterPrefix string `yaml:"musterPrefix,omitempty"` // Pre-prefix for all tools (default: "x")
-}
-
-// GetDefaultConfig returns the default configuration for muster.
-// mcName and wcName are the canonical names provided by the user.
-func GetDefaultConfig(mcName, wcName string) MusterConfig {
-	// Return minimal defaults - no k8s connection, no MCP servers, no port forwarding
-	return GetDefaultConfigWithRoles()
 }


### PR DESCRIPTION
Resolves https://github.com/giantswarm/giantswarm/issues/33976

### What does this PR do?

- Set `AggregatorConfig.Enabled: true` in default constructed configs, to better support running with incomplete/empty/default configuration. 
- ~~(Add missing config field overrides (probably forgotten when these fields were added) )~~
  - Removed legacy code function `mergeConfig()`
  - Replaced redundant and racy `os.Stat` calls (to detect non-existent config) completely
- Remove `AggregatorConfig.Enabled` field (always enabled where it's required)
- Refactor and unify: `DetectAggregatorEndpoint...` -> `GetAggregatorEndpoint()`
- Fix previously unnoticed coding error where `agentConfigPath` wasn't used
- Refactor `LoadConfig()` to always expect a path


### What is the effect of this change to users?

- `AggregatorConfig.Enabled` field dropped from `config.yaml`
- No problems running `giantswarm/debug` or `muster` out-of-the-box.
- `config-path` is honored for endpoint selection in `muster agent` modes

Pure bugfix and on-boarding enhancement, no changelog entry needed.
