### PR TITLE
Fix: Revert homebrew to brews in goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -127,7 +127,7 @@ release:
     - glob: ./dist/muster_windows_arm64*/muster.exe
       name_template: muster_windows_arm64.exe
 
-homebrew:
+brews:
   - name: muster
     repository:
       owner: giantswarm


### PR DESCRIPTION
## Summary

Revert the `homebrew` field back to `brews` in `.goreleaser.yaml`.

## Problem

PR #258 incorrectly changed `brews` to `homebrew`, but `homebrew` is not a valid field in goreleaser v2. This caused the auto-release to fail with:

```
line 130: field homebrew not found in type config.Project
```

## Solution

Revert to `brews` which is still valid (though deprecated). The valid options are:
- `brews` - for CLI tool formulas (deprecated but works)
- `homebrew_casks` - for macOS GUI app Casks (new format)

Since muster is a CLI tool, `brews` is the correct choice. A future PR can migrate to `homebrew_casks` if needed, but that requires more configuration changes.

## Test plan

- [ ] CI passes
- [ ] Auto-release succeeds after merge