### PR TITLE
Fix: Add explicit kubernetes config for CRD mode

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -58,6 +58,7 @@ namespace: "default"            # Kubernetes namespace for CR discovery (default
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `namespace` | `string` | `"default"` | Kubernetes namespace for discovering MCPServer, ServiceClass, and Workflow CRs |
+| `kubernetes` | `bool` | `false` | Enable Kubernetes CRD mode. When `true`, uses Kubernetes CRDs for resource storage. When `false`, uses filesystem YAML files. The Helm chart sets this to `true` by default. |
 | `aggregator` | `AggregatorConfig` | see below | Aggregator service configuration |
 
 ### Aggregator Configuration
@@ -99,6 +100,7 @@ aggregator:
 #### Production Configuration (Kubernetes)
 ```yaml
 namespace: "muster-system"      # Use dedicated namespace for muster CRs
+kubernetes: true                # Use Kubernetes CRDs instead of filesystem
 aggregator:
   port: 80
   host: "0.0.0.0"

--- a/helm/muster/templates/configmap.yaml
+++ b/helm/muster/templates/configmap.yaml
@@ -64,3 +64,4 @@ data:
         {{- end }}
       {{- end }}
     namespace: {{ include "muster.namespace" . | quote }}
+    kubernetes: true

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -327,14 +327,13 @@ func createMusterClientWithConfig(configPath string, debug bool, musterConfig co
 		namespace = "default"
 	}
 
-	// Create client config with the filesystem path
-	// When a config path is explicitly provided, force filesystem mode since
-	// that's where the CRD YAML files are stored. This ensures tests and local
-	// development use the correct storage backend.
+	// Create client config with the filesystem path as fallback.
+	// When kubernetes=true in config, use Kubernetes CRD mode.
+	// Otherwise, force filesystem mode for local development and tests.
 	clientConfig := &client.MusterClientConfig{
 		FilesystemPath:      configPath,
 		Namespace:           namespace,
-		ForceFilesystemMode: true,
+		ForceFilesystemMode: !musterConfig.Kubernetes,
 		Debug:               debug,
 	}
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -5,7 +5,8 @@ import "strings"
 // MusterConfig is the top-level configuration structure for muster.
 type MusterConfig struct {
 	Aggregator AggregatorConfig `yaml:"aggregator"`
-	Namespace  string           `yaml:"namespace,omitempty"` // Namespace for MCPServer, ServiceClass and Workflow discovery
+	Namespace  string           `yaml:"namespace,omitempty"`  // Namespace for MCPServer, ServiceClass and Workflow discovery
+	Kubernetes bool             `yaml:"kubernetes,omitempty"` // Enable Kubernetes CRD mode (uses CRDs instead of filesystem)
 }
 
 // MCPServerType defines the type of MCP server.


### PR DESCRIPTION
## Problem

When running in Kubernetes with a config path (e.g., `/etc/muster`), muster was incorrectly forcing filesystem mode. This caused the MCPServer reconciler to immediately delete all MCPServer services on startup because it couldn't find the CRDs in the filesystem.

### Root Cause

The `createMusterClientWithConfig` function had `ForceFilesystemMode: true` set unconditionally when a config path was provided. This was intended for "tests and local development" but was also triggered in production Kubernetes deployments because a config path is always provided via the Helm chart.

This caused a mode mismatch:
- **MusterClient** used filesystem mode (looking for YAML files in `/etc/muster/mcpservers/`)
- **ReconcileManager** auto-detected Kubernetes mode (watching CRDs via informers)

When the watcher detected MCPServer CRDs and the reconciler tried to fetch them via the filesystem-mode client, it got "not found" errors, which triggered the delete logic.

### Logs showing the issue

```
time=2025-12-24T00:52:14.176Z level=INFO msg="Found 0 MCPServer definitions for auto-start processing"
time=2025-12-24T00:52:14.345Z level=INFO msg="Started watching Kubernetes resources in namespace: muster"
time=2025-12-24T00:52:14.345Z level=INFO msg="Deleting MCPServer service: galaxy-mcp-kubernetes"
time=2025-12-24T00:52:14.345Z level=INFO msg="Deleting MCPServer service: gazelle-mcp-kubernetes"
time=2025-12-24T00:52:14.345Z level=INFO msg="Deleting MCPServer service: goose-mcp-kubernetes"
```

## Solution

Add an explicit `kubernetes` config option to control whether to use Kubernetes CRD mode or filesystem mode:

- **`kubernetes: true`** - Uses Kubernetes CRDs for resource storage
- **`kubernetes: false`** (default) - Uses filesystem YAML files

The Helm chart now sets `kubernetes: true` by default, since Helm charts only run in Kubernetes.

This provides explicit, predictable behavior instead of confusing auto-detection.

## Changes

- `internal/config/types.go`: Added `Kubernetes` bool field to `MusterConfig`
- `internal/app/services.go`: Use `!musterConfig.Kubernetes` for `ForceFilesystemMode`
- `helm/muster/templates/configmap.yaml`: Set `kubernetes: true` by default
- `docs/reference/configuration.md`: Document the new config option