### PR TITLE
client: fail if endpoints do not match

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"muster/internal/config"
@@ -64,4 +67,51 @@ func CheckServerRunning(endpoint string) error {
 	}
 
 	return nil
+}
+
+// CheckEndpointSystemdSocket verifies that the muster endpoint configuration matches a potential systemd socket
+//
+// Args:
+//   - cfg: Pointer to MusterConfig to use for checking possible endpoints.
+//
+// This function checks if the systemd user mode socket file exists and contains the expected endpoint.
+// returns true if systemd socket activation isn't used or the endpoint matches, false otherwise.
+func CheckEndpointSystemdSocket(cfg *config.MusterConfig) bool {
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return true
+	}
+
+	// systemd structure (if used) is well-known
+	musterSocketLink := filepath.Join(homeDir, ".config/systemd/user/sockets.target.wants/muster.socket")
+	socketFile, err := os.ReadFile(musterSocketLink)
+	if err != nil {
+		return true // systemd (user mode) socket activation very likely isn't used
+	}
+
+	defaultEndpoint := GetAggregatorEndpoint(cfg)
+	endpoints := []string{defaultEndpoint}
+	if cfg != nil {
+		// add listen address variants, too (like "localhost", "0.0.0.0")
+		if cfg.Aggregator.Host == "localhost" {
+			endpoints = append(endpoints, fmt.Sprintf("%s:%d", "127.0.0.1", cfg.Aggregator.Port))
+			endpoints = append(endpoints, fmt.Sprintf("%s:%d", "::1", cfg.Aggregator.Port))
+		}
+		if cfg.Aggregator.Host == "0.0.0.0" {
+			endpoints = append(endpoints, fmt.Sprintf("%s:%d", "::", cfg.Aggregator.Port))
+		}
+		if cfg.Aggregator.Host == "::" {
+			endpoints = append(endpoints, fmt.Sprintf("%s:%d", "0.0.0.0", cfg.Aggregator.Port))
+		}
+	}
+
+	socketConfig := string(socketFile)
+	for _, endpoint := range endpoints {
+		if strings.Contains(socketConfig, endpoint) {
+			return true // systemd socket enabled and matches the expected endpoint
+		}
+	}
+
+	return false // systemd socket enabled, but not matching
 }

--- a/internal/cli/executor.go
+++ b/internal/cli/executor.go
@@ -87,6 +87,12 @@ func NewToolExecutor(options ExecutorOptions) (*ToolExecutor, error) {
 
 	// Check if server is running first
 	endpoint := GetAggregatorEndpoint(&cfg)
+
+	// verify systemd user socket activation config (if any)
+	if CheckEndpointSystemdSocket(&cfg) == false {
+		return nil, fmt.Errorf("systemd muster.socket doesn't match configured endpoint %s. Please check your configuration in %s", endpoint, options.ConfigPath)
+	}
+
 	if err := CheckServerRunning(endpoint); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Fail client executions if the endpoint configured in systemd user socket doesn't match `config.yaml`.

### What is the effect of this change to users?

User will know why his `muster` client can't connect to the muster launched via systemd: `config.yaml` misconfigured.

### How does it look like?

The error message will look like this (positive/negative tests performed):
```
Error: systemd muster.socket doesn't match configured endpoint http://localhost:8099/mcp. Please check your configuration in /home/lyind/.config/muster

Process finished with the exit code 1
```

No CHANGELOG.md entry needed, because pure error avoidance/usability improvement.
