### PR TITLE
chore: update mcp-oauth to v0.2.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.2.26
+	github.com/giantswarm/mcp-oauth v0.2.27
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.7
 	github.com/mark3labs/mcp-go v0.43.2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.26 h1:SKJiLKww37edC1ItFMOfjfXfp8uX8Xw10D9IQXlXPCI=
-github.com/giantswarm/mcp-oauth v0.2.26/go.mod h1:e8W2usiHVKJhj4f4Zfgk/Bcnqx8Ck2XJFxLqyg0YC64=
+github.com/giantswarm/mcp-oauth v0.2.27 h1:GL/sQJ1UtGQubllgNAyJUQToGUQvy2gesf2AB3D98TY=
+github.com/giantswarm/mcp-oauth v0.2.27/go.mod h1:e8W2usiHVKJhj4f4Zfgk/Bcnqx8Ck2XJFxLqyg0YC64=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
Updates the mcp-oauth library from v0.2.26 to v0.2.27.