### PR TITLE
fix(helm): add OAuth server config to ConfigMap and health endpoint

### DIFF
--- a/helm/muster/templates/configmap.yaml
+++ b/helm/muster/templates/configmap.yaml
@@ -10,4 +10,36 @@ data:
       host: "0.0.0.0"
       port: {{ .Values.muster.aggregator.port }}
       transport: {{ .Values.muster.aggregator.transport | quote }}
+      {{- if .Values.muster.oauthServer.enabled }}
+      oauthServer:
+        enabled: true
+        baseUrl: {{ .Values.muster.oauthServer.baseUrl | quote }}
+        provider: {{ .Values.muster.oauthServer.provider | default "dex" | quote }}
+        {{- if eq (.Values.muster.oauthServer.provider | default "dex") "dex" }}
+        dex:
+          issuerUrl: {{ .Values.muster.oauthServer.dex.issuerUrl | quote }}
+          clientId: {{ .Values.muster.oauthServer.dex.clientId | quote }}
+          {{- if .Values.muster.oauthServer.dex.connectorId }}
+          connectorId: {{ .Values.muster.oauthServer.dex.connectorId | quote }}
+          {{- end }}
+          {{- if .Values.muster.oauthServer.dex.kubernetesAuthenticatorClientId }}
+          kubernetesAuthenticatorClientId: {{ .Values.muster.oauthServer.dex.kubernetesAuthenticatorClientId | quote }}
+          {{- end }}
+        {{- end }}
+        storage:
+          type: {{ .Values.muster.oauthServer.storage.type | default "memory" | quote }}
+          {{- if eq .Values.muster.oauthServer.storage.type "valkey" }}
+          valkey:
+            url: {{ .Values.muster.oauthServer.storage.valkey.url | quote }}
+            {{- if .Values.muster.oauthServer.storage.valkey.keyPrefix }}
+            keyPrefix: {{ .Values.muster.oauthServer.storage.valkey.keyPrefix | quote }}
+            {{- end }}
+            {{- if .Values.muster.oauthServer.storage.valkey.db }}
+            db: {{ .Values.muster.oauthServer.storage.valkey.db }}
+            {{- end }}
+            {{- if .Values.muster.oauthServer.storage.valkey.tls.enabled }}
+            tlsEnabled: true
+            {{- end }}
+          {{- end }}
+      {{- end }}
     namespace: {{ include "muster.namespace" . | quote }}

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -679,6 +679,13 @@ func (a *AggregatorServer) createHTTPMux(mcpHandler http.Handler) http.Handler {
 func (a *AggregatorServer) createStandardMux(mcpHandler http.Handler) http.Handler {
 	mux := http.NewServeMux()
 
+	// Health check endpoint for Kubernetes probes
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
 	// Check if OAuth proxy is enabled and mount OAuth-related handlers (for downstream auth)
 	oauthHandler := api.GetOAuthHandler()
 	if oauthHandler != nil && oauthHandler.IsEnabled() {

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -119,6 +119,13 @@ func NewOAuthHTTPServer(cfg config.OAuthServerConfig, mcpHandler http.Handler, d
 func (s *OAuthHTTPServer) CreateMux() http.Handler {
 	mux := http.NewServeMux()
 
+	// Health check endpoint for Kubernetes probes (unauthenticated)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
 	// Setup OAuth 2.1 endpoints
 	s.setupOAuthRoutes(mux)
 


### PR DESCRIPTION
## Problem

After PR #156 was merged, pods are still failing:
1. Health probes timeout - the `/health` endpoint doesn't exist
2. OAuth server fails to initialize - config is passed via env vars but code expects config file

## Solution

1. Added `/health` endpoint for Kubernetes probes
2. Updated Helm ConfigMap to include OAuth server configuration

## Priority

CRITICAL - Blocking deployment.