### PR TITLE
Fix: correct goimports formatting in client.go and oauth_http_test.go

### DIFF
--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -56,23 +56,23 @@ type ServerInfo struct {
 //   - Multiple output formats (text, JSON)
 //   - OAuth 2.1 authentication support via mcp-go's transport layer
 type Client struct {
-	endpoint         string
-	transport        TransportType
-	logger           *Logger
-	client           client.MCPClient
-	serverInfo       *ServerInfo // Stores server info from initialization
-	toolCache        []mcp.Tool
-	resourceCache    []mcp.Resource
-	promptCache      []mcp.Prompt
-	mu               sync.RWMutex
-	timeout          time.Duration
-	cacheEnabled     bool
-	formatters       *Formatters
-	NotificationChan chan mcp.JSONRPCNotification
-	headers             map[string]string           // Custom HTTP headers (e.g., X-Muster-Session-ID)
-	oauthConfig         *transport.OAuthConfig      // OAuth config for mcp-go transport
-	agentTokenStore     *agentoauth.AgentTokenStore // Token store for agent OAuth
-	sessionIDCallback   func(sessionID string)      // Called when server returns a session ID in response header
+	endpoint          string
+	transport         TransportType
+	logger            *Logger
+	client            client.MCPClient
+	serverInfo        *ServerInfo // Stores server info from initialization
+	toolCache         []mcp.Tool
+	resourceCache     []mcp.Resource
+	promptCache       []mcp.Prompt
+	mu                sync.RWMutex
+	timeout           time.Duration
+	cacheEnabled      bool
+	formatters        *Formatters
+	NotificationChan  chan mcp.JSONRPCNotification
+	headers           map[string]string           // Custom HTTP headers (e.g., X-Muster-Session-ID)
+	oauthConfig       *transport.OAuthConfig      // OAuth config for mcp-go transport
+	agentTokenStore   *agentoauth.AgentTokenStore // Token store for agent OAuth
+	sessionIDCallback func(sessionID string)      // Called when server returns a session ID in response header
 }
 
 // NewClient creates a new MCP client with the specified endpoint, logger, and transport type.

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -589,7 +589,7 @@ func TestTriggerSessionInitIfNeeded(t *testing.T) {
 		// Second call with SAME ID token but DIFFERENT access token (simulating server-side refresh)
 		req2 := httptest.NewRequest("GET", "/", nil)
 		req2.Header.Set(api.ClientSessionIDHeader, sessionID)
-		ctx2 := ContextWithIDToken(req2.Context(), idToken)       // Same ID token
+		ctx2 := ContextWithIDToken(req2.Context(), idToken)           // Same ID token
 		ctx2 = ContextWithUpstreamAccessToken(ctx2, accessTokenAfter) // Different access token
 		server.triggerSessionInitIfNeeded(ctx2, req2)
 


### PR DESCRIPTION
## Summary

- fix: correct goimports formatting in client.go and oauth_http_test.go

## Related issues

Relates to #420

## Commits

### fix: correct goimports formatting in client.go and oauth_http_test.go

Fixes struct field alignment in Client type and comment alignment in
test file to satisfy goimports linting in CI.

Closes #420

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

