### PR TITLE
Refactor: rename ContextWithAccessToken to ContextWithIDToken

### DIFF
--- a/docs/explanation/decisions/005-muster-auth.md
+++ b/docs/explanation/decisions/005-muster-auth.md
@@ -207,10 +207,10 @@ Context helpers for passing OAuth tokens through the request chain:
 
 ```go
 // Store ID token in context for downstream use
-ctx = oauth.ContextWithAccessToken(ctx, idToken)
+ctx = oauth.ContextWithIDToken(ctx, idToken)
 
 // Retrieve token in tool handlers
-token, ok := oauth.GetAccessTokenFromContext(ctx)
+token, ok := oauth.GetIDTokenFromContext(ctx)
 ```
 
 #### 3. Access Token Injector Middleware
@@ -229,7 +229,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
         token, err := s.tokenStore.GetToken(ctx, userInfo.Email)
         // Extract ID token and inject into context
         idToken := GetIDToken(token)
-        ctx = ContextWithAccessToken(ctx, idToken)
+        ctx = ContextWithIDToken(ctx, idToken)
         r = r.WithContext(ctx)
         next.ServeHTTP(w, r)
     })

--- a/internal/aggregator/session_connection_helper.go
+++ b/internal/aggregator/session_connection_helper.go
@@ -216,7 +216,7 @@ func getIDTokenForForwarding(ctx context.Context, sessionID, musterIssuer string
 	// First, check the request context for an ID token from muster's OAuth server protection.
 	// This is the primary SSO use case: user authenticates TO muster, and we forward that
 	// token to downstream servers that trust muster's OAuth client ID.
-	if idToken, ok := server.GetAccessTokenFromContext(ctx); ok && idToken != "" {
+	if idToken, ok := server.GetIDTokenFromContext(ctx); ok && idToken != "" {
 		logging.Debug("SessionConnection", "Found ID token in request context for session %s",
 			logging.TruncateSessionID(sessionID))
 		return idToken

--- a/internal/aggregator/session_connection_helper_test.go
+++ b/internal/aggregator/session_connection_helper_test.go
@@ -59,7 +59,7 @@ func TestGetIDTokenForForwarding(t *testing.T) {
 
 	t.Run("returns token from context when available", func(t *testing.T) {
 		ctx := context.Background()
-		ctx = server.ContextWithAccessToken(ctx, validToken)
+		ctx = server.ContextWithIDToken(ctx, validToken)
 
 		token := getIDTokenForForwarding(ctx, "test-session", "https://accounts.google.com")
 
@@ -76,7 +76,7 @@ func TestGetIDTokenForForwarding(t *testing.T) {
 
 	t.Run("context token takes priority over empty string", func(t *testing.T) {
 		ctx := context.Background()
-		ctx = server.ContextWithAccessToken(ctx, validToken)
+		ctx = server.ContextWithIDToken(ctx, validToken)
 
 		// Even with an issuer, context token should be returned
 		token := getIDTokenForForwarding(ctx, "test-session", "")
@@ -86,7 +86,7 @@ func TestGetIDTokenForForwarding(t *testing.T) {
 
 	t.Run("returns empty for empty context token", func(t *testing.T) {
 		ctx := context.Background()
-		ctx = server.ContextWithAccessToken(ctx, "")
+		ctx = server.ContextWithIDToken(ctx, "")
 
 		token := getIDTokenForForwarding(ctx, "test-session", "https://accounts.google.com")
 

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -345,7 +345,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 		}
 
 		// Inject the ID token into context for downstream SSO use
-		ctx = ContextWithAccessToken(ctx, idToken)
+		ctx = ContextWithIDToken(ctx, idToken)
 
 		// Also inject the upstream access token for refresh detection.
 		// The access token changes on every token refresh, while the ID token
@@ -385,7 +385,7 @@ func (s *OAuthHTTPServer) triggerSessionInitIfNeeded(ctx context.Context, r *htt
 	}
 
 	// Get the ID token from context - we need this for SSO forwarding
-	idToken, _ := GetAccessTokenFromContext(ctx)
+	idToken, _ := GetIDTokenFromContext(ctx)
 	if idToken == "" {
 		logging.Debug("OAuth", "SSO: No ID token in context for session %s, skipping session init",
 			logging.TruncateSessionID(sessionID))
@@ -448,7 +448,7 @@ func (s *OAuthHTTPServer) triggerSessionInitIfNeeded(ctx context.Context, r *htt
 		// Create a background context with the ID token for SSO forwarding.
 		// This context won't be canceled when the HTTP request completes.
 		bgCtx := context.Background()
-		bgCtx = ContextWithAccessToken(bgCtx, idToken)
+		bgCtx = ContextWithIDToken(bgCtx, idToken)
 		bgCtx = api.WithClientSessionID(bgCtx, sessionID)
 
 		callback(bgCtx, sessionID)

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -343,28 +343,28 @@ func TestTruncateEmail(t *testing.T) {
 }
 
 func TestTokenProviderContextFunctions(t *testing.T) {
-	t.Run("ContextWithAccessToken and GetAccessTokenFromContext", func(t *testing.T) {
+	t.Run("ContextWithIDToken and GetIDTokenFromContext", func(t *testing.T) {
 		ctx := httptest.NewRequest("GET", "/", nil).Context()
 		token := "test-token-123"
 
 		// Initially no token
-		_, ok := GetAccessTokenFromContext(ctx)
+		_, ok := GetIDTokenFromContext(ctx)
 		assert.False(t, ok)
 
 		// Add token to context
-		ctx = ContextWithAccessToken(ctx, token)
+		ctx = ContextWithIDToken(ctx, token)
 
 		// Retrieve token
-		retrieved, ok := GetAccessTokenFromContext(ctx)
+		retrieved, ok := GetIDTokenFromContext(ctx)
 		assert.True(t, ok)
 		assert.Equal(t, token, retrieved)
 	})
 
-	t.Run("GetAccessTokenFromContext with empty token returns false", func(t *testing.T) {
+	t.Run("GetIDTokenFromContext with empty token returns false", func(t *testing.T) {
 		ctx := httptest.NewRequest("GET", "/", nil).Context()
-		ctx = ContextWithAccessToken(ctx, "")
+		ctx = ContextWithIDToken(ctx, "")
 
-		_, ok := GetAccessTokenFromContext(ctx)
+		_, ok := GetIDTokenFromContext(ctx)
 		assert.False(t, ok)
 	})
 
@@ -440,7 +440,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// Create request with session ID and tokens in context
 		req := httptest.NewRequest("GET", "/", nil)
 		req.Header.Set(api.ClientSessionIDHeader, "test-session-1")
-		ctx := ContextWithAccessToken(req.Context(), "id-token-A")
+		ctx := ContextWithIDToken(req.Context(), "id-token-A")
 		ctx = ContextWithUpstreamAccessToken(ctx, "access-token-A")
 
 		server.triggerSessionInitIfNeeded(ctx, req)
@@ -471,7 +471,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// First call with tokens - should trigger callback
 		req1 := httptest.NewRequest("GET", "/", nil)
 		req1.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx1 := ContextWithAccessToken(req1.Context(), idToken)
+		ctx1 := ContextWithIDToken(req1.Context(), idToken)
 		ctx1 = ContextWithUpstreamAccessToken(ctx1, accessToken)
 		server.triggerSessionInitIfNeeded(ctx1, req1)
 
@@ -486,7 +486,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// Second call with SAME tokens - should NOT trigger callback
 		req2 := httptest.NewRequest("GET", "/", nil)
 		req2.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx2 := ContextWithAccessToken(req2.Context(), idToken)
+		ctx2 := ContextWithIDToken(req2.Context(), idToken)
 		ctx2 = ContextWithUpstreamAccessToken(ctx2, accessToken)
 		server.triggerSessionInitIfNeeded(ctx2, req2)
 
@@ -508,7 +508,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 
 		// Register callback that captures the ID token from context
 		api.RegisterSessionInitCallback(func(ctx context.Context, sessionID string) {
-			idToken, _ := GetAccessTokenFromContext(ctx)
+			idToken, _ := GetIDTokenFromContext(ctx)
 			callbackDone <- callbackResult{idToken: idToken}
 		})
 		defer api.RegisterSessionInitCallback(nil)
@@ -522,7 +522,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// First call with token A
 		req1 := httptest.NewRequest("GET", "/", nil)
 		req1.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx1 := ContextWithAccessToken(req1.Context(), idTokenA)
+		ctx1 := ContextWithIDToken(req1.Context(), idTokenA)
 		ctx1 = ContextWithUpstreamAccessToken(ctx1, accessTokenA)
 		server.triggerSessionInitIfNeeded(ctx1, req1)
 
@@ -537,7 +537,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// Second call with DIFFERENT tokens (simulating re-authentication)
 		req2 := httptest.NewRequest("GET", "/", nil)
 		req2.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx2 := ContextWithAccessToken(req2.Context(), idTokenB)
+		ctx2 := ContextWithIDToken(req2.Context(), idTokenB)
 		ctx2 = ContextWithUpstreamAccessToken(ctx2, accessTokenB)
 		server.triggerSessionInitIfNeeded(ctx2, req2)
 
@@ -559,7 +559,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 
 		// Register callback that captures the ID token from context
 		api.RegisterSessionInitCallback(func(ctx context.Context, sessionID string) {
-			idToken, _ := GetAccessTokenFromContext(ctx)
+			idToken, _ := GetIDTokenFromContext(ctx)
 			callbackDone <- callbackResult{idToken: idToken}
 		})
 		defer api.RegisterSessionInitCallback(nil)
@@ -574,7 +574,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// First call with original access token
 		req1 := httptest.NewRequest("GET", "/", nil)
 		req1.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx1 := ContextWithAccessToken(req1.Context(), idToken)
+		ctx1 := ContextWithIDToken(req1.Context(), idToken)
 		ctx1 = ContextWithUpstreamAccessToken(ctx1, accessTokenBefore)
 		server.triggerSessionInitIfNeeded(ctx1, req1)
 
@@ -589,7 +589,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// Second call with SAME ID token but DIFFERENT access token (simulating server-side refresh)
 		req2 := httptest.NewRequest("GET", "/", nil)
 		req2.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx2 := ContextWithAccessToken(req2.Context(), idToken)       // Same ID token
+		ctx2 := ContextWithIDToken(req2.Context(), idToken)       // Same ID token
 		ctx2 = ContextWithUpstreamAccessToken(ctx2, accessTokenAfter) // Different access token
 		server.triggerSessionInitIfNeeded(ctx2, req2)
 
@@ -613,7 +613,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 
 		// Request without session ID header
 		req := httptest.NewRequest("GET", "/", nil)
-		ctx := ContextWithAccessToken(req.Context(), "some-id-token")
+		ctx := ContextWithIDToken(req.Context(), "some-id-token")
 		ctx = ContextWithUpstreamAccessToken(ctx, "some-access-token")
 
 		// This returns early (no goroutine launched) when session ID is missing
@@ -669,7 +669,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// First call with ID token only (no upstream access token) - should trigger
 		req1 := httptest.NewRequest("GET", "/", nil)
 		req1.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx1 := ContextWithAccessToken(req1.Context(), idTokenA)
+		ctx1 := ContextWithIDToken(req1.Context(), idTokenA)
 		// Note: NOT setting ContextWithUpstreamAccessToken
 		server.triggerSessionInitIfNeeded(ctx1, req1)
 
@@ -683,7 +683,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// Second call with SAME ID token (no upstream access token) - should NOT trigger
 		req2 := httptest.NewRequest("GET", "/", nil)
 		req2.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx2 := ContextWithAccessToken(req2.Context(), idTokenA)
+		ctx2 := ContextWithIDToken(req2.Context(), idTokenA)
 		server.triggerSessionInitIfNeeded(ctx2, req2)
 
 		select {
@@ -696,7 +696,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// Third call with DIFFERENT ID token - should trigger
 		req3 := httptest.NewRequest("GET", "/", nil)
 		req3.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx3 := ContextWithAccessToken(req3.Context(), idTokenB)
+		ctx3 := ContextWithIDToken(req3.Context(), idTokenB)
 		server.triggerSessionInitIfNeeded(ctx3, req3)
 
 		select {

--- a/internal/server/token_provider.go
+++ b/internal/server/token_provider.go
@@ -11,10 +11,10 @@ import (
 type contextKey string
 
 const (
-	// accessTokenKey is the context key for storing the user's OAuth access token.
+	// idTokenKey is the context key for storing the user's OIDC ID token.
 	// This token can be used for downstream API authentication.
 	//nolint:gosec // G101 false positive - this is a context key name, not a credential
-	accessTokenKey contextKey = "oauth_access_token"
+	idTokenKey contextKey = "oauth_id_token"
 
 	// upstreamAccessTokenKey is the context key for storing the upstream IdP's access token.
 	// This is used to detect token refresh (the access token changes on refresh,
@@ -27,17 +27,17 @@ const (
 // This is a type alias for the library's providers.UserInfo type.
 type UserInfo = providers.UserInfo
 
-// ContextWithAccessToken creates a context with the given OAuth ID token.
-// This is used to pass the user's OAuth ID token for downstream
+// ContextWithIDToken creates a context with the given OIDC ID token.
+// This is used to pass the user's ID token for downstream
 // authentication (e.g., to remote MCP servers).
-func ContextWithAccessToken(ctx context.Context, idToken string) context.Context {
-	return context.WithValue(ctx, accessTokenKey, idToken)
+func ContextWithIDToken(ctx context.Context, idToken string) context.Context {
+	return context.WithValue(ctx, idTokenKey, idToken)
 }
 
-// GetAccessTokenFromContext retrieves the OAuth ID token from the context.
+// GetIDTokenFromContext retrieves the OIDC ID token from the context.
 // Returns the ID token and true if present, or empty string and false if not available.
-func GetAccessTokenFromContext(ctx context.Context) (string, bool) {
-	token, ok := ctx.Value(accessTokenKey).(string)
+func GetIDTokenFromContext(ctx context.Context) (string, bool) {
+	token, ok := ctx.Value(idTokenKey).(string)
 	return token, ok && token != ""
 }
 


### PR DESCRIPTION
## Summary

- refactor: rename ContextWithAccessToken to ContextWithIDToken

## Related issues

Relates to #412

## Commits

### refactor: rename ContextWithAccessToken to ContextWithIDToken

These functions store and retrieve the OIDC ID token, not the OAuth
access token. The previous naming was misleading. Rename the constant,
context key string, and both functions to accurately reflect what they
carry.

Closes #412

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

