### PR TITLE
Chore: Bump architect orb to 6.14.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.14.0
+  architect: giantswarm/architect@6.14.1
 
 workflows:
   build:


### PR DESCRIPTION
## Summary

- Bump `giantswarm/architect` orb from 6.14.0 to 6.14.1

## Motivation

The `push-to-registries` CI step was hanging due to a China registry push issue fixed in 6.14.1.

## Test plan

- [ ] CI pipeline completes successfully with `push-to-registries` no longer hanging

Made with [Cursor](https://cursor.com)