### PR TITLE
Fix: Suppress log messages during CLI commands unless --debug is used

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -11,6 +11,7 @@ import (
 var (
 	checkOutputFormat string
 	checkQuiet        bool
+	checkDebug        bool
 	checkConfigPath   string
 	checkEndpoint     string
 	checkContext      string
@@ -78,6 +79,7 @@ func init() {
 	// Add flags to the command
 	checkCmd.PersistentFlags().StringVarP(&checkOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	checkCmd.PersistentFlags().BoolVarP(&checkQuiet, "quiet", "q", false, "Suppress non-essential output")
+	checkCmd.PersistentFlags().BoolVar(&checkDebug, "debug", false, "Enable debug logging (show MCP protocol messages)")
 	checkCmd.PersistentFlags().StringVar(&checkConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 	checkCmd.PersistentFlags().StringVar(&checkEndpoint, "endpoint", cli.GetDefaultEndpoint(), "Remote muster aggregator endpoint URL (env: MUSTER_ENDPOINT)")
 	checkCmd.PersistentFlags().StringVar(&checkContext, "context", "", "Use a specific context (env: MUSTER_CONTEXT)")
@@ -103,6 +105,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(checkOutputFormat),
 		Quiet:      checkQuiet,
+		Debug:      checkDebug,
 		ConfigPath: checkConfigPath,
 		Endpoint:   checkEndpoint,
 		Context:    checkContext,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,6 +15,7 @@ import (
 var (
 	createOutputFormat string
 	createQuiet        bool
+	createDebug        bool
 	createConfigPath   string
 	createEndpoint     string
 	createContext      string
@@ -121,6 +122,7 @@ func init() {
 	// Add flags to the command
 	createCmd.PersistentFlags().StringVarP(&createOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	createCmd.PersistentFlags().BoolVarP(&createQuiet, "quiet", "q", false, "Suppress non-essential output")
+	createCmd.PersistentFlags().BoolVar(&createDebug, "debug", false, "Enable debug logging (show MCP protocol messages)")
 	createCmd.PersistentFlags().StringVar(&createConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 	createCmd.PersistentFlags().StringVar(&createEndpoint, "endpoint", cli.GetDefaultEndpoint(), "Remote muster aggregator endpoint URL (env: MUSTER_ENDPOINT)")
 	createCmd.PersistentFlags().StringVar(&createContext, "context", "", "Use a specific context (env: MUSTER_CONTEXT)")
@@ -328,6 +330,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(createOutputFormat),
 		Quiet:      createQuiet,
+		Debug:      createDebug,
 		ConfigPath: createConfigPath,
 		Endpoint:   createEndpoint,
 		Context:    createContext,

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -15,6 +15,7 @@ import (
 var (
 	eventsOutputFormat string
 	eventsQuiet        bool
+	eventsDebug        bool
 	eventsConfigPath   string
 	eventsResourceType string
 	eventsResourceName string
@@ -94,6 +95,7 @@ func init() {
 	// Add flags to the command
 	eventsCmd.PersistentFlags().StringVarP(&eventsOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	eventsCmd.PersistentFlags().BoolVarP(&eventsQuiet, "quiet", "q", false, "Suppress non-essential output")
+	eventsCmd.PersistentFlags().BoolVar(&eventsDebug, "debug", false, "Enable debug logging (show MCP protocol messages)")
 	eventsCmd.PersistentFlags().StringVar(&eventsConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 
 	// Filtering flags
@@ -181,6 +183,7 @@ func runEvents(cmd *cobra.Command, args []string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(eventsOutputFormat),
 		Quiet:      eventsQuiet,
+		Debug:      eventsDebug,
 		ConfigPath: eventsConfigPath,
 		Endpoint:   eventsEndpoint,
 		Context:    eventsContext,

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -15,6 +15,7 @@ import (
 var (
 	getOutputFormat string
 	getQuiet        bool
+	getDebug        bool
 	getConfigPath   string
 	getEndpoint     string
 	getContext      string
@@ -258,6 +259,7 @@ func init() {
 	// Add flags to the command
 	getCmd.PersistentFlags().StringVarP(&getOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	getCmd.PersistentFlags().BoolVarP(&getQuiet, "quiet", "q", false, "Suppress non-essential output")
+	getCmd.PersistentFlags().BoolVar(&getDebug, "debug", false, "Enable debug logging (show MCP protocol messages)")
 	getCmd.PersistentFlags().StringVar(&getConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 	getCmd.PersistentFlags().StringVar(&getEndpoint, "endpoint", cli.GetDefaultEndpoint(), "Remote muster aggregator endpoint URL (env: MUSTER_ENDPOINT)")
 	getCmd.PersistentFlags().StringVar(&getContext, "context", "", "Use a specific context (env: MUSTER_CONTEXT)")
@@ -288,6 +290,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(getOutputFormat),
 		Quiet:      getQuiet,
+		Debug:      getDebug,
 		ConfigPath: getConfigPath,
 		Endpoint:   getEndpoint,
 		Context:    getContext,
@@ -330,6 +333,7 @@ func runGetMCP(cmd *cobra.Command, mcpType, name string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(getOutputFormat),
 		Quiet:      getQuiet,
+		Debug:      getDebug,
 		ConfigPath: getConfigPath,
 		Endpoint:   getEndpoint,
 		Context:    getContext,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,6 +15,7 @@ import (
 var (
 	listOutputFormat string
 	listQuiet        bool
+	listDebug        bool
 	listConfigPath   string
 	listEndpoint     string
 	listContext      string
@@ -229,6 +230,7 @@ func init() {
 	// Add flags to the command
 	listCmd.PersistentFlags().StringVarP(&listOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	listCmd.PersistentFlags().BoolVarP(&listQuiet, "quiet", "q", false, "Suppress non-essential output")
+	listCmd.PersistentFlags().BoolVar(&listDebug, "debug", false, "Enable debug logging (show MCP protocol messages)")
 	listCmd.PersistentFlags().StringVar(&listConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 	listCmd.PersistentFlags().StringVar(&listEndpoint, "endpoint", cli.GetDefaultEndpoint(), "Remote muster aggregator endpoint URL (env: MUSTER_ENDPOINT)")
 	listCmd.PersistentFlags().StringVar(&listContext, "context", "", "Use a specific context (env: MUSTER_CONTEXT)")
@@ -312,6 +314,7 @@ func runListMCP(cmd *cobra.Command, mcpType string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(listOutputFormat),
 		Quiet:      listQuiet,
+		Debug:      listDebug,
 		ConfigPath: listConfigPath,
 		Endpoint:   listEndpoint,
 		Context:    listContext,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -14,6 +14,7 @@ import (
 var (
 	startOutputFormat string
 	startQuiet        bool
+	startDebug        bool
 	startConfigPath   string
 	startEndpoint     string
 	startContext      string
@@ -127,6 +128,7 @@ func init() {
 	// Add flags to the command
 	startCmd.PersistentFlags().StringVarP(&startOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	startCmd.PersistentFlags().BoolVarP(&startQuiet, "quiet", "q", false, "Suppress non-essential output")
+	startCmd.PersistentFlags().BoolVar(&startDebug, "debug", false, "Enable debug logging (show MCP protocol messages)")
 	startCmd.PersistentFlags().StringVar(&startConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 	startCmd.PersistentFlags().StringVar(&startEndpoint, "endpoint", cli.GetDefaultEndpoint(), "Remote muster aggregator endpoint URL (env: MUSTER_ENDPOINT)")
 	startCmd.PersistentFlags().StringVar(&startContext, "context", "", "Use a specific context (env: MUSTER_CONTEXT)")
@@ -209,6 +211,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(startOutputFormat),
 		Quiet:      startQuiet,
+		Debug:      startDebug,
 		ConfigPath: startConfigPath,
 		Endpoint:   startEndpoint,
 		Context:    startContext,

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -11,6 +11,7 @@ import (
 var (
 	stopOutputFormat string
 	stopQuiet        bool
+	stopDebug        bool
 	stopConfigPath   string
 	stopEndpoint     string
 	stopContext      string
@@ -71,6 +72,7 @@ func init() {
 	// Add flags to the command
 	stopCmd.PersistentFlags().StringVarP(&stopOutputFormat, "output", "o", "table", "Output format (table, json, yaml)")
 	stopCmd.PersistentFlags().BoolVarP(&stopQuiet, "quiet", "q", false, "Suppress non-essential output")
+	stopCmd.PersistentFlags().BoolVar(&stopDebug, "debug", false, "Enable debug logging (show MCP protocol messages)")
 	stopCmd.PersistentFlags().StringVar(&stopConfigPath, "config-path", config.GetDefaultConfigPathOrPanic(), "Configuration directory")
 	stopCmd.PersistentFlags().StringVar(&stopEndpoint, "endpoint", cli.GetDefaultEndpoint(), "Remote muster aggregator endpoint URL (env: MUSTER_ENDPOINT)")
 	stopCmd.PersistentFlags().StringVar(&stopContext, "context", "", "Use a specific context (env: MUSTER_CONTEXT)")
@@ -96,6 +98,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 	executor, err := cli.NewToolExecutor(cli.ExecutorOptions{
 		Format:     cli.OutputFormat(stopOutputFormat),
 		Quiet:      stopQuiet,
+		Debug:      stopDebug,
 		ConfigPath: stopConfigPath,
 		Endpoint:   stopEndpoint,
 		Context:    stopContext,

--- a/internal/cli/executor.go
+++ b/internal/cli/executor.go
@@ -111,6 +111,8 @@ type ExecutorOptions struct {
 	Format OutputFormat
 	// Quiet suppresses progress indicators and non-essential output
 	Quiet bool
+	// Debug enables verbose logging of MCP protocol messages and initialization
+	Debug bool
 	// ConfigPath specifies a custom configuration directory path
 	ConfigPath string
 	// Endpoint overrides the aggregator endpoint URL for remote connections
@@ -149,7 +151,14 @@ type ToolExecutor struct {
 //   - *ToolExecutor: Configured tool executor ready for use
 //   - error: Configuration or connection setup error
 func NewToolExecutor(options ExecutorOptions) (*ToolExecutor, error) {
-	logger := agent.NewLogger(false, false, false)
+	// Use DevNullLogger by default to suppress MCP protocol messages
+	// Only enable verbose logging when Debug mode is explicitly requested
+	var logger *agent.Logger
+	if options.Debug {
+		logger = agent.NewLogger(true, true, false)
+	} else {
+		logger = agent.NewDevNullLogger()
+	}
 
 	var endpoint string
 	var transport agent.TransportType


### PR DESCRIPTION
## Summary

When using CLI commands that connect to the muster server (like `muster list tools`, `muster get tool`, etc.), log messages were printed to stdout even without a debug flag. These messages should only appear when a `--debug` flag is used.

### Before
```
❯ muster list tools
[2026-01-17 08:50:11] Initializing MCP session...
⠸ Connecting to muster server...[2026-01-17 08:50:12] Session initialized successfully
[2026-01-17 08:50:12] Listing available tools...
[2026-01-17 08:50:12] Found 39 tools
[2026-01-17 08:50:12] Tool changes detected:
[2026-01-17 08:50:12] + Added: core_serviceclass_list
...
```

### After
```
❯ muster list tools
╭─────────────────────────────────────────────┬──────────────────────────────────────────────────────────────╮
│ NAME                                        │ DESCRIPTION                                                  │
├─────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ core_config_get                             │ Get the current muster configuration                         │
...
```

### With --debug
```
❯ muster list tools --debug
[2026-01-17 09:50:12] Initializing MCP session...
[2026-01-17 09:50:12] Session initialized successfully
[2026-01-17 09:50:12] Listing available tools...
[2026-01-17 09:50:12] Found 136 tools
...
```

## Changes

### `internal/cli/executor.go`
- Added `Debug` field to `ExecutorOptions`
- Modified `NewToolExecutor` to use `NewDevNullLogger()` by default, only using verbose logger when `Debug` is true

### CLI Commands (7 files)
- Added `--debug` flag to all affected commands: `list`, `get`, `create`, `start`, `stop`, `check`, `events`
- Added `Debug` field to `ExecutorOptions` when creating the executor

## Acceptance Criteria

- [x] `muster list tools` shows only the table output without log messages
- [x] `muster get tool <name>` shows only the tool details without log messages
- [x] `muster create service <name> <class>` shows only result without log messages
- [x] `muster start service <name>` shows only result without log messages
- [x] `muster stop service <name>` shows only result without log messages
- [x] `muster check serviceclass <name>` shows only result without log messages
- [x] `muster events` shows only events without log messages
- [x] Adding `--debug` shows initialization and protocol messages
- [x] `--quiet` continues to suppress all non-table output

Closes #220