### PR TITLE
Fix: Preserve ID token during OAuth token refresh

### DIFF
--- a/internal/cli/auth_adapter.go
+++ b/internal/cli/auth_adapter.go
@@ -727,6 +727,12 @@ func (a *AuthAdapter) doTokenRefresh(ctx context.Context, store *oauth.TokenStor
 		return fmt.Errorf("token refresh failed: %w", err)
 	}
 
+	// Preserve ID token if not returned (refresh responses typically don't include ID tokens)
+	// The ID token is needed for SSO forwarding to downstream MCP servers
+	if newToken.IDToken == "" && storedToken.IDToken != "" {
+		newToken.IDToken = storedToken.IDToken
+	}
+
 	// Convert to oauth2.Token for storage
 	oauth2Token := newToken.ToOAuth2Token()
 

--- a/internal/cli/auth_adapter_test.go
+++ b/internal/cli/auth_adapter_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -425,4 +426,224 @@ func TestAuthAdapter_SetNoSilentRefresh(t *testing.T) {
 	if adapter.noSilentRefresh {
 		t.Error("expected noSilentRefresh to be false after unsetting")
 	}
+}
+
+func TestDoTokenRefresh_PreservesIDToken(t *testing.T) {
+	// This test verifies that when a refresh response doesn't include an ID token,
+	// the original ID token is preserved for SSO forwarding purposes.
+
+	t.Run("preserves ID token when refresh response omits it", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create a mock OAuth server
+		var tokenEndpointCalls int
+		var serverURL string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-authorization-server":
+				// Return OAuth metadata with the actual server URL
+				metadata := map[string]interface{}{
+					"issuer":                 serverURL,
+					"token_endpoint":         serverURL + "/oauth/token",
+					"authorization_endpoint": serverURL + "/oauth/authorize",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(metadata)
+
+			case "/oauth/token":
+				tokenEndpointCalls++
+				// Return a refresh response WITHOUT an ID token
+				// (per OAuth 2.0 spec, refresh responses typically don't include ID tokens)
+				response := map[string]interface{}{
+					"access_token":  "new-access-token-12345",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+					"refresh_token": "new-refresh-token-67890",
+					// Note: no id_token in response
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+		serverURL = server.URL
+
+		// Create token store
+		store, err := oauth.NewTokenStore(oauth.TokenStoreConfig{
+			StorageDir: tmpDir,
+			FileMode:   true,
+		})
+		if err != nil {
+			t.Fatalf("failed to create token store: %v", err)
+		}
+
+		// Store a token WITH an ID token
+		originalIDToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIiwiZW1haWwiOiJ1c2VyQGV4YW1wbGUuY29tIiwiZXhwIjoxNzA5MjQ1MjAwfQ.signature"
+		normalizedEndpoint := "https://muster.example.com"
+
+		// Create a stored token with an ID token
+		storedToken := &oauth.StoredToken{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			TokenType:    "Bearer",
+			IDToken:      originalIDToken,
+			ServerURL:    normalizedEndpoint,
+			IssuerURL:    server.URL,
+		}
+
+		// Store the token using oauth2.Token conversion (simulating how it would be stored)
+		oauth2Token := storedToken.ToOAuth2Token()
+		if err := store.StoreToken(normalizedEndpoint, server.URL, oauth2Token); err != nil {
+			t.Fatalf("failed to store token: %v", err)
+		}
+
+		// Verify the stored token has the ID token
+		retrievedBefore := store.GetTokenIncludingExpiring(normalizedEndpoint)
+		if retrievedBefore == nil {
+			t.Fatal("expected to retrieve stored token")
+		}
+		if retrievedBefore.IDToken != originalIDToken {
+			t.Errorf("stored token should have ID token, got: %q", retrievedBefore.IDToken)
+		}
+
+		// Create adapter and perform refresh
+		adapter, err := NewAuthAdapterWithConfig(AuthAdapterConfig{
+			TokenStorageDir: tmpDir,
+		})
+		if err != nil {
+			t.Fatalf("failed to create adapter: %v", err)
+		}
+		defer adapter.Close()
+
+		// Call doTokenRefresh directly
+		ctx := context.Background()
+		err = adapter.doTokenRefresh(ctx, store, retrievedBefore, normalizedEndpoint)
+		if err != nil {
+			t.Fatalf("doTokenRefresh failed: %v", err)
+		}
+
+		// Verify token endpoint was called
+		if tokenEndpointCalls != 1 {
+			t.Errorf("expected 1 token endpoint call, got %d", tokenEndpointCalls)
+		}
+
+		// Retrieve the refreshed token and verify ID token is preserved
+		refreshedToken := store.GetTokenIncludingExpiring(normalizedEndpoint)
+		if refreshedToken == nil {
+			t.Fatal("expected to retrieve refreshed token")
+		}
+
+		// The access token should be updated
+		if refreshedToken.AccessToken != "new-access-token-12345" {
+			t.Errorf("access token should be updated, got: %q", refreshedToken.AccessToken)
+		}
+
+		// The ID token should be preserved (this is what we're testing)
+		if refreshedToken.IDToken != originalIDToken {
+			t.Errorf("ID token should be preserved after refresh.\nExpected: %q\nGot: %q",
+				originalIDToken, refreshedToken.IDToken)
+		}
+
+		// The refresh token should also be updated
+		if refreshedToken.RefreshToken != "new-refresh-token-67890" {
+			t.Errorf("refresh token should be updated, got: %q", refreshedToken.RefreshToken)
+		}
+	})
+
+	t.Run("uses new ID token when refresh response includes one", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		newIDToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIiwiZW1haWwiOiJ1c2VyQGV4YW1wbGUuY29tIiwiZXhwIjoxNzA5MzMxNjAwfQ.newsignature"
+
+		// Create a mock OAuth server that DOES return an ID token
+		var serverURL string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-authorization-server":
+				metadata := map[string]interface{}{
+					"issuer":                 serverURL,
+					"token_endpoint":         serverURL + "/oauth/token",
+					"authorization_endpoint": serverURL + "/oauth/authorize",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(metadata)
+
+			case "/oauth/token":
+				// Return a refresh response WITH a new ID token
+				response := map[string]interface{}{
+					"access_token":  "new-access-token",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+					"refresh_token": "new-refresh-token",
+					"id_token":      newIDToken,
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+		serverURL = server.URL
+
+		// Create token store
+		store, err := oauth.NewTokenStore(oauth.TokenStoreConfig{
+			StorageDir: tmpDir,
+			FileMode:   true,
+		})
+		if err != nil {
+			t.Fatalf("failed to create token store: %v", err)
+		}
+
+		originalIDToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIiwiZW1haWwiOiJ1c2VyQGV4YW1wbGUuY29tIiwiZXhwIjoxNzA5MjQ1MjAwfQ.oldsignature"
+		normalizedEndpoint := "https://muster.example.com"
+
+		storedToken := &oauth.StoredToken{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			TokenType:    "Bearer",
+			IDToken:      originalIDToken,
+			ServerURL:    normalizedEndpoint,
+			IssuerURL:    server.URL,
+		}
+
+		oauth2Token := storedToken.ToOAuth2Token()
+		if err := store.StoreToken(normalizedEndpoint, server.URL, oauth2Token); err != nil {
+			t.Fatalf("failed to store token: %v", err)
+		}
+
+		retrievedBefore := store.GetTokenIncludingExpiring(normalizedEndpoint)
+		if retrievedBefore == nil {
+			t.Fatal("expected to retrieve stored token")
+		}
+
+		adapter, err := NewAuthAdapterWithConfig(AuthAdapterConfig{
+			TokenStorageDir: tmpDir,
+		})
+		if err != nil {
+			t.Fatalf("failed to create adapter: %v", err)
+		}
+		defer adapter.Close()
+
+		ctx := context.Background()
+		err = adapter.doTokenRefresh(ctx, store, retrievedBefore, normalizedEndpoint)
+		if err != nil {
+			t.Fatalf("doTokenRefresh failed: %v", err)
+		}
+
+		refreshedToken := store.GetTokenIncludingExpiring(normalizedEndpoint)
+		if refreshedToken == nil {
+			t.Fatal("expected to retrieve refreshed token")
+		}
+
+		// When a new ID token is provided, it should be used instead of the old one
+		if refreshedToken.IDToken != newIDToken {
+			t.Errorf("ID token should be updated when provided in refresh response.\nExpected: %q\nGot: %q",
+				newIDToken, refreshedToken.IDToken)
+		}
+	})
 }

--- a/internal/oauth/client.go
+++ b/internal/oauth/client.go
@@ -183,6 +183,12 @@ func (c *Client) RefreshToken(ctx context.Context, token *pkgoauth.Token) (*pkgo
 		newToken.RefreshToken = token.RefreshToken
 	}
 
+	// Preserve ID token if not returned (refresh responses typically don't include ID tokens)
+	// The ID token is needed for SSO forwarding to downstream MCP servers
+	if newToken.IDToken == "" && token.IDToken != "" {
+		newToken.IDToken = token.IDToken
+	}
+
 	// Log successful refresh at INFO level for operational monitoring
 	logging.Info("OAuth", "Token refresh successful (issuer=%s, expires_in=%ds, duration=%v)",
 		token.Issuer, newToken.ExpiresIn, time.Since(startTime))


### PR DESCRIPTION
## Summary

Preserve ID token during OAuth token refresh when refresh response omits it (per OAuth 2.0 spec, refresh responses typically don't include ID tokens). The ID token is needed for SSO forwarding to downstream MCP servers.

## Changes

### CLI Auth Adapter
- `internal/cli/auth_adapter.go`: Added logic in `doTokenRefresh` to preserve the original ID token when the refresh response doesn't include one

### Server-Side OAuth Client
- `internal/oauth/client.go`: Added the same ID token preservation logic in `RefreshToken` for server-side token refresh operations

### Tests
- `internal/cli/auth_adapter_test.go`: Added `TestDoTokenRefresh_PreservesIDToken` with two test cases:
  - Verifies ID token is preserved when refresh response omits it
  - Verifies new ID token is used when refresh response includes one

## Test plan

- [x] All unit tests pass (`make test`)
- [x] All 167 BDD scenarios pass (`muster test --parallel 50`)
- [x] New tests specifically cover the ID token preservation behavior