### PR TITLE
Fix: Release workflow fixes for goreleaser homebrew and changelog format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -134,6 +134,8 @@ brews:
       name: homebrew-muster
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
     # URL template for the download
     url_template: >-
       https://github.com/giantswarm/muster/releases/download/{{ .Tag }}/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,3 +361,5 @@ See [ADR-010](docs/explanation/decisions/010-server-side-meta-tools.md) for desi
 - Simplified MCP server lifecycle management
 
 ## [0.6.0] - 2025-01-15
+
+[Unreleased]: https://github.com/giantswarm/muster/compare/v0.0.236...HEAD


### PR DESCRIPTION
## Summary
- Configure goreleaser `brews` to use `pull_request.enabled: true` for the `homebrew-muster` tap, fixing the 409 branch protection error when auto-release tries to push directly to main.
- Add `[Unreleased]` link reference to `CHANGELOG.md` in the format required by `architect prepare-release`, fixing the Create Release PR workflow failure.

## Context
Two workflow failures:
1. **Auto Release** failed because goreleaser tried to push the homebrew formula directly to `giantswarm/homebrew-muster` main, which has branch protection rules requiring PRs.
2. **Create Release PR** (`main#release#minor` for v0.1.0) failed because `architect prepare-release` requires an `[Unreleased]: https://...` link reference at the bottom of CHANGELOG.md.

## Test plan
- [ ] Merge this PR and verify the Auto Release workflow succeeds (homebrew creates a PR instead of direct push)
- [ ] After merge, push `main#release#minor` branch to trigger the 0.1.0 release PR

Made with [Cursor](https://cursor.com)