### PR TITLE
fix: update stale SessionID references and truncate subject in handler logs

### DIFF
--- a/internal/oauth/doc.go
+++ b/internal/oauth/doc.go
@@ -35,10 +35,10 @@
 //
 // For persistent token storage in future versions, encryption would be required.
 //
-// ## Session Isolation
+// ## Subject Isolation
 //
 // Each MCP connection (SSE or Streamable HTTP) receives a unique UUID-based session ID
-// from the mcp-go library. Tokens are stored with a composite key of (SessionID, Issuer, Scope),
+// from the mcp-go library. Tokens are stored with a composite key of (Subject, Issuer, Scope),
 // ensuring complete isolation between users. User A cannot access User B's tokens.
 //
 // For stdio transport (single-user CLI), a default session ID is used. This is acceptable

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logging.Debug("OAuth", "Processing OAuth callback for subject=%s server=%s issuer=%s",
-		state.Subject, state.ServerName, state.Issuer)
+		logging.TruncateSessionID(state.Subject), state.ServerName, state.Issuer)
 
 	// Validate we have the required data stored with the state
 	if state.Issuer == "" {
@@ -109,7 +109,7 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	h.client.StoreToken(state.Subject, token)
 
 	logging.Info("OAuth", "Successfully authenticated subject=%s server=%s",
-		state.Subject, state.ServerName)
+		logging.TruncateSessionID(state.Subject), state.ServerName)
 
 	// Call the auth completion callback to establish session connection
 	if h.manager != nil {
@@ -122,7 +122,7 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 				// Log the error but don't fail the OAuth flow - the token is already stored
 				// and can be used on the next request
 				logging.Warn("OAuth", "Auth completion callback failed for subject=%s server=%s: %v",
-					state.Subject, state.ServerName, err)
+					logging.TruncateSessionID(state.Subject), state.ServerName, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #444 (rekey TokenStore from SessionID to Subject). Fixes two issues left over from the rekey:

- **doc.go**: Updated stale comment that still referenced `(SessionID, Issuer, Scope)` composite key — now says `(Subject, Issuer, Scope)`
- **handler.go**: Added `logging.TruncateSessionID()` to three log calls that were logging `state.Subject` without truncation, which could leak full session identifiers in log output

## Approach

Minimal text changes — doc comment update and wrapping three log arguments with the existing truncation helper.

Relates to #441

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/oauth/...` passes
- [x] Grep confirms no remaining stale `SessionID` field references in oauth package

🤖 Generated with [Claude Code](https://claude.com/claude-code)