### PR TITLE
Fix: Regenerate CRDs with controller-gen v0.20.1

### DIFF
--- a/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
+++ b/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: mcpservers.muster.giantswarm.io
 spec:
   group: muster.giantswarm.io

--- a/helm/muster/crds/muster.giantswarm.io_serviceclasses.yaml
+++ b/helm/muster/crds/muster.giantswarm.io_serviceclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: serviceclasses.muster.giantswarm.io
 spec:
   group: muster.giantswarm.io

--- a/helm/muster/crds/muster.giantswarm.io_workflows.yaml
+++ b/helm/muster/crds/muster.giantswarm.io_workflows.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: workflows.muster.giantswarm.io
 spec:
   group: muster.giantswarm.io


### PR DESCRIPTION
## Summary
- Regenerated CRDs with controller-gen v0.20.1 (previously v0.20.0)
- The only change is the `controller-gen.kubebuilder.io/version` annotation in 3 CRD files
- This fixes the "Lint and Test" CI check failure on all open Renovate PRs (#364, #365, #366)

## Test plan
- [ ] CI "Lint and Test" check passes on this PR
- [ ] After merging, Renovate PRs should pass the CRD freshness check when rebased

Made with [Cursor](https://cursor.com)