### PR TITLE
fix: align goimports comment spacing in testSessionIDRoundTripper

### DIFF
--- a/internal/testing/mcp_client.go
+++ b/internal/testing/mcp_client.go
@@ -44,7 +44,7 @@ var _ transport.TokenStore = (*testTokenStore)(nil)
 type testSessionIDRoundTripper struct {
 	wrapped   http.RoundTripper
 	mu        sync.Mutex
-	sessionID string         // server-issued session ID (empty until first response)
+	sessionID string          // server-issued session ID (empty until first response)
 	onUpdate  func(id string) // optional callback when session ID is updated
 }
 


### PR DESCRIPTION
## Summary

- Fix single-space alignment issue in `testSessionIDRoundTripper` struct comment (`internal/testing/mcp_client.go` line 47) that was failing the CircleCI `goimports` check
- CircleCI has been failing on main since PR #413 due to import/formatting issues introduced by agents

## Context

The `goimports` linter requires struct field comments to be aligned. The `sessionID` field comment was one space short of aligning with the `onUpdate` field comment below it. This was introduced by PR #419's `testSessionIDRoundTripper` struct.

## Test plan

- [ ] CircleCI `go-build` pipeline passes (the only CI that was failing)

Made with [Cursor](https://cursor.com)