### PR TITLE
Fix: Update service configuration before restart in reconciler

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -31,6 +31,24 @@ type ServiceInfo interface {
 	GetServiceData() map[string]interface{}
 }
 
+// ConfigurableService extends ServiceInfo with the ability to update configuration.
+// Services that can have their configuration updated at runtime should implement
+// this interface to allow reconcilers and managers to update configuration
+// before restarting the service.
+type ConfigurableService interface {
+	ServiceInfo
+
+	// UpdateConfiguration updates the service's internal configuration.
+	// This should be called before restarting a service when its definition changes.
+	//
+	// Args:
+	//   - config: The new configuration (type depends on service implementation)
+	//
+	// Returns:
+	//   - error: Error if the configuration is invalid or update fails
+	UpdateConfiguration(config interface{}) error
+}
+
 // ServiceRegistryHandler provides access to registered services in the system.
 // This handler implements the service discovery aspect of the Service Locator Pattern,
 // allowing components to find and access service information without direct coupling.


### PR DESCRIPTION
## Problem

When MCPServer CRD configuration changes (e.g., URL, command, args), the reconciler detects the change and restarts the service. However, the restart was using the **old** configuration because the service's internal configuration was never updated.

**Observed behavior:**
- MCPServer definition shows correct URL: `https://mcp-kubernetes.gazelle.awsprod.gigantic.io/mcp`
- Running service still uses old URL: `https://mcp-kubernetes.gazelle.awsprod.gigantic.io`
- Service keeps failing with the old configuration even after reconciler restarts it

**Root cause:**
The `reconcileUpdate` method called `RestartService` directly without first updating the service's internal configuration via `UpdateConfiguration`.

## Solution

1. Added `ConfigurableService` interface to `internal/api/service.go` for services that can have their configuration updated at runtime

2. Updated `MCPServerReconciler.reconcileUpdate` to:
   - Check if the service implements `ConfigurableService`
   - Call `UpdateConfiguration` with the new MCPServer definition
   - Then proceed with the restart

## Changes

- `internal/api/service.go`: Added `ConfigurableService` interface
- `internal/reconciler/mcpserver_reconciler.go`: Updated `reconcileUpdate` to call `UpdateConfiguration` before restart

## Testing

- All unit tests pass (`make test`)
- All 135 scenario tests pass (`muster test --parallel 50`)