### PR TITLE
Fix: Add missing --server flag to auth logout command

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -50,7 +50,7 @@ re-authenticate on the next connection to protected endpoints.
 Examples:
   muster auth logout                   # Logout from configured aggregator
   muster auth logout --endpoint <url>  # Logout from specific endpoint
-  muster auth logout --server <name>   # Logout from specific MCP server
+  muster auth logout -s <name>         # Logout from specific MCP server
   muster auth logout --all             # Clear all stored tokens
   muster auth logout --all --yes       # Clear all without confirmation`,
 	RunE: runAuthLogout,
@@ -126,7 +126,7 @@ func init() {
 	// Logout-specific flags (only on logout subcommand)
 	authLogoutCmd.Flags().BoolVar(&logoutAll, "all", false, "Clear all stored tokens")
 	authLogoutCmd.Flags().BoolVarP(&logoutYes, "yes", "y", false, "Skip confirmation prompt for --all")
-	authLogoutCmd.Flags().StringVar(&logoutServer, "server", "", "MCP server name to disconnect")
+	authLogoutCmd.Flags().StringVarP(&logoutServer, "server", "s", "", "MCP server name to disconnect")
 }
 
 func runAuthLogout(cmd *cobra.Command, args []string) error {

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -121,6 +121,16 @@ func TestAuthLogoutCommand(t *testing.T) {
 			t.Error("expected --server flag on logout command")
 		}
 	})
+
+	t.Run("logout --server flag has -s shorthand", func(t *testing.T) {
+		flag := authLogoutCmd.Flags().ShorthandLookup("s")
+		if flag == nil {
+			t.Error("expected -s shorthand for --server flag")
+		}
+		if flag.Name != "server" {
+			t.Errorf("expected -s to be shorthand for 'server', got %q", flag.Name)
+		}
+	})
 }
 
 func TestAuthStatusCommand(t *testing.T) {


### PR DESCRIPTION
## Summary

The `muster auth logout --server <name>` command was failing with `unknown flag: --server` because the flag was never registered on the logout command.

## Problem

The code in `runAuthLogout` checked for `authServer != ""` but:
1. The `authServer` variable was declared but never bound to any flag
2. The `--server` flag was only registered on the `auth login` command, not on `auth logout`

This resulted in the error:
```
❯ muster auth logout --server work-inboxfewer
Error: unknown flag: --server
```

## Solution

- Added `logoutServer` variable and registered the `--server` flag on the logout command
- Updated `runAuthLogout` to use `logoutServer` instead of `authServer`
- Removed the unused `authServer` variable
- Updated command help examples to include `--server` usage
- Added `-s` shorthand for `--server` flag (consistent with other shorthand flags like `-y` for `--yes`)
- Added tests for both `--server` flag and `-s` shorthand

## Testing

```bash
❯ muster auth logout --help
# Now shows --server/-s flag in help output

❯ muster auth logout -s myserver
# Works with shorthand

❯ go test ./cmd/... -v -run TestAuthLogoutCommand
# All tests pass including --server flag and -s shorthand tests
```