### PR TITLE
fix: SSO-failed servers should not suggest manual login

### DIFF
--- a/cmd/auth_status.go
+++ b/cmd/auth_status.go
@@ -169,7 +169,7 @@ func showMCPServerStatus(ctx context.Context, handler api.AuthHandler, aggregato
 				authPrint("  Issuer:   %s\n", srv.Issuer)
 			}
 			if srv.Status == pkgoauth.ServerStatusAuthRequired {
-				if srv.SSOAttemptFailed {
+				if srv.SSOAttemptFailed && (srv.TokenForwardingEnabled || srv.TokenExchangeEnabled) {
 					authPrint("  Action:   SSO failed - check server configuration\n")
 				} else if srv.AuthTool != "" {
 					authPrint("  Action:   Run: muster auth login --server %s\n", srv.Name)
@@ -246,7 +246,7 @@ func printMCPServerStatuses(servers []pkgoauth.ServerAuthStatus) {
 			ssoLabel = fmt.Sprintf("  %*s ", maxSSOLen+5, "")
 		}
 
-		if srv.Status == pkgoauth.ServerStatusAuthRequired && srv.SSOAttemptFailed {
+		if srv.Status == pkgoauth.ServerStatusAuthRequired && srv.SSOAttemptFailed && (srv.TokenForwardingEnabled || srv.TokenExchangeEnabled) {
 			fmt.Printf("  %-*s %s%s  SSO failed - check server configuration\n", maxNameLen, srv.Name, statusStr, ssoLabel)
 		} else if srv.Status == pkgoauth.ServerStatusAuthRequired && srv.AuthTool != "" {
 			fmt.Printf("  %-*s %s%s  Run: muster auth login --server %s\n", maxNameLen, srv.Name, statusStr, ssoLabel, srv.Name)

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -1672,10 +1672,10 @@ func (c *Client) GetAuthRequired() []AuthRequiredInfo {
 			continue
 		}
 
-		// Skip SSO-enabled servers unless SSO explicitly failed
-		// These servers use token forwarding or token exchange and don't need
-		// separate browser-based OAuth authentication
-		if (srv.TokenForwardingEnabled || srv.TokenExchangeEnabled) && !srv.SSOAttemptFailed {
+		// Skip SSO-enabled servers entirely -- manual login cannot fix SSO failures.
+		// These servers use token forwarding or token exchange; authentication is
+		// managed by the admin, not the user.
+		if srv.TokenForwardingEnabled || srv.TokenExchangeEnabled {
 			continue
 		}
 

--- a/pkg/oauth/types.go
+++ b/pkg/oauth/types.go
@@ -349,7 +349,7 @@ type ServerAuthStatus struct {
 	Status   string `json:"status"` // "connected", "auth_required", "sso_pending", "disconnected", "error"
 	Issuer   string `json:"issuer,omitempty"`
 	Scope    string `json:"scope,omitempty"`
-	AuthTool string `json:"auth_tool,omitempty"` // Always "core_auth_login" per ADR-008
+	AuthTool string `json:"auth_tool,omitempty"` // "core_auth_login" for non-SSO servers; empty for SSO servers (per ADR-008)
 	Error    string `json:"error,omitempty"`
 
 	// TokenForwardingEnabled indicates this server uses SSO via ID token forwarding.


### PR DESCRIPTION
## Summary

- SSO-enabled servers (token forwarding/exchange) no longer expose `AuthTool` in `auth://status`, preventing agents from calling `core_auth_login` unnecessarily
- `muster auth status` shows "SSO failed - check server configuration" instead of "Run: muster auth login --server" for SSO-failed servers
- `muster auth login --server <sso-server>` prints a helpful diagnostic message and exits without triggering browser OAuth
- `muster auth login --all` skips SSO-enabled servers entirely from the pending list
- Agent's `GetAuthRequired` skips SSO servers unconditionally (not just when SSO succeeded)

## Approach

The core insight is that SSO-enabled servers are authenticated by admin configuration (token forwarding or exchange), not by user action. When SSO fails, the fix is on the server/config side, not something `muster auth login` can resolve. The change enforces this across all code paths identified in the issue:

1. **Protocol layer** (`auth_resource.go`): `AuthTool` gated behind `!TokenForwardingEnabled && !TokenExchangeEnabled`
2. **CLI list view** (`auth_status.go:printMCPServerStatuses`): New SSO-failed branch with admin message
3. **CLI detail view** (`auth_status.go:showMCPServerStatus`): Same treatment
4. **CLI login** (`auth_login.go:loginToMCPServer`): Early return with diagnostic checklist
5. **CLI login --all** (`auth_login.go:loginToAll`): Unconditional SSO server skip
6. **Agent** (`client.go:GetAuthRequired`): Unconditional SSO server skip (found during code review)

SSO failure checks in status display also guard against the edge case where `SSOAttemptFailed` might be set on a non-SSO server by requiring `TokenForwardingEnabled || TokenExchangeEnabled`.

Closes #433

## Test plan

- [x] `TestHandleAuthStatusResource_SSOServerNoAuthTool` - AuthTool empty for token forwarding, token exchange; present for non-SSO
- [x] `TestPrintMCPServerStatuses_SSOFailed` - SSO-failed message shown, login suggestion suppressed, non-SSO unaffected
- [x] All existing tests pass: `./internal/aggregator/`, `./cmd/`, `./internal/agent/`, `./pkg/oauth/`
- [x] Code reviewed by `base:code-reviewer` and `code-quality:security-auditor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)