### PR TITLE
feat: add standalone CapabilityCache for per-user MCP capabilities

### DIFF
--- a/internal/aggregator/capability_cache.go
+++ b/internal/aggregator/capability_cache.go
@@ -52,6 +52,7 @@ type CapabilityCache struct {
 	defaultTTL time.Duration
 	stopCh     chan struct{}
 	stopped    chan struct{}
+	stopOnce   sync.Once
 }
 
 // NewCapabilityCache creates a cache with the given default TTL and starts a
@@ -96,9 +97,9 @@ func (c *CapabilityCache) Set(subject, serverName string, tools []mcp.Tool, reso
 func (c *CapabilityCache) SetWithTTL(subject, serverName string, tools []mcp.Tool, resources []mcp.Resource, prompts []mcp.Prompt, ttl time.Duration) {
 	now := time.Now()
 	entry := &CacheEntry{
-		Tools:         tools,
-		Resources:     resources,
-		Prompts:       prompts,
+		Tools:         append([]mcp.Tool(nil), tools...),
+		Resources:     append([]mcp.Resource(nil), resources...),
+		Prompts:       append([]mcp.Prompt(nil), prompts...),
 		StoredAt:      now,
 		ExpiresAt:     now.Add(ttl),
 		graceDeadline: now.Add(2 * ttl),
@@ -143,12 +144,9 @@ func (c *CapabilityCache) Invalidate(subject, serverName string) {
 // Stop stops the background cleanup goroutine. It is safe to call multiple
 // times but only the first call has an effect.
 func (c *CapabilityCache) Stop() {
-	select {
-	case <-c.stopCh:
-		// Already stopped.
-	default:
+	c.stopOnce.Do(func() {
 		close(c.stopCh)
-	}
+	})
 	<-c.stopped
 }
 

--- a/internal/aggregator/capability_cache_test.go
+++ b/internal/aggregator/capability_cache_test.go
@@ -73,16 +73,11 @@ func TestCapabilityCache_TTLExpiry(t *testing.T) {
 	assert.True(t, entry.IsStale())
 	assert.Equal(t, "t1", entry.Tools[0].Name)
 
-	// Wait past grace period
-	time.Sleep(ttl + 10*time.Millisecond)
-
-	entry, ok = cache.Get("user1", "server1")
-	if ok {
-		// Entry might still be present if cleanup hasn't run yet,
-		// but it should no longer be stale (past grace).
-		assert.True(t, entry.IsExpired())
-		assert.False(t, entry.IsStale(), "entry past grace period should not be stale")
-	}
+	// After the grace period (2x TTL), the background cleanup should evict the entry.
+	require.Eventually(t, func() bool {
+		_, found := cache.Get("user1", "server1")
+		return !found
+	}, 5*time.Second, 5*time.Millisecond, "entry should be evicted after grace period")
 }
 
 func TestCapabilityCache_SetWithTTL(t *testing.T) {
@@ -215,11 +210,12 @@ func TestCapabilityCache_BackgroundCleanup(t *testing.T) {
 
 	cache.Set("user1", "server1", []mcp.Tool{{Name: "t1"}}, nil, nil)
 
-	// Wait for grace period (2x TTL) + cleanup interval (TTL/2) + buffer
-	time.Sleep(3*ttl + 20*time.Millisecond)
-
-	_, ok := cache.Get("user1", "server1")
-	assert.False(t, ok, "entry past grace period should be evicted by background cleanup")
+	// The grace period is 2x TTL. The cleanup goroutine runs every TTL/2.
+	// Use Eventually to avoid flakiness on slow CI runners.
+	require.Eventually(t, func() bool {
+		_, ok := cache.Get("user1", "server1")
+		return !ok
+	}, 5*time.Second, 5*time.Millisecond, "entry past grace period should be evicted by background cleanup")
 }
 
 func TestCapabilityCache_StopHaltsCleanup(t *testing.T) {


### PR DESCRIPTION
## Summary

- Implements `CapabilityCache` as an independent data structure that stores per-user, per-server MCP capabilities (tools, resources, prompts) with TTL-based expiry and stale-while-revalidate semantics
- Decouples capability caching from `SessionConnection` lifecycle, enabling Phase 2 to rewire tool/resource/prompt listing without N network round-trips
- Pure data structure with no wiring into existing code (Phase 1B)

Closes #442

## Approach

- Cache key is `{subject, serverName}` matching the future sub-based identity model
- `Get` returns expired entries for stale-while-revalidate; callers check `IsExpired()` / `IsStale()`
- Background goroutine evicts entries past the grace period (2x TTL), with `Stop()` using `sync.Once` to prevent double-close panics
- Defensive slice copies in `SetWithTTL` prevent caller mutation of cached data
- `sync.RWMutex` for thread safety
- No imports of `internal/oauth`, `SessionRegistry`, `SessionConnection`, or session-related types

## Self-review summary

Addressed findings from code review and security audit:
- **Fixed:** Race condition on concurrent `Stop()` calls -- replaced select/default with `sync.Once`
- **Fixed:** Mutable slice aliasing -- `SetWithTTL` now copies slices defensively
- **Fixed:** Flaky timing-based tests -- replaced `time.Sleep` assertions with `require.Eventually`
- **Deferred (out of scope):** Unbounded entry count (will be addressed when usage patterns are known in Phase 2), zero-TTL validation (constructor is internal)

## Test plan

- [x] Basic Get/Set round-trip
- [x] TTL expiry with stale-while-revalidate (entry returned as stale after TTL, evicted after grace)
- [x] SetWithTTL overrides default TTL
- [x] InvalidateUser removes all entries for a subject
- [x] InvalidateServer removes all entries for a server
- [x] Invalidate removes a specific user+server entry
- [x] Concurrent access (parallel Get/Set/Invalidate from multiple goroutines)
- [x] Background cleanup evicts entries past grace period
- [x] Stop() halts cleanup goroutine (no leak)
- [x] Get returns false for nonexistent keys
- [x] Set overwrites previous entries
- [x] CacheEntry.IsExpired / IsStale unit tests
- [x] `go vet ./internal/aggregator/...` passes
- [x] All 13 tests pass

Generated with [Claude Code](https://claude.com/claude-code)