### PR TITLE
chore(deps): Update mcp-oauth to v0.2.48

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/giantswarm/mcp-oauth v0.2.47
+	github.com/giantswarm/mcp-oauth v0.2.48
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.47 h1:kkusXMCSgZCrlXxT4SWysPqE0LZjgB4JbjLvM6Jgt6w=
-github.com/giantswarm/mcp-oauth v0.2.47/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
+github.com/giantswarm/mcp-oauth v0.2.48 h1:YQaSp4fcceAIDsVws4YLUJBLUYKkPtnZss/al+lpUU8=
+github.com/giantswarm/mcp-oauth v0.2.48/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

Updates mcp-oauth to v0.2.48 which includes the fix for forwarding `id_token` from upstream OIDC providers in token responses.

## Problem

The token endpoint in mcp-oauth was not forwarding the `id_token` from upstream providers (e.g., Dex) to clients. This caused the muster CLI to store tokens without the `id_token`, which broke silent re-authentication flows (`prompt=none`) because:

- `login_hint` couldn't be extracted (no email in stored token)
- `id_token_hint` couldn't be provided (no id_token to forward)

As a result, users always saw the account selection screen when re-authenticating, even with `prompt=none`.

## Fix

mcp-oauth v0.2.48 includes [PR #190](https://github.com/giantswarm/mcp-oauth/pull/190) which:

- Extracts `id_token` from `authCode.ProviderToken.Extra("id_token")` during code exchange
- Forwards `id_token` in refresh token responses
- Includes `id_token` in the JSON token response via `writeTokenResponse()`

Muster already correctly handles the `id_token` in `token_store.go` by extracting it from `token.Extra("id_token")`, so no changes are needed in muster beyond updating the dependency.

## Test Plan

- [x] All unit tests pass (`make test`)
- [x] Verified muster's `token_store.go` correctly extracts `id_token` from token response

## Related

- Fixes the remaining issue from #294 (silent re-authentication)
- giantswarm/mcp-oauth#189 - Issue tracking the bug
- giantswarm/mcp-oauth#190 - PR with the fix