### PR TITLE
fix(crd): regenerate MCPServer CRD with missing status fields

### DIFF
--- a/deploy/crds/muster.giantswarm.io_mcpservers.yaml
+++ b/deploy/crds/muster.giantswarm.io_mcpservers.yaml
@@ -67,6 +67,47 @@ spec:
                 items:
                   type: string
                 type: array
+              auth:
+                description: |-
+                  Auth configures authentication behavior for this MCP server.
+                  This is only relevant for remote servers (streamable-http or sse).
+                properties:
+                  fallbackToOwnAuth:
+                    default: true
+                    description: |-
+                      FallbackToOwnAuth enables fallback to server-specific OAuth flow.
+                      When true and token forwarding fails (e.g., 401 response despite forwarded token),
+                      muster will trigger a separate OAuth flow for this server.
+                      When false, token forwarding failures result in an error.
+                    type: boolean
+                  forwardToken:
+                    default: false
+                    description: |-
+                      ForwardToken enables ID token forwarding for SSO.
+                      When true, muster forwards the user's ID token to this server instead of
+                      triggering a separate OAuth flow. The downstream server must be configured
+                      to trust muster's client ID in its TrustedAudiences.
+                    type: boolean
+                  sso:
+                    default: true
+                    description: |-
+                      SSO controls Single Sign-On token reuse for this server.
+                      When true (default), tokens from other servers using the same OAuth issuer
+                      can be reused to authenticate to this server without re-authenticating.
+                      When false, this server always requires its own authentication flow,
+                      even if a token exists for the same issuer. Use this when you want to
+                      use different accounts for servers that share the same OAuth provider.
+                    type: boolean
+                  type:
+                    default: none
+                    description: |-
+                      Type specifies the authentication type.
+                      Supported values: "oauth" for OAuth 2.0/OIDC authentication, "none" for no authentication
+                    enum:
+                    - oauth
+                    - none
+                    type: string
+                type: object
               autoStart:
                 default: false
                 description: |-
@@ -97,36 +138,6 @@ spec:
                 description: |-
                   Headers contains HTTP headers to send with requests to remote MCP servers.
                   This field is only relevant when Type is "streamable-http" or "sse".
-                type: object
-              auth:
-                description: |-
-                  Auth defines authentication configuration for this MCP server.
-                  This enables OAuth-based authentication and SSO token forwarding.
-                properties:
-                  type:
-                    description: |-
-                      Type specifies the authentication type.
-                      Supported values: "oauth", "none"
-                    enum:
-                    - oauth
-                    - none
-                    type: string
-                  forwardToken:
-                    default: false
-                    description: |-
-                      ForwardToken determines whether the user's ID token from muster's session
-                      should be forwarded to the downstream MCP server.
-                      When true, muster will inject the ID token as an Authorization: Bearer header.
-                      This enables Single Sign-On (SSO) to downstream services that trust muster's ID tokens.
-                    type: boolean
-                  fallbackToOwnAuth:
-                    default: true
-                    description: |-
-                      FallbackToOwnAuth determines whether to trigger a separate OAuth flow for this
-                      downstream server if token forwarding fails (e.g., 401 Unauthorized).
-                      When true, if the forwarded token is rejected, muster will attempt to
-                      authenticate directly to this server.
-                    type: boolean
                 type: object
               timeout:
                 default: 30
@@ -222,6 +233,12 @@ spec:
                   - type
                   type: object
                 type: array
+              consecutiveFailures:
+                description: |-
+                  ConsecutiveFailures tracks the number of consecutive connection failures.
+                  This is used for exponential backoff and to identify unreachable servers.
+                  Reset to 0 when a connection succeeds.
+                type: integer
               health:
                 description: Health represents the health status of the MCP server
                 enum:
@@ -229,6 +246,12 @@ spec:
                 - healthy
                 - unhealthy
                 - checking
+                type: string
+              lastAttempt:
+                description: |-
+                  LastAttempt indicates when the last connection attempt was made.
+                  Used with ConsecutiveFailures to implement exponential backoff.
+                format: date-time
                 type: string
               lastConnected:
                 description: LastConnected indicates when the server was last successfully
@@ -238,6 +261,12 @@ spec:
               lastError:
                 description: LastError contains any error message from the most recent
                   server operation
+                type: string
+              nextRetryAfter:
+                description: |-
+                  NextRetryAfter indicates the earliest time when the next retry should be attempted.
+                  This is calculated based on exponential backoff from ConsecutiveFailures.
+                format: date-time
                 type: string
               restartCount:
                 description: RestartCount tracks how many times this server has been
@@ -253,6 +282,9 @@ spec:
                 - stopping
                 - stopped
                 - failed
+                - waiting
+                - retrying
+                - unreachable
                 type: string
             type: object
         type: object

--- a/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
+++ b/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
@@ -67,6 +67,47 @@ spec:
                 items:
                   type: string
                 type: array
