### PR TITLE
Fix: Use PAT for checkout to allow pushing tags with workflow changes

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -22,6 +22,9 @@ jobs:
         with:
           # Fetch all history and tags for version calculation and changelog
           fetch-depth: 0
+          # Use PAT to allow pushing tags for commits with workflow changes
+          # GITHUB_TOKEN cannot push tags that modify .github/workflows/
+          token: ${{ secrets.RELEASE_PAT }}
 
       # yamllint disable rule:line-length
       - name: Check if commit already tagged


### PR DESCRIPTION
## Summary

Use a Personal Access Token (PAT) for the checkout step in the auto-release workflow to allow pushing tags when commits include workflow file changes.

## Problem

The `GITHUB_TOKEN` cannot push tags when the tagged commit includes changes to `.github/workflows/` files. This causes the error:

```
refusing to allow a GitHub App to create or update workflow without workflows permission
```

This happened when PR #257 (which modified `auto-release.yaml`) was merged - the auto-release workflow failed at the "Create Tag" step.

## Solution

Use a PAT with `repo` and `workflow` scopes for the `actions/checkout` step. This configures Git to use the PAT for subsequent push operations, allowing tag pushes to succeed for all commits.

## Required Action

**Before merging this PR**, create a repository secret:

| Secret Name | Required Scopes | Description |
|-------------|-----------------|-------------|
| `RELEASE_PAT` | `repo`, `workflow` | PAT for pushing tags in auto-release |

You can create a fine-grained PAT scoped only to this repository, or a classic PAT with the above scopes.

## Test plan

- [ ] CI passes
- [ ] Create `RELEASE_PAT` secret
- [ ] After merge, verify auto-release workflow succeeds