### PR TITLE
fix: Correct CRD validation rule paths to use self.spec prefix

### DIFF
--- a/deploy/crds/muster.giantswarm.io_mcpservers.yaml
+++ b/deploy/crds/muster.giantswarm.io_mcpservers.yaml
@@ -228,13 +228,13 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: command is required when type is stdio
-          rule: self.type != 'stdio' || has(self.command)
+          rule: self.spec.type != 'stdio' || has(self.spec.command)
         - message: url is required when type is streamable-http or sse
-          rule: self.type == 'stdio' || has(self.url)
+          rule: self.spec.type == 'stdio' || has(self.spec.url)
         - message: args field is only allowed when type is stdio
-          rule: self.type == 'stdio' || !has(self.args)
+          rule: self.spec.type == 'stdio' || !has(self.spec.args)
         - message: headers field is only allowed when type is streamable-http or sse
-          rule: self.type != 'stdio' || !has(self.headers)
+          rule: self.spec.type != 'stdio' || !has(self.spec.headers)
     served: true
     storage: true
     subresources:

--- a/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
+++ b/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
@@ -228,13 +228,13 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: command is required when type is stdio
-          rule: self.type != 'stdio' || has(self.command)
+          rule: self.spec.type != 'stdio' || has(self.spec.command)
         - message: url is required when type is streamable-http or sse
-          rule: self.type == 'stdio' || has(self.url)
+          rule: self.spec.type == 'stdio' || has(self.spec.url)
         - message: args field is only allowed when type is stdio
-          rule: self.type == 'stdio' || !has(self.args)
+          rule: self.spec.type == 'stdio' || !has(self.spec.args)
         - message: headers field is only allowed when type is streamable-http or sse
-          rule: self.type != 'stdio' || !has(self.headers)
+          rule: self.spec.type != 'stdio' || !has(self.spec.headers)
     served: true
     storage: true
     subresources:

--- a/pkg/apis/muster/v1alpha1/mcpserver_types.go
+++ b/pkg/apis/muster/v1alpha1/mcpserver_types.go
@@ -89,10 +89,10 @@ type MCPServerStatus struct {
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="Health",type="string",JSONPath=".status.health"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:validation:XValidation:rule="self.type != 'stdio' || has(self.command)",message="command is required when type is stdio"
-// +kubebuilder:validation:XValidation:rule="self.type == 'stdio' || has(self.url)",message="url is required when type is streamable-http or sse"
-// +kubebuilder:validation:XValidation:rule="self.type == 'stdio' || !has(self.args)",message="args field is only allowed when type is stdio"
-// +kubebuilder:validation:XValidation:rule="self.type != 'stdio' || !has(self.headers)",message="headers field is only allowed when type is streamable-http or sse"
+// +kubebuilder:validation:XValidation:rule="self.spec.type != 'stdio' || has(self.spec.command)",message="command is required when type is stdio"
+// +kubebuilder:validation:XValidation:rule="self.spec.type == 'stdio' || has(self.spec.url)",message="url is required when type is streamable-http or sse"
+// +kubebuilder:validation:XValidation:rule="self.spec.type == 'stdio' || !has(self.spec.args)",message="args field is only allowed when type is stdio"
+// +kubebuilder:validation:XValidation:rule="self.spec.type != 'stdio' || !has(self.spec.headers)",message="headers field is only allowed when type is streamable-http or sse"
 
 // MCPServer is the Schema for the mcpservers API
 type MCPServer struct {


### PR DESCRIPTION
## Problem

The Helm upgrade on gazelle is failing with CRD validation errors:

```
CustomResourceDefinition.apiextensions.k8s.io "mcpservers.muster.giantswarm.io" is invalid:
  spec.validation.openAPIV3Schema.x-kubernetes-validations[0].rule: Invalid value: 
  "self.type != 'stdio' || has(self.command)": compilation failed: 
  ERROR: undefined field 'type'
```

## Cause

The `x-kubernetes-validations` rules are defined at the root `openAPIV3Schema` level (on the MCPServer struct), so `self` refers to the entire MCPServer object which has:
- `apiVersion`
- `kind`
- `metadata`
- `spec`
- `status`

The rules were incorrectly using `self.type`, `self.command`, etc., but those fields are under `spec`, not at the root level.

## Solution

Updated the kubebuilder validation markers to use the correct paths:
- `self.type` → `self.spec.type`
- `has(self.command)` → `has(self.spec.command)`
- `has(self.url)` → `has(self.spec.url)`
- `has(self.args)` → `has(self.spec.args)`
- `has(self.headers)` → `has(self.spec.headers)`

## Changes

- `pkg/apis/muster/v1alpha1/mcpserver_types.go`: Fixed XValidation marker rules
- `deploy/crds/muster.giantswarm.io_mcpservers.yaml`: Regenerated CRD
- `helm/muster/crds/muster.giantswarm.io_mcpservers.yaml`: Copied regenerated CRD

## Testing

- All unit tests pass
- All 135 scenario tests pass