### PR TITLE
Fix auto-release workflow YAML syntax error

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Auto Release
     if: >-
       github.event.pull_request.merged &&
-      !startsWith(github.event.pull_request.title, \'Release v\')
+      !startsWith(github.event.pull_request.title, 'Release v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Fix backslash-escaped single quotes in the auto-release workflow `if` expression that caused GitHub Actions to reject the workflow file with:

> Unexpected symbol: `'Release`

Single quotes do not need escaping in a YAML block scalar.

## Test plan
- [ ] Verify the auto-release workflow passes validation
- [ ] Confirm next PR merge triggers a successful release

Made with [Cursor](https://cursor.com)