### PR TITLE
refactor: replace X-Muster-Session-ID with mcp-go native Mcp-Session-Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced custom `X-Muster-Session-ID` header with mcp-go's native `Mcp-Session-Id` header for session tracking. The `MusterSessionIdManager` middleware now handles session ID assignment using the standard MCP header.
+
 ## [0.1.0] - 2026-02-23
 
 ### Changed

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -69,7 +69,7 @@ type Client struct {
 	cacheEnabled      bool
 	formatters        *Formatters
 	NotificationChan  chan mcp.JSONRPCNotification
-	headers           map[string]string           // Custom HTTP headers (e.g., X-Muster-Session-ID)
+	headers           map[string]string           // Custom HTTP headers
 	oauthConfig       *transport.OAuthConfig      // OAuth config for mcp-go transport
 	agentTokenStore   *agentoauth.AgentTokenStore // Token store for agent OAuth
 	sessionIDCallback func(sessionID string)      // Called when server returns a session ID in response header
@@ -259,8 +259,8 @@ func isValidUUIDv4Format(s string) bool {
 }
 
 // sessionIDRoundTripper wraps an http.RoundTripper to intercept server-issued session IDs
-// from the X-Muster-Session-ID response header. When a session ID is received, the callback
-// is invoked and the session ID header is updated for subsequent requests.
+// from the Mcp-Session-Id response header. When a session ID is received, the callback
+// is invoked for disk persistence (enabling CLI reconnection across invocations).
 type sessionIDRoundTripper struct {
 	wrapped  http.RoundTripper
 	callback func(sessionID string)
@@ -293,8 +293,8 @@ func (rt *sessionIDRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 // createAndConnectClient creates and connects an MCP client based on transport type.
 // When OAuth is configured via SetOAuthConfig, it uses mcp-go's built-in OAuth handler
 // for automatic bearer token injection and typed 401 error handling.
-// Non-auth headers (e.g., X-Muster-Session-ID) are always applied.
-// A custom HTTP client with a session ID interceptor is used to capture server-issued session IDs.
+// A custom HTTP client with a session ID interceptor captures server-issued Mcp-Session-Id
+// for disk persistence across CLI invocations.
 func (c *Client) createAndConnectClient(ctx context.Context) (client.MCPClient, error) {
 	if c.transport != TransportSSE && c.transport != TransportStreamableHTTP {
 		return nil, fmt.Errorf("unsupported transport type: %s", c.transport)

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -131,7 +131,7 @@ func (c *Client) SetHeader(key, value string) {
 }
 
 // SetSessionIDCallback sets a callback that is called when the server returns
-// a session ID in the X-Muster-Session-ID response header. This enables
+// a session ID in the Mcp-Session-Id response header. This enables
 // the client to persist server-issued session IDs for future requests.
 func (c *Client) SetSessionIDCallback(cb func(sessionID string)) {
 	c.mu.Lock()

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -199,6 +199,17 @@ func (a *AggregatorServer) Start(ctx context.Context) error {
 		serverVersion = "dev"
 	}
 
+	// Create hooks for proactive SSO via OnAfterInitialize.
+	// When a client completes the MCP initialize handshake, trigger proactive SSO
+	// to automatically connect SSO-enabled servers using the user's ID token.
+	hooks := &mcpserver.Hooks{}
+	hooks.AddAfterInitialize(func(ctx context.Context, id any, msg *mcp.InitializeRequest, result *mcp.InitializeResult) {
+		session := mcpserver.ClientSessionFromContext(ctx)
+		if session != nil {
+			go a.handleSessionInit(ctx, session.SessionID())
+		}
+	})
+
 	// Create MCP server with full capabilities enabled
 	// WithToolFilter enables session-specific tool visibility for OAuth-authenticated servers
 	// (see ADR-006: Session-Scoped Tool Visibility)
@@ -209,6 +220,7 @@ func (a *AggregatorServer) Start(ctx context.Context) error {
 		mcpserver.WithResourceCapabilities(true, true), // Enable resources with subscribe and listChanged
 		mcpserver.WithPromptCapabilities(true),         // Enable prompt retrieval
 		mcpserver.WithToolFilter(a.sessionToolFilter),  // Return session-specific tools for OAuth servers
+		mcpserver.WithHooks(hooks),                     // Proactive SSO on client initialize
 	)
 
 	a.mcpServer = mcpSrv
@@ -340,7 +352,11 @@ func (a *AggregatorServer) Start(ctx context.Context) error {
 		fallthrough
 	default:
 		// Streamable HTTP transport (default) - HTTP-based streaming protocol
-		a.streamableHTTPServer = mcpserver.NewStreamableHTTPServer(a.mcpServer)
+		sessionIdManager := NewMusterSessionIdManager(a.sessionRegistry)
+		a.streamableHTTPServer = mcpserver.NewStreamableHTTPServer(a.mcpServer,
+			mcpserver.WithSessionIdManager(sessionIdManager),
+			mcpserver.WithHTTPContextFunc(a.httpContextFunc),
+		)
 
 		// Create a mux that routes to both MCP and OAuth handlers
 		handler, err := a.createHTTPMux(a.streamableHTTPServer)
@@ -845,9 +861,9 @@ func (a *AggregatorServer) createStandardMux(mcpHandler http.Handler) http.Handl
 	// Session invalidation endpoint for client-initiated logout
 	mux.HandleFunc("DELETE /session", a.handleSessionInvalidation)
 
-	// Mount the MCP handler as the default for all other paths
-	// Wrap with clientSessionIDMiddleware to enable server-side session lifecycle
-	mux.Handle("/", a.clientSessionIDMiddleware(mcpHandler))
+	// Mount the MCP handler as the default for all other paths.
+	// Session lifecycle is managed by mcp-go's SessionIdManager (MusterSessionIdManager).
+	mux.Handle("/", mcpHandler)
 
 	return mux
 }
@@ -865,11 +881,9 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 		return nil, fmt.Errorf("invalid OAuth server config type: expected OAuthServerConfig")
 	}
 
-	// Wrap the MCP handler with clientSessionIDMiddleware to enable server-side session lifecycle
-	// This must be done before OAuth middleware so the session ID is available in context
-	wrappedHandler := a.clientSessionIDMiddleware(mcpHandler)
-
-	oauthHTTPServer, err := server.NewOAuthHTTPServer(cfg, wrappedHandler, a.config.Debug)
+	// Session lifecycle is managed by mcp-go's SessionIdManager (MusterSessionIdManager).
+	// The mcpHandler already has session management wired via WithSessionIdManager.
+	oauthHTTPServer, err := server.NewOAuthHTTPServer(cfg, mcpHandler, a.config.Debug)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OAuth HTTP server: %w", err)
 	}
@@ -1733,176 +1747,40 @@ const defaultSessionID = "default-session"
 
 // getSessionIDFromContext extracts the session ID from context.
 //
-// Session ID precedence (first match wins):
-//  1. Client-provided session ID via X-Muster-Session-ID header (enables CLI persistence)
-//  2. MCP session ID from mcp-go library (per-connection, random UUID)
-//  3. Default session ID for stdio transport (single-user mode)
-//
-// The client-provided session ID (via header) is critical for CLI tools where each
-// invocation creates a new connection. Without it, MCP server tokens would be lost
-// between CLI invocations because the mcp-go session ID changes on each connection.
-// See ADR-004 for the design rationale.
-//
-// SECURITY: The client-provided session ID is trusted because:
-//   - It's sent by the authenticated CLI client (aggregator auth validates the user)
-//   - Token lookup still requires matching (sessionID, issuer, scope)
-//   - A malicious client can only access tokens it previously stored with that session ID
+// Uses mcp-go's native Mcp-Session-Id (set by the library) as the primary source.
+// Falls back to the default session ID for stdio transport (single-user mode).
 func getSessionIDFromContext(ctx context.Context) string {
-	// 1. Check for client-provided session ID (CLI persistence)
-	if clientSessionID, ok := api.GetClientSessionIDFromContext(ctx); ok {
-		return clientSessionID
-	}
-
-	// 2. Try to get session ID from MCP client session (set by mcp-go library)
 	if session := mcpserver.ClientSessionFromContext(ctx); session != nil {
-		sessionID := session.SessionID()
-		if sessionID != "" {
-			return sessionID
+		if id := session.SessionID(); id != "" {
+			return id
 		}
 	}
 
-	// 3. Fall back to default session ID for stdio transport only.
-	// This is a security limitation for stdio which is inherently single-user.
-	// For HTTP transports (SSE/Streamable HTTP), the mcp-go library always provides
-	// a unique session ID, so this fallback should only trigger for stdio.
+	// Fall back to default session ID for stdio transport only.
+	// For HTTP transports, mcp-go always provides a session ID.
 	logging.Warn("OAuth", "No MCP session in context, using default session (stdio mode). "+
 		"Token isolation is not enforced for stdio transport.")
 	return defaultSessionID
 }
 
-// clientSessionIDMiddleware handles server-side session ID lifecycle.
+// httpContextFunc is passed to mcp-go's WithHTTPContextFunc to inject
+// identity binding per-request. It runs after mcp-go has set the session in
+// context but before the MCP handler processes the request.
 //
-// For every authenticated request, it:
-//  1. Validates the client-provided X-Muster-Session-ID (if any)
-//  2. Creates a new server-side session if none exists or the provided ID is unknown
-//  3. Validates identity binding (session must match authenticated user)
-//  4. Sets the X-Muster-Session-ID response header on every response
-//
-// Edge case handling:
-//   - No session ID header: Create new session, return ID in response header
-//   - Valid session ID, matching identity: Reuse session
-//   - Valid session ID, different identity: Reject with 403
-//   - Unknown session ID (not in store): Create new session, return new ID (with warning)
-//   - Malformed session ID (not UUID): Reject with 400
-//   - Session ID exceeds max length: Reject with 400
-func (a *AggregatorServer) clientSessionIDMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		clientSessionID := r.Header.Get(api.ClientSessionIDHeader)
-
-		// Extract authenticated subject from context (set by OAuth ValidateToken middleware).
-		// For unprotected endpoints, subject will be empty and identity binding is skipped.
-		subject := api.GetSubjectFromContext(r.Context())
-
-		var sessionID string
-
-		switch {
-		case clientSessionID == "":
-			// No session ID: create a new server-side session
-			session, err := a.sessionRegistry.CreateSessionForSubject(subject)
-			if err != nil {
-				logging.Warn("Aggregator", "Failed to create session: %v", err)
-				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
-				return
-			}
-			sessionID = session.SessionID
-			logging.Debug("Aggregator", "Created new server-side session: %s", logging.TruncateSessionID(sessionID))
-
-		case len(clientSessionID) > MaxSessionIDLength:
-			// Session ID exceeds max length: reject before running regex
-			logging.Warn("Aggregator", "Rejected oversized session ID (length %d)", len(clientSessionID))
-			http.Error(w, "Bad Request: session ID too long", http.StatusBadRequest)
-			return
-
-		case !IsValidUUIDv4(clientSessionID):
-			// Malformed session ID (not UUID v4 format): reject with 400
-			logging.Warn("Aggregator", "Rejected malformed session ID (not UUID v4): %s",
-				logging.TruncateSessionID(clientSessionID))
-			http.Error(w, "Bad Request: malformed session ID (expected UUID v4 format)", http.StatusBadRequest)
-			return
-
-		default:
-			// Client provided a UUID v4 session ID: validate it
-			if err := ValidateSessionID(clientSessionID); err != nil {
-				logging.Warn("Aggregator", "Rejected invalid session ID: %v", err)
-				http.Error(w, "Bad Request: "+err.Error(), http.StatusBadRequest)
-				return
-			}
-
-			session, exists := a.sessionRegistry.GetSession(clientSessionID)
-			if !exists {
-				// Unknown session ID (not in store): deduplicate both the warning
-				// and session creation across concurrent requests with the same
-				// stale ID. sync.Once ensures the session is created exactly once;
-				// concurrent and slightly-late requests share the cached result. (#435)
-				//
-				// Size cap: if the dedup map is too large (possible DoS via unique
-				// stale IDs), skip dedup and create the session directly.
-				if a.staleSessionDedupCount.Load() >= staleSessionDedupMaxEntries {
-					logging.Warn("Aggregator", "Unknown session ID %s (not in server store), issuing new session (dedup map full)",
-						logging.TruncateSessionID(clientSessionID))
-					newSession, createErr := a.sessionRegistry.CreateSessionForSubject(subject)
-					if createErr != nil {
-						logging.Warn("Aggregator", "Failed to create session: %v", createErr)
-						http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
-						return
-					}
-					sessionID = newSession.SessionID
-				} else {
-					val, loaded := a.staleSessionDedup.LoadOrStore(clientSessionID, &staleSessionEntry{createdAt: time.Now()})
-					entry := val.(*staleSessionEntry)
-					if !loaded {
-						a.staleSessionDedupCount.Add(1)
-					}
-					// sync.Once ensures only one goroutine creates the session.
-					// If creation fails (e.g., session limit exceeded), the error
-					// is cached for the lifetime of this entry (staleSessionDedupTTL).
-					// Concurrent requests sharing this entry will receive the same
-					// error. This is acceptable because the TTL is short (5s) and
-					// the underlying condition (session limit) is unlikely to clear
-					// within that window.
-					entry.once.Do(func() {
-						logging.Warn("Aggregator", "Unknown session ID %s (not in server store), issuing new session",
-							logging.TruncateSessionID(clientSessionID))
-						newSession, createErr := a.sessionRegistry.CreateSessionForSubject(subject)
-						if createErr != nil {
-							entry.err = createErr
-							return
-						}
-						entry.sessionID = newSession.SessionID
-					})
-
-					if entry.err != nil {
-						logging.Warn("Aggregator", "Failed to create session: %v", entry.err)
-						http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
-						return
-					}
-					sessionID = entry.sessionID
-				}
-			} else {
-				// Session exists: validate identity binding
-				if subject != "" {
-					if err := a.sessionRegistry.ValidateSessionIdentity(clientSessionID, subject); err != nil {
-						if _, ok := err.(*SessionIdentityMismatchError); ok {
-							logging.Warn("Aggregator", "Session identity mismatch: %v", err)
-							http.Error(w, "Forbidden: session identity mismatch - clear your session and re-authenticate", http.StatusForbidden)
-							return
-						}
-					}
-				}
-				sessionID = session.SessionID
-				session.UpdateActivity()
+// This binds the authenticated user's subject (from OAuth middleware) to the
+// mcp-go session, replacing the identity binding that was previously done in
+// clientSessionIDMiddleware.
+func (a *AggregatorServer) httpContextFunc(ctx context.Context, r *http.Request) context.Context {
+	subject := api.GetSubjectFromContext(ctx)
+	session := mcpserver.ClientSessionFromContext(ctx)
+	if session != nil && subject != "" {
+		if err := a.sessionRegistry.ValidateSessionIdentity(session.SessionID(), subject); err != nil {
+			if _, ok := err.(*SessionIdentityMismatchError); ok {
+				logging.Warn("Aggregator", "Session identity mismatch: %v", err)
 			}
 		}
-
-		// Set the session ID in the response header on every authenticated response
-		w.Header().Set(api.ClientSessionIDHeader, sessionID)
-
-		// Add session ID to context for downstream handlers
-		ctx := api.WithClientSessionID(r.Context(), sessionID)
-		r = r.WithContext(ctx)
-
-		next.ServeHTTP(w, r)
-	})
+	}
+	return ctx
 }
 
 // startStaleSessionDedupCleanup runs a background goroutine that periodically
@@ -1943,7 +1821,7 @@ func (a *AggregatorServer) cleanupStaleSessionDedup() {
 }
 
 // handleSessionInvalidation handles DELETE /session requests for client-initiated logout.
-// The client sends the session ID via the X-Muster-Session-ID header.
+// The client sends the session ID via the Mcp-Session-Id header.
 // The server deletes the session from the registry and closes all connections.
 //
 // This endpoint does not require OAuth authentication because:

--- a/internal/aggregator/session_id_manager.go
+++ b/internal/aggregator/session_id_manager.go
@@ -1,0 +1,77 @@
+package aggregator
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// MusterSessionIdManager implements mcpserver.SessionIdManager to bridge
+// muster's SessionRegistry into mcp-go's session lifecycle.
+//
+// This replaces the custom X-Muster-Session-ID header with mcp-go's native
+// Mcp-Session-Id session mechanism, while preserving muster's session registry
+// features (identity binding, OAuth token storage, proactive SSO).
+//
+// Generate() creates a new session in the registry (subject bound later via httpContextFunc).
+// Validate() checks whether the session exists or has been terminated.
+// Terminate() removes the session from the registry.
+type MusterSessionIdManager struct {
+	registry *SessionRegistry
+}
+
+// NewMusterSessionIdManager creates a new session ID manager backed by the given registry.
+func NewMusterSessionIdManager(registry *SessionRegistry) *MusterSessionIdManager {
+	return &MusterSessionIdManager{registry: registry}
+}
+
+// Generate creates a new session in the registry and returns its ID.
+// The session is created without a subject; identity binding happens later
+// in httpContextFunc when the authenticated user's subject is available.
+func (m *MusterSessionIdManager) Generate() string {
+	session, err := m.registry.CreateSessionForSubject("")
+	if err != nil {
+		logging.Warn("SessionIdManager", "Failed to create session: %v", err)
+		// Return a generated ID anyway so the protocol doesn't break.
+		// The session won't be in the registry, but subsequent requests
+		// will get "session not found" errors which is better than a crash.
+		id, genErr := GenerateSessionID()
+		if genErr != nil {
+			return fmt.Sprintf("fallback-%d", 0) // extremely unlikely
+		}
+		return id
+	}
+	logging.Debug("SessionIdManager", "Generated new session: %s", logging.TruncateSessionID(session.SessionID))
+	return session.SessionID
+}
+
+// Validate checks if a session ID is valid and whether it has been terminated.
+// Returns (false, nil) if the session exists and is active.
+// Returns (true, nil) if the session ID format is valid but the session doesn't exist (terminated).
+// Returns (false, err) if the session ID format is invalid.
+func (m *MusterSessionIdManager) Validate(sessionID string) (isTerminated bool, err error) {
+	if err := ValidateSessionID(sessionID); err != nil {
+		return false, fmt.Errorf("invalid session ID: %w", err)
+	}
+
+	_, exists := m.registry.GetSession(sessionID)
+	if !exists {
+		// Session not in registry = terminated (or never existed, same effect)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Terminate removes a session from the registry, closing all its connections.
+// Returns (false, nil) on success.
+// Returns (false, err) if the session ID is invalid.
+func (m *MusterSessionIdManager) Terminate(sessionID string) (isNotAllowed bool, err error) {
+	if err := ValidateSessionID(sessionID); err != nil {
+		return false, fmt.Errorf("invalid session ID: %w", err)
+	}
+
+	m.registry.DeleteSession(sessionID)
+	logging.Info("SessionIdManager", "Terminated session: %s", logging.TruncateSessionID(sessionID))
+	return false, nil
+}

--- a/internal/aggregator/session_id_manager.go
+++ b/internal/aggregator/session_id_manager.go
@@ -9,9 +9,9 @@ import (
 // MusterSessionIdManager implements mcpserver.SessionIdManager to bridge
 // muster's SessionRegistry into mcp-go's session lifecycle.
 //
-// This replaces the custom X-Muster-Session-ID header with mcp-go's native
-// Mcp-Session-Id session mechanism, while preserving muster's session registry
-// features (identity binding, OAuth token storage, proactive SSO).
+// It uses mcp-go's native Mcp-Session-Id session mechanism while preserving
+// muster's session registry features (identity binding, OAuth token storage,
+// proactive SSO).
 //
 // Generate() creates a new session in the registry (subject bound later via httpContextFunc).
 // Validate() checks whether the session exists or has been terminated.

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -62,12 +62,12 @@ type AuthHandler interface {
 
 	// GetSessionIDForEndpoint returns the server-issued session ID for the given endpoint.
 	// Session IDs are scoped per-endpoint and stored locally after being received
-	// from the server's X-Muster-Session-ID response header.
+	// from the server's Mcp-Session-Id response header.
 	// Returns empty string if no session ID exists for this endpoint.
 	GetSessionIDForEndpoint(endpoint string) string
 
 	// UpdateSessionID stores a server-issued session ID for the given endpoint.
-	// This is called after reading the X-Muster-Session-ID response header.
+	// This is called after reading the Mcp-Session-Id response header.
 	UpdateSessionID(endpoint, sessionID string)
 
 	// Close cleans up any resources held by the auth handler.

--- a/internal/api/constants.go
+++ b/internal/api/constants.go
@@ -2,51 +2,10 @@ package api
 
 import "context"
 
-// ClientSessionIDHeader is the HTTP header name for client-provided session IDs.
-// This enables CLI tools to maintain persistent session identity across invocations.
-//
-// When present, this header takes precedence over the random session ID generated
-// by mcp-go for token storage. This is critical for CLI tools where each invocation
-// creates a new connection - without it, MCP server tokens would be lost between
-// CLI invocations because the mcp-go session ID changes on each connection.
-//
-// Security: The client-provided session ID is trusted because:
-//   - It's sent by the authenticated CLI client (aggregator auth validates the user)
-//   - Token lookup still requires matching (sessionID, issuer, scope)
-//   - A malicious client can only access tokens it previously stored with that session ID
-const ClientSessionIDHeader = "X-Muster-Session-ID"
-
-// ClientSessionIDContextKey is the context key for storing client-provided session IDs.
-// This type is defined in the api package to ensure both the aggregator and server
-// packages use the same type identity when setting/getting context values.
-//
-// Usage:
-//
-//	// Setting the value (in middleware)
-//	ctx := context.WithValue(r.Context(), api.ClientSessionIDContextKey{}, sessionID)
-//
-//	// Getting the value
-//	if sessionID, ok := ctx.Value(api.ClientSessionIDContextKey{}).(string); ok {
-//	    // use sessionID
-//	}
-type ClientSessionIDContextKey struct{}
-
-// GetClientSessionIDFromContext extracts the client-provided session ID from context.
-// Returns the session ID and true if found, or empty string and false if not present.
-//
-// This is a convenience function that encapsulates the context key type assertion.
-func GetClientSessionIDFromContext(ctx context.Context) (string, bool) {
-	if sessionID, ok := ctx.Value(ClientSessionIDContextKey{}).(string); ok && sessionID != "" {
-		return sessionID, true
-	}
-	return "", false
-}
-
-// WithClientSessionID returns a new context with the client session ID set.
-// This is a convenience function for setting the session ID in context.
-func WithClientSessionID(ctx context.Context, sessionID string) context.Context {
-	return context.WithValue(ctx, ClientSessionIDContextKey{}, sessionID)
-}
+// ClientSessionIDHeader is the standard MCP session ID header.
+// This is the same header that mcp-go uses natively for session management.
+// Both the server and CLI clients use this header for session identification.
+const ClientSessionIDHeader = "Mcp-Session-Id"
 
 // SubjectContextKey is the context key for storing the authenticated user's subject claim.
 // This is set by the OAuth middleware after token validation and used by the session

--- a/internal/cli/auth_adapter.go
+++ b/internal/cli/auth_adapter.go
@@ -37,7 +37,7 @@ const DefaultConnectionCheckTimeout = 5 * time.Second
 const DefaultHTTPClientTimeout = 5 * time.Second
 
 // SessionIDFilename is the name of the file storing the persistent CLI session ID.
-// This session ID is used for X-Muster-Session-ID header to enable MCP server
+// This session ID is used for Mcp-Session-Id header to enable MCP server
 // token persistence across CLI invocations.
 const SessionIDFilename = "session-id"
 
@@ -114,7 +114,7 @@ func NewAuthAdapterWithConfig(cfg AuthAdapterConfig) (*AuthAdapter, error) {
 
 // Note: Client-side session ID generation has been removed.
 // Session IDs are now generated server-side and returned via the
-// X-Muster-Session-ID response header. See issue #414.
+// Mcp-Session-Id response header. See issue #414.
 
 // GetSessionID returns an empty string. Session IDs are now server-issued and per-endpoint.
 // Use GetSessionIDForEndpoint instead.

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -383,9 +383,10 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 // - Re-authentication (logout + login with new ID token)
 // - Token refresh (server-side refresh gets new access token)
 func (s *OAuthHTTPServer) triggerSessionInitIfNeeded(ctx context.Context, r *http.Request) {
-	// Get session ID from the request header directly.
-	// We can't rely on context here because clientSessionIDMiddleware runs
-	// AFTER this middleware in the chain (it wraps the MCP handler, not the OAuth chain).
+	// Get session ID from the Mcp-Session-Id request header.
+	// mcp-go's client transport sends this header on every request after initialize.
+	// We can't use ClientSessionFromContext here because mcp-go processes the
+	// request after this middleware in the chain.
 	sessionID := r.Header.Get(api.ClientSessionIDHeader)
 	if sessionID == "" {
 		logging.Debug("OAuth", "SSO: No session ID header, skipping session init")
@@ -464,7 +465,6 @@ func (s *OAuthHTTPServer) triggerSessionInitIfNeeded(ctx context.Context, r *htt
 		// This context won't be canceled when the HTTP request completes.
 		bgCtx := context.Background()
 		bgCtx = ContextWithIDToken(bgCtx, idToken)
-		bgCtx = api.WithClientSessionID(bgCtx, sessionID)
 
 		callback(bgCtx, sessionID)
 	}()

--- a/internal/testing/mcp_client.go
+++ b/internal/testing/mcp_client.go
@@ -38,7 +38,7 @@ func (s *testTokenStore) SaveToken(_ context.Context, token *transport.Token) er
 var _ transport.TokenStore = (*testTokenStore)(nil)
 
 // testSessionIDRoundTripper wraps an http.RoundTripper to track server-issued session IDs.
-// On each response, it reads the X-Muster-Session-ID header and stores the server's
+// On each response, it reads the Mcp-Session-Id header and stores the server's
 // authoritative session ID. On each request, it overrides the session ID header with
 // the server-issued value so that subsequent requests reuse the same server-side session.
 type testSessionIDRoundTripper struct {


### PR DESCRIPTION
### What does this PR do?

Migrates session management from a custom `X-Muster-Session-ID` header to mcp-go's built-in `Mcp-Session-Id` mechanism, as defined in the [MCP spec — Session Management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management). This replaces the hand-rolled `clientSessionIDMiddleware` with mcp-go's `SessionIdManager` interface (`MusterSessionIdManager`), uses `WithHTTPContextFunc` for identity binding, and `WithHooks` (OnAfterInitialize) for proactive SSO.

Key changes:
- **New `MusterSessionIdManager`** — implements `Generate`, `Validate`, `Terminate` backed by the existing `SessionRegistry`
- **Removed `clientSessionIDMiddleware`** — session lifecycle is now handled by mcp-go internally
- **Added `httpContextFunc`** — binds the authenticated user's subject to the mcp-go session (replaces identity binding from the old middleware)
- **Added `AfterInitialize` hook** — triggers proactive SSO when a client completes the MCP handshake
- **Header rename** — `X-Muster-Session-ID` → `Mcp-Session-Id` throughout (client, server, tests)
- **Removed `GetClientSessionIDFromContext` / `WithClientSessionID`** — no longer needed since mcp-go manages session context natively

### What is the effect of this change to users?

CLI clients will now use the standard `Mcp-Session-Id` header instead of the custom `X-Muster-Session-ID` header. Session persistence across CLI invocations continues to work — the client intercepts the `Mcp-Session-Id` response header and replays it on subsequent requests.

### Any background context you can provide?

The custom `X-Muster-Session-ID` header was introduced before mcp-go had native session management support. Now that mcp-go provides `SessionIdManager` and `WithHTTPContextFunc`, we can delegate session lifecycle to the library and remove ~50 lines of custom middleware.

### What is needed from the reviewers?

- Verify the `MusterSessionIdManager` correctly bridges the `SessionRegistry` into mcp-go's lifecycle
- Confirm identity binding via `httpContextFunc` is equivalent to the old middleware behavior
- Check that proactive SSO via `AfterInitialize` hook fires at the right time

### Testing

- [ ] New functionality is covered by unit/integration tests.
- [x] Existing tests have been updated to reflect changes.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)