### PR TITLE
Fix: CLI auth login command missing server argument for core_auth_login

### DIFF
--- a/cmd/auth_helpers.go
+++ b/cmd/auth_helpers.go
@@ -170,8 +170,13 @@ func triggerMCPServerAuthWithWait(ctx context.Context, handler api.AuthHandler, 
 	}
 	defer client.Close()
 
-	// Call the auth tool
-	result, err := client.CallTool(ctx, authTool, nil)
+	// Call the auth tool with the server name as argument.
+	// Per ADR-008, core_auth_login requires a "server" parameter to identify
+	// which MCP server to authenticate to.
+	args := map[string]interface{}{
+		"server": serverName,
+	}
+	result, err := client.CallTool(ctx, authTool, args)
 	if err != nil {
 		return fmt.Errorf("failed to call auth tool: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes the `muster auth login --server <name>` CLI command which was broken after PR #226.

## Problem

After PR #226 introduced the unified `core_auth_login` tool (per ADR-008), the CLI `auth login --server` command started failing with:

```
Error: auth tool did not return an auth URL
```

## Root Cause

PR #226 changed the authentication architecture from synthetic per-server `x_<server>_authenticate` tools to a unified `core_auth_login` tool that requires a `server` parameter.

The `triggerMCPServerAuthWithWait` function in `cmd/auth_helpers.go` was calling:

```go
result, err := client.CallTool(ctx, authTool, nil)  // Missing server argument!
```

But `core_auth_login` requires the `server` argument to identify which MCP server to authenticate to.

## Solution

Updated `triggerMCPServerAuthWithWait` to pass the server name as an argument when calling the auth tool:

```go
args := map[string]interface{}{
    "server": serverName,
}
result, err := client.CallTool(ctx, authTool, args)
```

## Testing

- All unit tests pass (`make test`)
- All 147 BDD scenarios pass (`muster test --parallel 50`)
- Code formatted with `goimports -w . && go fmt ./...`

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally
- [x] BDD scenarios pass
- [x] Code is formatted