### PR TITLE
Update module github.com/giantswarm/mcp-oauth to v0.2.51

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/giantswarm/mcp-oauth v0.2.50
+	github.com/giantswarm/mcp-oauth v0.2.51
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.50 h1:NYUPfBaWTGqOf9GIXqyfmGULEzOBtY+SNirQArrMgFk=
-github.com/giantswarm/mcp-oauth v0.2.50/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
+github.com/giantswarm/mcp-oauth v0.2.51 h1:D1rJVrjZFHqJpLdVbWotUBd2LFe0cv0lSzHtTPc9gYw=
+github.com/giantswarm/mcp-oauth v0.2.51/go.mod h1:RDeLA6LGjKcGRQrRuvgFTeMNT98eRM4/1rPtbhnVojE=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

- Updates `github.com/giantswarm/mcp-oauth` from v0.2.50 to v0.2.51

## Test plan

- [x] Local tests pass
- [ ] CI checks pass