### PR TITLE
Test: Add BDD scenarios for multi-server OAuth flow isolation (#269)

### DIFF
--- a/internal/testing/scenarios/oauth-authorization-code-reuse.yaml
+++ b/internal/testing/scenarios/oauth-authorization-code-reuse.yaml
@@ -1,0 +1,202 @@
+name: "oauth-authorization-code-reuse"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  Test scenario for issue #269: OAuth authorization code reuse detection.
+  
+  This scenario tests the multi-MCPServer OAuth flow where servers have
+  different SSO configurations that can cause authorization code issues when:
+  1. One server uses token forwarding (forwardToken=true)
+  2. Another server uses a different IdP requiring fallback OAuth
+  3. Fallback triggers a separate OAuth flow
+  
+  The test verifies that:
+  - Token forwarding works for servers sharing muster's IdP
+  - Fallback OAuth works for servers with different IdPs
+  - Both servers remain connected (no token revocation)
+
+tags: ["oauth", "authentication", "security", "issue-269", "mcpserver", "sso", "token-forwarding", "token-exchange", "fallback"]
+timeout: "2m"
+
+pre_configuration:
+  mock_oauth_servers:
+    # Shared Dex-like OAuth server for muster and the forwarding server
+    - name: "muster-dex"
+      scopes: ["openid", "profile", "email", "groups", "mcp:admin"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      client_id: "muster-dex-client"
+      client_secret: "muster-dex-secret"
+      use_as_muster_oauth_server: true
+
+    # Remote cluster's IdP for the fallback server
+    # This is a different IdP, so token forwarding from muster won't work
+    - name: "remote-idp"
+      scopes: ["openid", "profile", "email", "mcp:admin"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      client_id: "remote-client"
+
+  mcp_servers:
+    # Server A: Uses token forwarding (same IdP as muster)
+    - name: "forwarding-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "muster-dex"
+          scope: "mcp:admin"
+          forward_token: true
+          fallback_to_own_auth: true
+        tools:
+          - name: "forwarding_op"
+            description: "Operation on server with token forwarding"
+            responses:
+              - response:
+                  server: "forwarding-server"
+                  auth_method: "token-forwarding"
+
+    # Server B: Uses different IdP with fallback
+    # Token forwarding won't work because it uses a different IdP
+    - name: "fallback-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "remote-idp"
+          scope: "mcp:admin"
+          forward_token: true
+          fallback_to_own_auth: true
+        tools:
+          - name: "fallback_op"
+            description: "Operation on server requiring fallback"
+            responses:
+              - response:
+                  server: "fallback-server"
+                  auth_method: "fallback-oauth"
+
+steps:
+  # Step 1: Verify OAuth servers are running
+  - id: verify-muster-dex
+    description: "Verify the muster Dex OAuth server is running"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "muster-dex"
+    expected:
+      success: true
+      contains:
+        - "muster-dex"
+
+  - id: verify-remote-idp
+    description: "Verify the remote IdP is running"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "remote-idp"
+    expected:
+      success: true
+      contains:
+        - "remote-idp"
+
+  # Step 2: Verify MCP servers are registered
+  - id: verify-servers-registered
+    description: "Verify all MCP servers are registered"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "forwarding-server"
+        - "fallback-server"
+
+  # Step 3: Authenticate to forwarding-server (establishes ID token from muster-dex)
+  - id: authenticate-forwarding
+    description: "Authenticate to forwarding-server via muster-dex"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "forwarding-server"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  # Step 4: Connect to forwarding-server (token forwarding should work)
+  - id: connect-forwarding-server
+    description: "Connect to forwarding-server - token forwarding should succeed"
+    tool: "core_auth_login"
+    args:
+      server: "forwarding-server"
+    expected:
+      success: true
+
+  # Step 5: Verify forwarding-server works
+  - id: call-forwarding-tool
+    description: "Call tool on forwarding-server"
+    tool: "x_forwarding-server_forwarding_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "forwarding-server"
+
+  # Step 6: Try to connect to fallback-server
+  # Token forwarding will fail (different IdP), should trigger fallback
+  - id: connect-fallback-attempt
+    description: "Attempt to connect to fallback-server (will trigger fallback)"
+    tool: "core_auth_login"
+    args:
+      server: "fallback-server"
+    expected:
+      success: true
+
+  # Step 7: Complete the fallback OAuth flow
+  - id: authenticate-fallback
+    description: "Complete fallback OAuth flow for fallback-server"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "fallback-server"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  # Step 8: Login after fallback auth
+  - id: login-after-fallback
+    description: "Login after fallback authentication"
+    tool: "core_auth_login"
+    args:
+      server: "fallback-server"
+    expected:
+      success: true
+
+  # Step 9: Verify fallback-server works
+  - id: call-fallback-tool
+    description: "Call tool on fallback-server (authenticated via fallback)"
+    tool: "x_fallback-server_fallback_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "fallback-server"
+
+  # Step 10: Verify forwarding-server still works (no token revocation)
+  - id: verify-forwarding-still-works
+    description: "Verify forwarding-server still works (no token revocation occurred)"
+    tool: "x_forwarding-server_forwarding_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "forwarding-server"
+
+  # Step 11: Check auth status
+  - id: verify-final-auth-status
+    description: "Verify final auth status shows both servers connected"
+    tool: "test_read_auth_status"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "forwarding-server"
+        - "fallback-server"

--- a/internal/testing/scenarios/oauth-concurrent-code-exchange-multi-user.yaml
+++ b/internal/testing/scenarios/oauth-concurrent-code-exchange-multi-user.yaml
@@ -1,0 +1,269 @@
+name: "oauth-concurrent-code-exchange-multi-user"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  Test scenario for issue #269: Multi-server OAuth flow isolation.
+  
+  This scenario tests what happens when a user rapidly authenticates to
+  multiple MCPServers that require fallback OAuth flows. The key test is
+  whether OAuth flows for different servers can interfere with each other.
+  
+  Test conditions:
+  1. Multiple MCPServers are configured with different auth strategies
+  2. Some use token forwarding (works with muster's ID token)
+  3. Some use different IdPs requiring fallback OAuth
+  4. Multiple fallback flows are started in quick succession
+  
+  This test verifies:
+  1. OAuth flows for multiple servers complete correctly
+  2. Each server receives the correct token from its IdP
+  3. No cross-contamination of tokens/auth state between servers
+
+tags: ["oauth", "authentication", "security", "issue-269", "multi-server", "session-isolation", "mcpserver"]
+timeout: "2m"
+
+pre_configuration:
+  mock_oauth_servers:
+    # Muster's upstream Dex
+    - name: "muster-dex"
+      scopes: ["openid", "profile", "email", "groups", "mcp:admin"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      client_id: "muster-client"
+      client_secret: "muster-secret"
+      use_as_muster_oauth_server: true
+
+    # IdP for server-alpha (different from muster's Dex)
+    - name: "alpha-idp"
+      scopes: ["openid", "profile", "email", "mcp:admin"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      client_id: "alpha-client"
+
+    # IdP for server-beta (different from muster's Dex)
+    - name: "beta-idp"
+      scopes: ["openid", "profile", "email", "mcp:admin"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      client_id: "beta-client"
+
+  mcp_servers:
+    # Server using muster's Dex (token forwarding works)
+    - name: "server-muster"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "muster-dex"
+          scope: "mcp:admin"
+          forward_token: true
+          fallback_to_own_auth: true
+        tools:
+          - name: "muster_op"
+            description: "Operation on muster-dex server"
+            responses:
+              - response:
+                  server: "server-muster"
+                  idp: "muster-dex"
+
+    # Server requiring fallback to alpha-idp
+    - name: "server-alpha"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "alpha-idp"
+          scope: "mcp:admin"
+          forward_token: true
+          fallback_to_own_auth: true
+        tools:
+          - name: "alpha_op"
+            description: "Operation on alpha server"
+            responses:
+              - response:
+                  server: "server-alpha"
+                  idp: "alpha-idp"
+
+    # Server requiring fallback to beta-idp
+    - name: "server-beta"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "beta-idp"
+          scope: "mcp:admin"
+          forward_token: true
+          fallback_to_own_auth: true
+        tools:
+          - name: "beta_op"
+            description: "Operation on beta server"
+            responses:
+              - response:
+                  server: "server-beta"
+                  idp: "beta-idp"
+
+steps:
+  # Verify OAuth servers
+  - id: verify-muster-dex
+    description: "Verify muster-dex is running"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "muster-dex"
+    expected:
+      success: true
+      contains:
+        - "muster-dex"
+
+  - id: verify-alpha-idp
+    description: "Verify alpha-idp is running"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "alpha-idp"
+    expected:
+      success: true
+      contains:
+        - "alpha-idp"
+
+  - id: verify-beta-idp
+    description: "Verify beta-idp is running"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "beta-idp"
+    expected:
+      success: true
+      contains:
+        - "beta-idp"
+
+  # Verify servers are registered
+  - id: verify-servers
+    description: "Verify all servers are registered"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "server-muster"
+        - "server-alpha"
+        - "server-beta"
+
+  # Step 1: Authenticate to server-muster (establishes ID token)
+  - id: auth-muster
+    description: "Authenticate to server-muster via muster-dex"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "server-muster"
+    expected:
+      success: true
+
+  - id: connect-muster
+    description: "Connect to server-muster (token forwarding)"
+    tool: "core_auth_login"
+    args:
+      server: "server-muster"
+    expected:
+      success: true
+
+  # Step 2: Start OAuth flow for server-alpha (triggers fallback)
+  - id: trigger-alpha-fallback
+    description: "Trigger fallback OAuth for server-alpha"
+    tool: "core_auth_login"
+    args:
+      server: "server-alpha"
+    expected:
+      success: true
+
+  # Step 3: Start OAuth flow for server-beta (triggers fallback)
+  # At this point, there are TWO pending OAuth flows
+  - id: trigger-beta-fallback
+    description: "Trigger fallback OAuth for server-beta"
+    tool: "core_auth_login"
+    args:
+      server: "server-beta"
+    expected:
+      success: true
+
+  # Step 4: Complete OAuth for server-alpha
+  - id: complete-alpha-auth
+    description: "Complete OAuth callback for server-alpha"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "server-alpha"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  # Step 5: Complete OAuth for server-beta
+  - id: complete-beta-auth
+    description: "Complete OAuth callback for server-beta"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "server-beta"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  # Step 6: Login to both servers after auth
+  - id: login-alpha
+    description: "Login to server-alpha after OAuth"
+    tool: "core_auth_login"
+    args:
+      server: "server-alpha"
+    expected:
+      success: true
+
+  - id: login-beta
+    description: "Login to server-beta after OAuth"
+    tool: "core_auth_login"
+    args:
+      server: "server-beta"
+    expected:
+      success: true
+
+  # Step 7: Verify each server responds with correct identity
+  - id: call-muster-op
+    description: "Call tool on server-muster"
+    tool: "x_server-muster_muster_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "server-muster"
+        - "muster-dex"
+
+  - id: call-alpha-op
+    description: "Call tool on server-alpha"
+    tool: "x_server-alpha_alpha_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "server-alpha"
+        - "alpha-idp"
+
+  - id: call-beta-op
+    description: "Call tool on server-beta"
+    tool: "x_server-beta_beta_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "server-beta"
+        - "beta-idp"
+
+  # Step 8: Verify auth status shows all servers connected
+  - id: verify-auth-status
+    description: "Verify all servers are connected with correct status"
+    tool: "test_read_auth_status"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "server-muster"
+        - "server-alpha"
+        - "server-beta"
+        - "connected"


### PR DESCRIPTION
## Summary

- Add BDD test scenarios to verify OAuth flow isolation when multiple MCPServers have different SSO configurations
- Tests cover token forwarding and fallback OAuth flows across multiple servers
- Scenarios verify no cross-contamination of tokens/auth state between servers

## Test Scenarios

### `oauth-authorization-code-reuse`
Tests two servers with different IdPs:
- One server using token forwarding (same IdP as muster)
- Another server using a different IdP requiring fallback OAuth
- Verifies both servers can be authenticated without token revocation

### `oauth-concurrent-code-exchange-multi-user`
Tests three servers with multiple fallback OAuth flows:
- Starts multiple OAuth flows in quick succession
- Verifies each flow completes with the correct server
- Confirms no cross-contamination of tokens/auth state

## Notes

These scenarios currently **pass**, demonstrating correct behavior for the tested conditions. Further investigation is needed to identify and reproduce the specific conditions that trigger the authorization code reuse issue described in #269.

## Test plan

- [x] Both new scenarios pass
- [x] Existing OAuth scenarios still pass
- [x] `make test` passes

Related to #269
