### PR TITLE
fix(helm): mount valkey password from separate secret

### DIFF
--- a/helm/muster/templates/deployment.yaml
+++ b/helm/muster/templates/deployment.yaml
@@ -115,9 +115,19 @@ spec:
             name: {{ include "muster.fullname" . }}-config
         {{- if .Values.muster.oauthServer.enabled }}
         - name: oauth-secrets
-          secret:
-            secretName: {{ .Values.muster.oauthServer.existingSecret | default (printf "%s-oauth" (include "muster.fullname" .)) }}
-            optional: false
+          projected:
+            sources:
+              # OAuth credentials (dex-client-secret, oauth-encryption-key, registration-token)
+              - secret:
+                  name: {{ .Values.muster.oauthServer.existingSecret | default (printf "%s-oauth" (include "muster.fullname" .)) }}
+              {{- if and (eq .Values.muster.oauthServer.storage.type "valkey") (or .Values.muster.oauthServer.storage.valkey.existingSecret .Values.muster.oauthServer.existingSecret .Values.muster.oauthServer.storage.valkey.password) }}
+              # Valkey password (mounted as valkey-password)
+              - secret:
+                  name: {{ .Values.muster.oauthServer.storage.valkey.existingSecret | default .Values.muster.oauthServer.existingSecret | default (printf "%s-oauth" (include "muster.fullname" .)) }}
+                  items:
+                    - key: {{ .Values.muster.oauthServer.storage.valkey.secretKeyPassword | default "valkey-password" }}
+                      path: valkey-password
+              {{- end }}
         {{- end }}
         - name: sa-token
           projected:


### PR DESCRIPTION
## Problem

Muster pods (0.0.92+) are crashing with:
```
failed to read Valkey password from /etc/muster/secrets/valkey-password: no such file or directory
```

## Root Cause

The valkey password is stored in a **separate secret** (e.g., `muster-valkey-auth`) from the OAuth credentials (`muster-oauth-credentials`). The previous fix only mounted the OAuth secret, not the valkey secret.

Configuration on gazelle:
- OAuth secret: `muster-oauth-credentials` (has: `dex-client-secret`, `oauth-encryption-key`, `registration-token`)
- Valkey secret: `muster-valkey-auth` (has: key `default` containing the password)
- Config expects: `/etc/muster/secrets/valkey-password`

## Solution

Use a **projected volume** to combine both secrets:
1. OAuth credentials from `existingSecret` (or chart-generated secret)
2. Valkey password from `valkey.existingSecret`, with the key mapped to `valkey-password` path

This allows the valkey password to be stored in a different secret with a different key name, while still being available at the expected path.

## Priority

CRITICAL - This is blocking the muster rollout to 0.0.92+ on gazelle.