### PR TITLE
Fix: Upgrade mcp-oauth to v0.2.56 for cross-client audience scope merging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/giantswarm/mcp-oauth v0.2.55
+	github.com/giantswarm/mcp-oauth v0.2.56
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.55 h1:/cY1b4dhzp1ahM3chnZU1BZUxELZr44FYHmPY13VWK0=
-github.com/giantswarm/mcp-oauth v0.2.55/go.mod h1:b0V5d3qLeS9F1AbdpMcCaPR0jy6h1ad63VRHwDbKVOU=
+github.com/giantswarm/mcp-oauth v0.2.56 h1:Nkmkf2Q7Nxc0+53zE/ADr+3P7TuXnW2dA5goIu+FbPA=
+github.com/giantswarm/mcp-oauth v0.2.56/go.mod h1:b0V5d3qLeS9F1AbdpMcCaPR0jy6h1ad63VRHwDbKVOU=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

- Upgrades mcp-oauth from v0.2.55 to v0.2.56
- Fixes SSO token forwarding for Kubernetes OIDC authentication
- Adds automatic retry loop for failed MCPServer services with exponential backoff
- Improves transient error detection to include HTTP 5xx server errors

## Problem

When users authenticated to muster, client-requested OAuth scopes (`openid profile email offline_access`) were overriding the provider's configured cross-client audience scopes. This resulted in tokens that lacked the `dex-k8s-authenticator` audience required for Kubernetes API access.

**Symptom**: `muster agent` could connect to mcp-kubernetes via SSO, but Kubernetes API calls failed with "the server has asked for the client to provide credentials".

Additionally, when MCP servers experienced transient failures (e.g., 503 Service Unavailable), muster would not automatically retry connecting to them.

## Root Cause

1. **OAuth scope merging**: The `CopyScopes` function in mcp-oauth used either client-requested scopes OR provider defaults, not both. Cross-client audience scopes configured via `requiredAudiences` in MCPServer CRs were being ignored.

2. **Missing retry logic**: The orchestrator lacked automatic retry for failed MCP servers, requiring manual intervention for transient issues.

## Fix

1. **mcp-oauth v0.2.56** includes a fix that merges mandatory scopes (cross-client audiences like `audience:server:client_id:dex-k8s-authenticator`) from provider defaults into client-requested scopes.

2. **Automatic retry loop**: Added a background goroutine in the orchestrator that checks failed/unreachable MCP servers every 30 seconds and attempts reconnection when their backoff period expires.

3. **HTTP 5xx detection**: Extended transient error detection to recognize HTTP 5xx server errors (500-504, 507-509) as retry-eligible.

## Changes

### Orchestrator (`internal/orchestrator/orchestrator.go`)
- Added `RetryInterval` constant (30 seconds) at file-level with other constants
- Added `sync.WaitGroup` for tracking in-flight retry goroutines (clean shutdown)
- Added `retryFailedMCPServers()` - background loop respecting context cancellation
- Added `attemptReconnectFailedServers()` - checks backoff and spawns restart goroutines
- Added `shouldAttemptRetry()` - extracted eligibility check for readability

### MCP Server Service (`internal/services/mcpserver/service.go`)
- Extended `isTransientConnectivityError()` with consolidated HTTP 5xx patterns
- Added coverage for status codes 500, 501, 502, 503, 504, 507, 508, 509

### Tests (`internal/services/mcpserver/service_test.go`)
- Added comprehensive HTTP 5xx test cases including:
  - All covered status codes (500-504, 507-509)
  - Mixed case error messages
  - Wrapped errors
  - 4xx errors (verified as NOT transient)

## Test Plan

- [x] Unit tests pass (`make test`)
- [ ] Deploy to gazelle and verify SSO token forwarding works with Kubernetes OIDC
- [ ] Verify `muster auth status` shows `gazelle-mcp-kubernetes` as `Connected [SSO: Forwarded]`
- [ ] Verify `kubernetes_cluster_health` tool returns healthy status instead of auth error
- [ ] Verify failed MCP servers are automatically retried after backoff expires

## Related

- mcp-oauth issue: https://github.com/giantswarm/mcp-oauth/issues/203