+              auth:
+                description: |-
+                  Auth configures authentication behavior for this MCP server.
+                  This is only relevant for remote servers (streamable-http or sse).
+                properties:
+                  fallbackToOwnAuth:
+                    default: true
+                    description: |-
+                      FallbackToOwnAuth enables fallback to server-specific OAuth flow.
+                      When true and token forwarding fails (e.g., 401 response despite forwarded token),
+                      muster will trigger a separate OAuth flow for this server.
+                      When false, token forwarding failures result in an error.
+                    type: boolean
+                  forwardToken:
+                    default: false
+                    description: |-
+                      ForwardToken enables ID token forwarding for SSO.
+                      When true, muster forwards the user's ID token to this server instead of
+                      triggering a separate OAuth flow. The downstream server must be configured
+                      to trust muster's client ID in its TrustedAudiences.
+                    type: boolean
+                  sso:
+                    default: true
+                    description: |-
+                      SSO controls Single Sign-On token reuse for this server.
+                      When true (default), tokens from other servers using the same OAuth issuer
+                      can be reused to authenticate to this server without re-authenticating.
+                      When false, this server always requires its own authentication flow,
+                      even if a token exists for the same issuer. Use this when you want to
+                      use different accounts for servers that share the same OAuth provider.
+                    type: boolean
+                  type:
+                    default: none
+                    description: |-
+                      Type specifies the authentication type.
+                      Supported values: "oauth" for OAuth 2.0/OIDC authentication, "none" for no authentication
+                    enum:
+                    - oauth
+                    - none
+                    type: string
+                type: object
               autoStart:
                 default: false
                 description: |-
@@ -97,36 +138,6 @@ spec:
                 description: |-
                   Headers contains HTTP headers to send with requests to remote MCP servers.
                   This field is only relevant when Type is "streamable-http" or "sse".
-                type: object
-              auth:
-                description: |-
-                  Auth defines authentication configuration for this MCP server.
-                  This enables OAuth-based authentication and SSO token forwarding.
-                properties:
-                  type:
-                    description: |-
-                      Type specifies the authentication type.
-                      Supported values: "oauth", "none"
-                    enum:
-                    - oauth
-                    - none
-                    type: string
-                  forwardToken:
-                    default: false
-                    description: |-
-                      ForwardToken determines whether the user's ID token from muster's session
-                      should be forwarded to the downstream MCP server.
-                      When true, muster will inject the ID token as an Authorization: Bearer header.
-                      This enables Single Sign-On (SSO) to downstream services that trust muster's ID tokens.
-                    type: boolean
-                  fallbackToOwnAuth:
-                    default: true
-                    description: |-
-                      FallbackToOwnAuth determines whether to trigger a separate OAuth flow for this
-                      downstream server if token forwarding fails (e.g., 401 Unauthorized).
-                      When true, if the forwarded token is rejected, muster will attempt to
-                      authenticate directly to this server.
-                    type: boolean
                 type: object
               timeout:
                 default: 30
@@ -222,6 +233,12 @@ spec:
                   - type
                   type: object
                 type: array
+              consecutiveFailures:
+                description: |-
+                  ConsecutiveFailures tracks the number of consecutive connection failures.
+                  This is used for exponential backoff and to identify unreachable servers.
+                  Reset to 0 when a connection succeeds.
+                type: integer
               health:
                 description: Health represents the health status of the MCP server
                 enum:
@@ -229,6 +246,12 @@ spec:
                 - healthy
                 - unhealthy
                 - checking
+                type: string
+              lastAttempt:
+                description: |-
+                  LastAttempt indicates when the last connection attempt was made.
+                  Used with ConsecutiveFailures to implement exponential backoff.
+                format: date-time
                 type: string
               lastConnected:
                 description: LastConnected indicates when the server was last successfully
@@ -238,6 +261,12 @@ spec:
               lastError:
                 description: LastError contains any error message from the most recent
                   server operation
+                type: string
+              nextRetryAfter:
+                description: |-
+                  NextRetryAfter indicates the earliest time when the next retry should be attempted.
+                  This is calculated based on exponential backoff from ConsecutiveFailures.
+                format: date-time
                 type: string
               restartCount:
                 description: RestartCount tracks how many times this server has been
@@ -253,6 +282,9 @@ spec:
                 - stopping
                 - stopped
                 - failed
+                - waiting
+                - retrying
+                - unreachable
                 type: string
             type: object
         type: object


### PR DESCRIPTION
## Summary

- Regenerate MCPServer CRD from Go types using controller-gen
- Add missing status fields: `consecutiveFailures`, `lastAttempt`, `nextRetryAfter`

## Problem

The MCPServerStatus Go struct had three fields that were added but never regenerated into the CRD schema. This caused muster to log warnings like:

```
msg="unknown field \"status.consecutiveFailures\""
msg="unknown field \"status.lastAttempt\""
msg="unknown field \"status.nextRetryAfter\""
msg="Status sync failure for MCPServer/grizzly-mcp-kubernetes: update_status_failed (failures: 255)"
```

## Solution

Run `controller-gen crd paths="./pkg/apis/..." output:crd:artifacts:config=deploy/crds` to regenerate the CRD from the Go types, then copy to helm chart.

## Test plan

- [ ] Deploy new muster version to a cluster
- [ ] Verify status fields are now accepted without "unknown field" warnings