### PR TITLE
fix: restructure CI for faster PR builds and multiarch support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.13.0
+  architect: giantswarm/architect@6.14.0
 
 workflows:
   build:
@@ -11,13 +11,43 @@ workflows:
           name: go-build
           binary: muster
           filters:
-            # Trigger job also on git tag.
             tags:
               only: /^v.*/
 
-      - architect/push-to-registries:
+      # Branch builds: amd64 only for faster PR feedback
+      - architect/push-to-registries-multiarch:
           context: architect
           name: push-to-registries
+          platforms: "linux/amd64"
+          requires:
+            - go-build
+          filters:
+            branches:
+              ignore:
+                - main
+
+      # Tag builds: full multi-arch (amd64 + arm64)
+      - architect/push-to-registries-multiarch:
+          context: architect
+          name: push-to-registries-release
+          requires:
+            - go-build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      - architect/push-to-app-catalog:
+          executor: app-build-suite
+          context: architect
+          name: build-muster-chart
+          app_catalog: giantswarm-catalog
+          app_catalog_test: giantswarm-test-catalog
+          chart: muster
+          push_to_appcatalog: false
+          push_to_oci_registry: false
+          persist_chart_archive: true
           requires:
             - go-build
           filters:
@@ -27,6 +57,18 @@ workflows:
               ignore:
                 - main
 
+      - architect/run-tests-with-ats:
+          name: execute chart tests
+          requires:
+            - build-muster-chart
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - main
+
+      # Branch: push chart after tests + amd64 image
       - architect/push-to-app-catalog:
           executor: app-build-suite
           context: architect
@@ -35,20 +77,26 @@ workflows:
           app_catalog_test: giantswarm-test-catalog
           chart: muster
           requires:
+            - execute chart tests
             - push-to-registries
-          persist_chart_archive: true
           filters:
-            tags:
-              only: /^v.*/
             branches:
               ignore:
                 - main
 
-      - architect/run-tests-with-ats:
-          name: execute chart tests
-          filters:
-            branches:
-              ignore:
-                - main
+      # Tag: push chart after tests + multi-arch image
+      - architect/push-to-app-catalog:
+          executor: app-build-suite
+          context: architect
+          name: push-muster-to-giantswarm-app-catalog-release
+          app_catalog: giantswarm-catalog
+          app_catalog_test: giantswarm-test-catalog
+          chart: muster
           requires:
-            - push-muster-to-giantswarm-app-catalog
+            - execute chart tests
+            - push-to-registries-release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Kubernetes event emission is now disabled by default (alpha feature). Use `--enable-events` flag on `muster serve` or set `events: true` in `config.yaml` to opt in.
+- Switch CI to `push-to-registries-multiarch` (`architect-orb@6.14.0`) with
+  amd64-only on branches for faster PR feedback and full multi-arch on release
+  tags. Chart tests now run before publishing to the app catalog.
+- Update Dockerfile to multi-stage build with native cross-compilation support
+  for multi-architecture images.
 
 > **Note:** The Server-Side Meta-Tools Migration below is a **breaking change** that will be released as part of the next major version. External integrations should prepare for this change.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,32 @@
-FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm
+# Stage 1: Build the Go binary (runs on the build host, cross-compiles for target).
+FROM --platform=$BUILDPLATFORM golang:1.26.0 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags "-w -extldflags '-static' \
+    -X 'main.version=${VERSION}' \
+    -X 'main.commit=${COMMIT}' \
+    -X 'main.date=${DATE}'" \
+    -o muster .
+
+# Stage 2: Minimal scratch-based runtime.
+FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm AS certs
 FROM scratch
 
-COPY --from=0 /etc/passwd /etc/passwd
-COPY --from=0 /etc/group /etc/group
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=certs /etc/passwd /etc/passwd
+COPY --from=certs /etc/group /etc/group
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-ADD muster /
+COPY --from=builder /app/muster /muster
 USER giantswarm
 
 ENTRYPOINT ["/muster"]
-
-


### PR DESCRIPTION
## Summary

- **Multiarch Dockerfile**: Replace the simple `ADD muster /` Dockerfile with a multi-stage build that cross-compiles inside Docker using `FROM --platform=$BUILDPLATFORM`. This enables proper multiarch image builds via buildx.

- **Faster PR builds**: Switch to `push-to-registries-multiarch` (`architect-orb@6.14.0`) with `platforms: "linux/amd64"` on branches to avoid cross-compilation and slow Aliyun registry pushes. Full multi-arch builds (amd64 + arm64) only run on release tags.

- **Fix CI job ordering**: Chart tests now run *before* the chart is pushed to the app catalog. The chart is first built/packaged without publishing, tested with ATS, and only pushed once tests pass and the image is available.

## Test plan

- [ ] Verify branch CI build passes with amd64-only image push
- [ ] Verify chart tests execute before catalog push
- [ ] Verify release tag flow builds multi-arch images

Made with [Cursor](https://cursor.com)