### PR TITLE
Fix: Add idempotency check to Auto Release workflow

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -23,28 +23,35 @@ jobs:
           # Fetch all history and tags for version calculation and changelog
           fetch-depth: 0
 
+      # yamllint disable rule:line-length
       - name: Check if commit already tagged
         id: check_tag
         run: |
-          # Check if HEAD already has a version tag (prevents duplicate releases on re-run)
-          EXISTING_TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          # Check if HEAD already has a version tag
+          # This prevents duplicate releases on workflow re-run
+          EXISTING_TAG=$(git tag --points-at HEAD \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
           if [[ -n "$EXISTING_TAG" ]]; then
             echo "Commit already has version tag: $EXISTING_TAG"
-            echo "Skipping release to prevent duplicate tags on workflow re-run"
+            echo "Skipping release to prevent duplicate tags"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "existing_tag=$EXISTING_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "No existing version tag found on HEAD, proceeding with release"
+            echo "No existing version tag found, proceeding"
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Report skipped release
         if: steps.check_tag.outputs.skip == 'true'
         run: |
-          echo "::notice::Release skipped - commit already tagged as ${{ steps.check_tag.outputs.existing_tag }}"
+          TAG="${{ steps.check_tag.outputs.existing_tag }}"
+          echo "::notice::Release skipped - already tagged as $TAG"
           echo "## Release Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "This commit already has version tag \`${{ steps.check_tag.outputs.existing_tag }}\`." >> $GITHUB_STEP_SUMMARY
-          echo "Re-running the workflow on an already-tagged commit is safe and will not create duplicate releases." >> $GITHUB_STEP_SUMMARY
+          echo "Commit already has version tag \`$TAG\`." \
+            >> $GITHUB_STEP_SUMMARY
+          echo "Re-running on an already-tagged commit is safe." \
+            >> $GITHUB_STEP_SUMMARY
+      # yamllint enable rule:line-length
 
       - name: Set up Go
         if: steps.check_tag.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Add idempotency check to the Auto Release workflow to prevent duplicate version tags when the workflow is re-run after a partial failure.

### Changes

- Add "Check if commit already tagged" step that detects existing version tags on HEAD
- Add "Report skipped release" step that writes a job summary when release is skipped
- Skip all release steps if HEAD already has a version tag (`v*.*.*` pattern)
- Prevents the race condition that caused v0.0.153 and v0.0.154 to point to the same commit

## Root Cause Analysis

The Auto Release workflow was not idempotent. When PR #252 (Homebrew formula) was merged:

1. **Attempt 1**: Created tag v0.0.153 on commit 8ce2059, published release, then failed at Homebrew formula step (401 Bad credentials)
2. **Attempt 2** (re-run): Found v0.0.153, calculated v0.0.154, created tag v0.0.154 on the SAME commit 8ce2059

This resulted in:
- v0.0.153 → 8ce2059 (correct)
- v0.0.154 → 8ce2059 (WRONG - should be 8471d9d from PR #253)

CircleCI then failed with "HEAD ref has multiple tags [v0.0.153 v0.0.154]".

## Fix Applied

1. **Immediate**: Deleted incorrect v0.0.154 tag and recreated on correct commit 8471d9d
2. **Prevention**: Added idempotency check that skips release if HEAD already has a version tag
3. **Visibility**: Added job summary explaining why the release was skipped

## Test plan

- [x] Verify v0.0.154 now points to correct commit (8471d9d)
- [x] YAML lint passes
- [ ] CI checks pass
- [ ] Future re-runs of failed releases will skip tag creation if tag already exists

Closes #256