### PR TITLE
Fix: Suppress MCP notification debug output from CLI

### DIFF
--- a/internal/cli/executor.go
+++ b/internal/cli/executor.go
@@ -240,9 +240,12 @@ func NewToolExecutor(options ExecutorOptions) (*ToolExecutor, error) {
 
 	client := agent.NewClient(endpoint, logger, transport)
 
+	// Handle MCP notifications silently unless debug mode is enabled
 	go func() {
 		for notification := range client.NotificationChan {
-			fmt.Println(notification)
+			if options.Debug {
+				logger.Debug("MCP Notification: %s", notification.Method)
+			}
 		}
 	}()
 

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -12,6 +12,7 @@ import (
 	"muster/internal/client"
 	"muster/internal/events"
 	musterv1alpha1 "muster/pkg/apis/muster/v1alpha1"
+	"muster/pkg/logging"
 )
 
 // Adapter provides MCP server management functionality using the unified client
@@ -64,7 +65,7 @@ func (a *Adapter) ListMCPServers() []api.MCPServerInfo {
 	servers, err := a.client.ListMCPServers(ctx, a.namespace)
 	if err != nil {
 		// Log error and return empty list
-		fmt.Printf("Warning: Failed to list MCPServers: %v\n", err)
+		logging.Warn("MCPServer", "Failed to list MCPServers: %v", err)
 		return []api.MCPServerInfo{}
 	}
 
@@ -704,8 +705,8 @@ func (a *Adapter) generateCRDEvent(name string, reason events.EventReason, data 
 	err := eventManager.CreateEvent(context.Background(), objectRef, string(reason), "", string(events.EventTypeNormal))
 	if err != nil {
 		// Log error but don't fail the operation
-		fmt.Printf("Debug: Failed to generate event %s for MCPServer %s: %v\n", string(reason), name, err)
+		logging.Debug("MCPServer", "Failed to generate event %s for MCPServer %s: %v", string(reason), name, err)
 	} else {
-		fmt.Printf("Debug: Generated event %s for MCPServer %s\n", string(reason), name)
+		logging.Debug("MCPServer", "Generated event %s for MCPServer %s", string(reason), name)
 	}
 }


### PR DESCRIPTION
## Summary

MCP protocol notifications like `notifications/tools/list_changed` were being printed to stdout during normal CLI operations, causing noise like:

```
⠋ Executing command...{2.0 {notifications/tools/list_changed {map[] map[]}}}
NAME                      HEALTH      STATE       SERVICE_TYPE
gazelle-mcp-kubernetes    healthy     Connected   MCPServer
...
```

## Changes

- Only log MCP notifications in debug mode via the agent logger
- Replace `fmt.Printf` debug statements with proper `logging.Debug`/`logging.Warn` calls in the mcpserver adapter

## Test Plan

- [x] All unit tests pass (`make test`)
- [x] Manual testing: `muster list services` no longer shows notification debug output
- [x] Debug mode still logs notifications when enabled