### PR TITLE
make muster CRs discovery namespace configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ All notable changes to this project will be documented in this file.
   - Added [Troubleshooting Guide](docs/troubleshooting.md) with common issues and solutions
   - Enhanced development documentation with recent architectural improvements
   - Documented dependency management, state management, and message flow in detail
+- Make muster CRs discovery's namespace configurable.
 
 ### Changed
 - **Service Manager Refactoring**

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -97,5 +97,10 @@ func mergeConfigs(base, overlay MusterConfig) MusterConfig {
 	// Merge Enabled field - only if explicitly set in overlay
 	mergedConfig.Aggregator.Enabled = overlay.Aggregator.Enabled
 
+	// Merge namespace
+	if overlay.Namespace != "" {
+		mergedConfig.Namespace = overlay.Namespace
+	}
+
 	return mergedConfig
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -3,6 +3,7 @@ package config
 // MusterConfig is the top-level configuration structure for muster.
 type MusterConfig struct {
 	Aggregator AggregatorConfig `yaml:"aggregator"`
+	Namespace  string           `yaml:"namespace,omitempty"` // Namespace for MCPServer, ServiceClass and Workflow discovery
 }
 
 // MCPServerType defines the type of MCP server.


### PR DESCRIPTION
### What does this PR do?

This PR makes the discovery namespace for CRs configurable. This is needed to make muster work in a k8s environment.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
