### PR TITLE
Feat: Add Homebrew formula support for Muster

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -77,3 +77,5 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Token for pushing to homebrew-muster tap
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -127,5 +127,39 @@ release:
     - glob: ./dist/muster_windows_arm64*/muster.exe
       name_template: muster_windows_arm64.exe
 
+brews:
+  - name: muster
+    repository:
+      owner: giantswarm
+      name: homebrew-muster
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    # URL template for the download
+    url_template: >-
+      https://github.com/giantswarm/muster/releases/download/{{ .Tag }}/
+      {{- .ArtifactName }}
+    # Git author used for commits
+    commit_author:
+      name: giantswarm-bot
+      email: bot@giantswarm.io
+    # Commit message template
+    commit_msg_template: "Update {{ .ProjectName }} to {{ .Tag }}"
+    # Folder inside the repository to put the formula
+    directory: Formula
+    # Homepage URL
+    homepage: "https://github.com/giantswarm/muster"
+    # Description of the project
+    description: "Universal Control Plane for AI Agents - MCP server aggregator"
+    # License
+    license: "Apache-2.0"
+    # Skip upload if this is a prerelease
+    skip_upload: auto
+    # Custom install script
+    install: |
+      bin.install "muster"
+    # Test block
+    test: |
+      system "#{bin}/muster", "version"
+
 # Modelines
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/README.md
+++ b/README.md
@@ -173,7 +173,16 @@ Set up Muster for infrastructure management:
 Configure your development environment:
 > 📖 **[Development Setup](docs/contributing/development-setup.md)**
 
-### Manual Installation
+### Installation
+
+#### Homebrew (macOS)
+
+```bash
+brew tap giantswarm/muster
+brew install muster
+```
+
+#### Manual Installation
 
 ```bash
 git clone https://github.com/giantswarm/muster.git

--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -24,7 +24,29 @@ Muster can be deployed in several configurations depending on your needs:
 
 ## Installation Methods
 
-### Method 1: Binary Installation (Recommended)
+### Method 1: Homebrew (macOS - Recommended)
+
+The easiest way to install Muster on macOS is via Homebrew:
+
+```bash
+# Add the Muster tap
+brew tap giantswarm/muster
+
+# Install Muster
+brew install muster
+```
+
+#### Upgrade
+```bash
+brew upgrade muster
+```
+
+#### Verify Installation
+```bash
+muster version
+```
+
+### Method 2: Binary Installation
 
 #### Download Latest Release
 ```bash
@@ -49,7 +71,7 @@ sudo mv muster /usr/local/bin/
 muster version
 ```
 
-### Method 2: Build from Source
+### Method 3: Build from Source
 
 ```bash
 # Clone repository
@@ -63,7 +85,7 @@ go build -o muster .
 sudo mv muster /usr/local/bin/
 ```
 
-### Method 3: Container Deployment
+### Method 4: Container Deployment
 
 ```bash
 # Run with Docker


### PR DESCRIPTION
## Summary

- Created `giantswarm/homebrew-muster` repository for the Homebrew tap
- Added GoReleaser `brews` configuration for automated formula generation on releases
- Updated auto-release workflow to pass `HOMEBREW_TAP_GITHUB_TOKEN` environment variable
- Added Homebrew installation instructions to documentation

## Changes

### GoReleaser Configuration (`.goreleaser.yaml`)
Added `brews` section that will automatically generate and push the Homebrew formula to `giantswarm/homebrew-muster` on each release.

### Auto-Release Workflow (`.github/workflows/auto-release.yaml`)
Added `HOMEBREW_TAP_GITHUB_TOKEN` environment variable for GoReleaser to push formula updates.

### Documentation Updates
- `docs/operations/installation.md`: Added Homebrew as Method 1 (recommended for macOS)
- `README.md`: Added Homebrew installation in Quick Start section

## Setup Required

To enable automated Homebrew formula updates, a GitHub secret `HOMEBREW_TAP_GITHUB_TOKEN` needs to be created with write access to the `giantswarm/homebrew-muster` repository.

## Credits

This implementation integrates the Homebrew formula concept originally contributed by [@choas](https://github.com/choas) (Lars) in issue #117.

## Test plan

- [x] All unit tests pass
- [x] All 152 scenario tests pass
- [ ] Verify `HOMEBREW_TAP_GITHUB_TOKEN` secret is configured in repository settings
- [ ] After merge, verify formula is pushed to homebrew-muster on next release

Closes #117