### PR TITLE
Fix: Address GoReleaser deprecation warnings

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: --version  # Print version for verification
 
       - name: Configure Git
@@ -109,7 +109,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           install-only: true
 
       - name: Run Release Dry-Run

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -127,7 +127,7 @@ release:
     - glob: ./dist/muster_windows_arm64*/muster.exe
       name_template: muster_windows_arm64.exe
 
-brews:
+homebrew:
   - name: muster
     repository:
       owner: giantswarm


### PR DESCRIPTION
## Summary

- Rename `brews` to `homebrew` in `.goreleaser.yaml` to fix deprecation warning
- Pin GoReleaser version to `~> v2` instead of `latest` in CI and auto-release workflows

## Context

The auto-release workflow was showing these warnings:
- `brews is being phased out in favor of homebrew_casks`
- `You are using 'latest' as default version. Will lock to '~> v2'`

Using `~> v2` locks to the v2 major version while still receiving patch/minor updates.

## Files Changed

- `.goreleaser.yaml`: `brews` → `homebrew`
- `.github/workflows/auto-release.yaml`: `version: latest` → `version: "~> v2"` (2 places)
- `.github/workflows/ci.yaml`: `version: latest` → `version: "~> v2"`

## Test plan

- [ ] CI passes
- [ ] GoReleaser dry-run succeeds without deprecation warnings