### PR TITLE
Fix: Make auto-release resilient to homebrew tap failures

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Run GoReleaser
         if: steps.check_tag.outputs.skip != 'true'
+        continue-on-error: true
+        id: goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
@@ -116,5 +118,23 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Token for pushing to homebrew-muster tap
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Check release result
+        if: steps.check_tag.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.version.outputs.next_version }}
+          GR_OUTCOME: ${{ steps.goreleaser.outcome }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              > /dev/null 2>&1; then
+            echo "Release $TAG published successfully"
+            if [[ "$GR_OUTCOME" == "failure" ]]; then
+              echo "::warning::GoReleaser had non-fatal errors" \
+                "(e.g. homebrew tap update). Release artifacts are fine."
+            fi
+          else
+            echo "::error::Release $TAG was not published"
+            exit 1
+          fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -134,32 +134,20 @@ brews:
       name: homebrew-muster
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-      pull_request:
-        enabled: true
-    # URL template for the download
     url_template: >-
       https://github.com/giantswarm/muster/releases/download/{{ .Tag }}/
       {{- .ArtifactName }}
-    # Git author used for commits
     commit_author:
       name: giantswarm-bot
       email: bot@giantswarm.io
-    # Commit message template
     commit_msg_template: "Update {{ .ProjectName }} to {{ .Tag }}"
-    # Folder inside the repository to put the formula
     directory: Formula
-    # Homepage URL
     homepage: "https://github.com/giantswarm/muster"
-    # Description of the project
     description: "Universal Control Plane for AI Agents - MCP server aggregator"
-    # License
     license: "Apache-2.0"
-    # Skip upload if this is a prerelease
     skip_upload: auto
-    # Custom install script
     install: |
       bin.install "muster"
-    # Test block
     test: |
       system "#{bin}/muster", "version"
 


### PR DESCRIPTION
## Summary
- Remove goreleaser `pull_request` config from brews (the `HOMEBREW_TAP_GITHUB_TOKEN` lacks fork permissions, causing `404 repos//` errors)
- Add `continue-on-error: true` to the goreleaser step so homebrew tap push failures don't block the release
- Add a verification step that confirms the GitHub release was published (fails only if the release is missing)

## Context
The `giantswarm/homebrew-muster` repo has branch protection requiring PRs. The goreleaser `pull_request.enabled` feature tried to fork the repo but the token couldn't determine the authenticated user's fork (empty owner/repo in API calls). 

Since the homebrew tap update is non-critical (release artifacts are published fine), this makes it non-blocking while logging a warning.

## Test plan
- [ ] Merge and verify the next auto-release completes successfully (with a warning about homebrew)

Made with [Cursor](https://cursor.com)