### PR TITLE
Fix: Add 'groups' scope to muster-agent CIMD

### DIFF
--- a/docs/muster-agent.json
+++ b/docs/muster-agent.json
@@ -13,7 +13,7 @@
     "code"
   ],
   "token_endpoint_auth_method": "none",
-  "scope": "openid profile email offline_access",
+  "scope": "openid profile email groups offline_access",
   "software_id": "giantswarm-muster-agent",
   "software_version": "1.0.0"
 }


### PR DESCRIPTION
## Summary

- Adds the missing 'groups' scope to the muster-agent Client ID Metadata Document (CIMD)
- Fixes OAuth authentication failures for muster-agent CLI users

## Problem

The muster-agent CLI requests these OAuth scopes:
```go
var agentOAuthScopes = []string{"openid", "profile", "email", "groups", "offline_access"}
```

But the CIMD at `docs/muster-agent.json` (served via GitHub Pages) only declared:
```json
"scope": "openid profile email offline_access"
```

This mismatch caused the muster OAuth server to reject authorization requests with:
```
invalid_scope: client is not authorized for one or more requested scopes
```

## Root Cause

The 'groups' scope was added to the agent code in #334 for RBAC support, but the CIMD was not updated to match.

## Test Plan

- [ ] After merge, verify GitHub Pages updates the CIMD
- [ ] Restart muster pod on gazelle (or wait for 10min cache TTL)
- [ ] Test `muster auth login` works successfully