### PR TITLE
docs: add CHANGELOG entry for CiliumNetworkPolicy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Helm CiliumNetworkPolicy**: Fixed incorrect values path for OAuth storage check (was `.Values.muster.oauth.storage`, should be `.Values.muster.oauthServer.storage`)
+
 ### Added
 - **Remote MCP Server Support for Kubernetes Environments**
   - Added comprehensive support for `stdio`, `streamable-http` and `sse` transport protocols


### PR DESCRIPTION
## Summary

Adds a CHANGELOG entry documenting the CiliumNetworkPolicy fix that was committed directly to main.

## Background

Two commits were pushed directly to main to fix a Helm template error that was blocking the gazelle deployment:

1. `904e025` - Initial fix attempt (added nil check for `oauth.storage`)
2. `3c045b9` - Corrected fix (changed path from `oauth.storage` to `oauthServer.storage`)

These direct pushes bypassed the auto-release workflow, so no v0.0.95 tag was created and the Helm chart wasn't published.

## Purpose

This PR:
1. Documents the fix in CHANGELOG.md
2. Triggers the auto-release workflow to create v0.0.95
3. Allows CircleCI to build and publish the updated Helm chart

Once merged, Flux should be able to deploy the fix to gazelle.