### PR TITLE
Fix: Decouple chart push from image push in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
               ignore:
                 - main
 
-      # Branch: push chart after tests + amd64 image
+      # Branch: push chart after tests
       - architect/push-to-app-catalog:
           executor: app-build-suite
           context: architect
@@ -78,13 +78,12 @@ workflows:
           chart: muster
           requires:
             - execute chart tests
-            - push-to-registries
           filters:
             branches:
               ignore:
                 - main
 
-      # Tag: push chart after tests + multi-arch image
+      # Tag: push chart after tests
       - architect/push-to-app-catalog:
           executor: app-build-suite
           context: architect
@@ -94,7 +93,6 @@ workflows:
           chart: muster
           requires:
             - execute chart tests
-            - push-to-registries-release
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
## Summary

- Remove the dependency between `push-to-registries` / `push-to-registries-release` and `push-to-app-catalog` / `push-to-app-catalog-release` in the CircleCI workflow

## Problem

When the China (Alibaba Cloud) container registry is unreachable, the `push-to-registries-release` job times out after 10 minutes. Because the chart push job (`push-muster-to-giantswarm-app-catalog-release`) had a `requires: push-to-registries-release` dependency, the Helm chart was never published to the app catalog.

This blocked Flux-managed deployments (e.g. gazelle) from picking up new releases. Releases v0.1.0 through v0.1.3 were all affected -- the container images were pushed to gsoci successfully, but the charts were never published.

## Fix

The Helm chart and the container image are independent artifacts. The chart push only needs the chart to be built and tested. Remove `push-to-registries` from the `requires` list of both `push-muster-to-giantswarm-app-catalog` (branch) and `push-muster-to-giantswarm-app-catalog-release` (tag).

The image push still runs in parallel but no longer blocks chart publication.

## Test plan

- [x] `circleci config validate` passes
- [ ] Merge and tag a new release, verify chart appears in `oci://gsoci.azurecr.io/charts/giantswarm/muster`

Made with [Cursor](https://cursor.com)