### PR TITLE
fix: Use WatchModeAuto for ReconcileManager to enable Kubernetes mode

### DIFF
--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -242,7 +242,7 @@ func InitializeServices(cfg *Config) (*Services, error) {
 	var reconcileManager *reconciler.Manager
 	if cfg.ConfigPath != "" {
 		reconcileConfig := reconciler.ManagerConfig{
-			Mode:           reconciler.WatchModeFilesystem,
+			Mode:           reconciler.WatchModeAuto,
 			FilesystemPath: cfg.ConfigPath,
 			Namespace:      namespace,
 			WorkerCount:    2,


### PR DESCRIPTION
## Summary

Fixes #178

The ReconcileManager was hardcoded to use `WatchModeFilesystem`, which prevented Kubernetes mode from being used even when running in a cluster.

## Changes

Changed `WatchModeFilesystem` to `WatchModeAuto` in `internal/app/services.go`. The auto-detection logic in `manager.go` already handles this correctly:

1. Checks for Kubernetes availability first
2. Falls back to filesystem mode if not in a cluster

## Impact

When running in Kubernetes:
- MCPServer CRs with `autoStart: true` will now be automatically detected and started
- Changes to CRDs will be picked up by the Kubernetes informers
- The reconciler will use Kubernetes mode instead of filesystem mode

When running locally:
- No change - auto-detection falls back to filesystem mode

## Testing

- All unit tests pass
- Verified the change is a one-liner with no side effects