### PR TITLE
Fix: SSO token forwarding - middleware ordering bug

### DIFF
--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -105,7 +105,7 @@ func TestValidateHTTPSRequirement(t *testing.T) {
 	}
 }
 
-func TestHashEmail(t *testing.T) {
+func TestTruncateEmail(t *testing.T) {
 	tests := []struct {
 		name     string
 		email    string
@@ -130,7 +130,7 @@ func TestHashEmail(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := hashEmail(tt.email)
+			result := truncateEmail(tt.email)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the SSO token forwarding flow and adds diagnostic logging.

Fixes #246

## Root Cause

The `triggerSessionInitIfNeeded` function was trying to get the session ID from context:

```go
sessionID, ok := api.GetClientSessionIDFromContext(ctx)
```

But `clientSessionIDMiddleware` runs **AFTER** `createAccessTokenInjectorMiddleware` in the middleware chain (it wraps the MCP handler, not the OAuth chain). So the session ID was never set when the SSO init callback tried to read it.

### Middleware Chain (before fix)

```
ValidateToken -> createAccessTokenInjectorMiddleware -> clientSessionIDMiddleware -> MCP handler
                 ^--- tries to read session ID here
                                                        ^--- session ID is set here (too late!)
```

## Fix

Read the session ID directly from the `X-Muster-Session-ID` header instead of relying on context:

```go
sessionID := r.Header.Get(api.ClientSessionIDHeader)
```

## Additional Changes

Added logging to help diagnose SSO issues:

- WARN level when token lookup by email fails
- WARN level when token exists but has no ID token
- DEBUG level when ID token is successfully found (to reduce log noise in production)
- DEBUG/INFO level for session init triggering

## Code Review Refactoring

Following code review feedback, the following improvements were made:

- Renamed `hashEmail` to `truncateEmail` for clarity (it truncates, not hashes)
- Changed success path logging from INFO to DEBUG level to reduce log noise in production
- Simplified redundant condition check in `triggerSessionInitIfNeeded`
- Simplified verbose comments for better readability

## Test Plan

- [x] All unit tests pass
- [x] All 152 scenario tests pass
- [x] CI checks pass