### PR TITLE
Fix: Prevent browser tabs from opening during tests

### DIFF
--- a/internal/agent/oauth/browser.go
+++ b/internal/agent/oauth/browser.go
@@ -7,6 +7,12 @@ import (
 	"runtime"
 )
 
+// browserLauncher is the function used to launch the browser command.
+// It can be replaced in tests to prevent actual browser opening.
+var browserLauncher = func(cmd *exec.Cmd) error {
+	return cmd.Start()
+}
+
 // OpenBrowser opens the specified URL in the default web browser.
 // It supports Linux, macOS, and Windows.
 //
@@ -48,7 +54,7 @@ func OpenBrowser(urlStr string) error {
 
 	// Start the command but don't wait for it to complete
 	// The browser will open in the background
-	if err := cmd.Start(); err != nil {
+	if err := browserLauncher(cmd); err != nil {
 		return fmt.Errorf("failed to open browser: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

Running `make test` opens many browser tabs with `example.com` URLs. This happens because the browser tests in `internal/agent/oauth/browser_test.go` call `OpenBrowser()` with valid URLs on supported platforms (Linux, macOS, Windows), which actually executes `xdg-open`, `open`, or `cmd /c start` commands.

## Solution

Introduced a `browserLauncher` function variable that can be replaced in tests with a mock to prevent actual browser opening while still testing:
- URL validation logic
- Command construction for different platforms
- Error handling

### Changes

- **browser.go**: Added `browserLauncher` variable that wraps `cmd.Start()` and can be replaced in tests
- **browser_test.go**: 
  - Added `mockBrowserLauncher` that does nothing instead of opening browsers
  - Updated `TestOpenBrowser_SupportedPlatforms` and `TestOpenBrowser_ValidURLSchemes` to use the mock
  - Added new `TestOpenBrowser_LauncherError` test to verify error handling when the launcher fails

## Testing

All tests pass without opening any browser tabs:

```
=== RUN   TestOpenBrowser_ValidURLSchemes
=== RUN   TestOpenBrowser_ValidURLSchemes/https://example.com
=== RUN   TestOpenBrowser_ValidURLSchemes/https://example.com/path?query=value
=== RUN   TestOpenBrowser_ValidURLSchemes/http://localhost:8080
=== RUN   TestOpenBrowser_ValidURLSchemes/https://auth.example.com/oauth/authorize?client_id=123
--- PASS: TestOpenBrowser_ValidURLSchemes (0.00s)
```