### PR TITLE
refactor: rekey AuthRateLimiter from session ID to sub

### DIFF
--- a/internal/aggregator/auth_rate_limiter.go
+++ b/internal/aggregator/auth_rate_limiter.go
@@ -7,12 +7,12 @@ import (
 	"github.com/giantswarm/muster/pkg/logging"
 )
 
-// AuthRateLimiter provides per-session rate limiting for authentication operations.
-// This prevents OAuth flow abuse by limiting the number of auth attempts per session.
+// AuthRateLimiter provides per-user rate limiting for authentication operations.
+// This prevents OAuth flow abuse by limiting the number of auth attempts per user.
 //
 // Rate limiting is implemented using a sliding window approach:
-//   - Each session can make at most MaxAuthAttempts auth attempts within the time window
-//   - Attempts are tracked per session, not globally
+//   - Each user can make at most MaxAuthAttempts auth attempts within the time window
+//   - Attempts are tracked per user (sub claim), not globally
 //   - Old attempts are automatically cleaned up via a background goroutine
 //
 // Callers MUST call Stop() when done to prevent goroutine leaks.
@@ -20,11 +20,11 @@ type AuthRateLimiter struct {
 	mu sync.RWMutex
 
 	// Configuration
-	maxAttempts int           // Maximum attempts per session within the window
+	maxAttempts int           // Maximum attempts per user within the window
 	window      time.Duration // Time window for rate limiting
 
-	// Per-session attempt tracking
-	attempts map[string][]time.Time // sessionID -> list of attempt timestamps
+	// Per-user attempt tracking
+	attempts map[string][]time.Time // userID (sub claim) -> list of attempt timestamps
 
 	// Lifecycle management
 	stopCh chan struct{} // Closed to signal the cleanup goroutine to exit
@@ -32,7 +32,7 @@ type AuthRateLimiter struct {
 
 // AuthRateLimiterConfig holds configuration for the rate limiter.
 type AuthRateLimiterConfig struct {
-	// MaxAttempts is the maximum number of auth attempts per session within the window.
+	// MaxAttempts is the maximum number of auth attempts per user within the window.
 	// Default: 10 attempts
 	MaxAttempts int
 
@@ -72,16 +72,16 @@ func NewAuthRateLimiter(config AuthRateLimiterConfig) *AuthRateLimiter {
 	return rl
 }
 
-// Allow checks if an auth attempt is allowed for the given session.
+// Allow checks if an auth attempt is allowed for the given user.
 // If allowed, the attempt is recorded and true is returned.
 // If rate limited, false is returned and the attempt is NOT recorded.
 //
 // Args:
-//   - sessionID: The session making the auth attempt
+//   - userID: The user making the auth attempt (sub claim or session ID fallback)
 //   - serverName: The server being authenticated to (for logging)
 //
 // Returns true if the attempt is allowed, false if rate limited.
-func (rl *AuthRateLimiter) Allow(sessionID, serverName string) bool {
+func (rl *AuthRateLimiter) Allow(userID, serverName string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
@@ -89,7 +89,7 @@ func (rl *AuthRateLimiter) Allow(sessionID, serverName string) bool {
 	windowStart := now.Add(-rl.window)
 
 	// Get existing attempts and filter out old ones
-	existing := rl.attempts[sessionID]
+	existing := rl.attempts[userID]
 	var recent []time.Time
 	for _, t := range existing {
 		if t.After(windowStart) {
@@ -99,32 +99,32 @@ func (rl *AuthRateLimiter) Allow(sessionID, serverName string) bool {
 
 	// Check if we've exceeded the limit
 	if len(recent) >= rl.maxAttempts {
-		logging.Warn("AuthRateLimiter", "Rate limit exceeded for session %s attempting to auth to server %s (%d attempts in %v)",
-			logging.TruncateSessionID(sessionID), serverName, len(recent), rl.window)
+		logging.Warn("AuthRateLimiter", "Rate limit exceeded for user %s attempting to auth to server %s (%d attempts in %v)",
+			logging.TruncateSessionID(userID), serverName, len(recent), rl.window)
 		// Update the filtered list even though we're rejecting
-		rl.attempts[sessionID] = recent
+		rl.attempts[userID] = recent
 		return false
 	}
 
 	// Record this attempt
 	recent = append(recent, now)
-	rl.attempts[sessionID] = recent
+	rl.attempts[userID] = recent
 
-	logging.Debug("AuthRateLimiter", "Auth attempt allowed for session %s server %s (%d/%d attempts)",
-		logging.TruncateSessionID(sessionID), serverName, len(recent), rl.maxAttempts)
+	logging.Debug("AuthRateLimiter", "Auth attempt allowed for user %s server %s (%d/%d attempts)",
+		logging.TruncateSessionID(userID), serverName, len(recent), rl.maxAttempts)
 
 	return true
 }
 
-// RemainingAttempts returns the number of remaining auth attempts for a session.
-func (rl *AuthRateLimiter) RemainingAttempts(sessionID string) int {
+// RemainingAttempts returns the number of remaining auth attempts for a user.
+func (rl *AuthRateLimiter) RemainingAttempts(userID string) int {
 	rl.mu.RLock()
 	defer rl.mu.RUnlock()
 
 	now := time.Now()
 	windowStart := now.Add(-rl.window)
 
-	existing := rl.attempts[sessionID]
+	existing := rl.attempts[userID]
 	count := 0
 	for _, t := range existing {
 		if t.After(windowStart) {
@@ -139,14 +139,14 @@ func (rl *AuthRateLimiter) RemainingAttempts(sessionID string) int {
 	return remaining
 }
 
-// Reset clears all rate limiting state for a session.
+// Reset clears all rate limiting state for a user.
 // This can be called after successful authentication to reset the counter.
-func (rl *AuthRateLimiter) Reset(sessionID string) {
+func (rl *AuthRateLimiter) Reset(userID string) {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	delete(rl.attempts, sessionID)
-	logging.Debug("AuthRateLimiter", "Rate limit reset for session %s", logging.TruncateSessionID(sessionID))
+	delete(rl.attempts, userID)
+	logging.Debug("AuthRateLimiter", "Rate limit reset for user %s", logging.TruncateSessionID(userID))
 }
 
 // Stop terminates the background cleanup goroutine.
@@ -193,7 +193,7 @@ func (rl *AuthRateLimiter) Cleanup() {
 	now := time.Now()
 	windowStart := now.Add(-rl.window)
 
-	for sessionID, attempts := range rl.attempts {
+	for userID, attempts := range rl.attempts {
 		var recent []time.Time
 		for _, t := range attempts {
 			if t.After(windowStart) {
@@ -202,9 +202,9 @@ func (rl *AuthRateLimiter) Cleanup() {
 		}
 
 		if len(recent) == 0 {
-			delete(rl.attempts, sessionID)
+			delete(rl.attempts, userID)
 		} else {
-			rl.attempts[sessionID] = recent
+			rl.attempts[userID] = recent
 		}
 	}
 }

--- a/internal/aggregator/auth_rate_limiter_test.go
+++ b/internal/aggregator/auth_rate_limiter_test.go
@@ -1,7 +1,6 @@
 package aggregator
 
 import (
-	"sync"
 	"testing"
 	"time"
 )
@@ -45,12 +44,12 @@ func TestAuthRateLimiter_Allow(t *testing.T) {
 			})
 			defer rl.Stop()
 
-			sessionID := "test-session-123"
+			userID := "test-user-123"
 			serverName := "test-server"
 			allowed := 0
 
 			for i := 0; i < tt.attempts; i++ {
-				if rl.Allow(sessionID, serverName) {
+				if rl.Allow(userID, serverName) {
 					allowed++
 				}
 			}
@@ -69,30 +68,30 @@ func TestAuthRateLimiter_RemainingAttempts(t *testing.T) {
 	})
 	defer rl.Stop()
 
-	sessionID := "test-session-123"
+	userID := "test-user-123"
 	serverName := "test-server"
 
 	// Initially should have all attempts remaining
-	if got := rl.RemainingAttempts(sessionID); got != 5 {
+	if got := rl.RemainingAttempts(userID); got != 5 {
 		t.Errorf("RemainingAttempts() = %d, want 5", got)
 	}
 
 	// Use 3 attempts
 	for i := 0; i < 3; i++ {
-		rl.Allow(sessionID, serverName)
+		rl.Allow(userID, serverName)
 	}
 
 	// Should have 2 remaining
-	if got := rl.RemainingAttempts(sessionID); got != 2 {
+	if got := rl.RemainingAttempts(userID); got != 2 {
 		t.Errorf("RemainingAttempts() = %d, want 2", got)
 	}
 
 	// Use remaining 2
-	rl.Allow(sessionID, serverName)
-	rl.Allow(sessionID, serverName)
+	rl.Allow(userID, serverName)
+	rl.Allow(userID, serverName)
 
 	// Should have 0 remaining
-	if got := rl.RemainingAttempts(sessionID); got != 0 {
+	if got := rl.RemainingAttempts(userID); got != 0 {
 		t.Errorf("RemainingAttempts() = %d, want 0", got)
 	}
 }
@@ -104,56 +103,56 @@ func TestAuthRateLimiter_Reset(t *testing.T) {
 	})
 	defer rl.Stop()
 
-	sessionID := "test-session-123"
+	userID := "test-user-123"
 	serverName := "test-server"
 
 	// Use all attempts
 	for i := 0; i < 3; i++ {
-		rl.Allow(sessionID, serverName)
+		rl.Allow(userID, serverName)
 	}
 
 	// Should be blocked
-	if rl.Allow(sessionID, serverName) {
+	if rl.Allow(userID, serverName) {
 		t.Error("Allow() should return false when rate limited")
 	}
 
 	// Reset
-	rl.Reset(sessionID)
+	rl.Reset(userID)
 
 	// Should be allowed again
-	if !rl.Allow(sessionID, serverName) {
+	if !rl.Allow(userID, serverName) {
 		t.Error("Allow() should return true after reset")
 	}
 
 	// Should have remaining attempts
-	if got := rl.RemainingAttempts(sessionID); got != 2 {
+	if got := rl.RemainingAttempts(userID); got != 2 {
 		t.Errorf("RemainingAttempts() = %d, want 2 after reset and one attempt", got)
 	}
 }
 
-func TestAuthRateLimiter_PerSessionIsolation(t *testing.T) {
+func TestAuthRateLimiter_PerUserIsolation(t *testing.T) {
 	rl := NewAuthRateLimiter(AuthRateLimiterConfig{
 		MaxAttempts: 2,
 		Window:      time.Minute,
 	})
 	defer rl.Stop()
 
-	session1 := "session-1"
-	session2 := "session-2"
+	user1 := "user-1"
+	user2 := "user-2"
 	serverName := "test-server"
 
-	// Use all attempts for session1
-	rl.Allow(session1, serverName)
-	rl.Allow(session1, serverName)
+	// Use all attempts for user1
+	rl.Allow(user1, serverName)
+	rl.Allow(user1, serverName)
 
-	// session1 should be blocked
-	if rl.Allow(session1, serverName) {
-		t.Error("session1 should be rate limited")
+	// user1 should be blocked
+	if rl.Allow(user1, serverName) {
+		t.Error("user1 should be rate limited")
 	}
 
-	// session2 should still be allowed (independent rate limiting)
-	if !rl.Allow(session2, serverName) {
-		t.Error("session2 should not be affected by session1's rate limiting")
+	// user2 should still be allowed (independent rate limiting)
+	if !rl.Allow(user2, serverName) {
+		t.Error("user2 should not be affected by user1's rate limiting")
 	}
 }
 
@@ -164,12 +163,12 @@ func TestAuthRateLimiter_Cleanup(t *testing.T) {
 	})
 	defer rl.Stop()
 
-	sessionID := "test-session-123"
+	userID := "test-user-123"
 	serverName := "test-server"
 
 	// Make some attempts
 	for i := 0; i < 3; i++ {
-		rl.Allow(sessionID, serverName)
+		rl.Allow(userID, serverName)
 	}
 
 	// Wait for window to expire
@@ -179,7 +178,7 @@ func TestAuthRateLimiter_Cleanup(t *testing.T) {
 	rl.Cleanup()
 
 	// Should have all attempts available again
-	if got := rl.RemainingAttempts(sessionID); got != 5 {
+	if got := rl.RemainingAttempts(userID); got != 5 {
 		t.Errorf("RemainingAttempts() = %d, want 5 after cleanup", got)
 	}
 }
@@ -222,16 +221,16 @@ func TestAuthRateLimiter_CleanupGoroutine(t *testing.T) {
 	})
 	defer rl.Stop()
 
-	sessionID := "goroutine-test-session"
+	userID := "goroutine-test-user"
 	serverName := "test-server"
 
 	// Record some attempts
 	for i := 0; i < 3; i++ {
-		rl.Allow(sessionID, serverName)
+		rl.Allow(userID, serverName)
 	}
 
 	// Verify attempts were recorded
-	if got := rl.RemainingAttempts(sessionID); got != 2 {
+	if got := rl.RemainingAttempts(userID); got != 2 {
 		t.Fatalf("RemainingAttempts() = %d, want 2", got)
 	}
 
@@ -239,7 +238,7 @@ func TestAuthRateLimiter_CleanupGoroutine(t *testing.T) {
 	time.Sleep(1500 * time.Millisecond)
 
 	// The background goroutine should have cleaned up the stale entries
-	if got := rl.RemainingAttempts(sessionID); got != 5 {
+	if got := rl.RemainingAttempts(userID); got != 5 {
 		t.Errorf("RemainingAttempts() = %d after cleanup goroutine ran, want 5", got)
 	}
 }
@@ -253,59 +252,4 @@ func TestAuthRateLimiter_StopIsIdempotent(t *testing.T) {
 	// Calling Stop multiple times should not panic
 	rl.Stop()
 	rl.Stop()
-}
-
-func TestSessionRegistry_OnSessionRemoved_DeleteSession(t *testing.T) {
-	sr := NewSessionRegistryWithLimits(30*time.Minute, 100)
-	defer sr.Stop()
-
-	var removedIDs []string
-	sr.SetOnSessionRemoved(func(sessionID string) {
-		removedIDs = append(removedIDs, sessionID)
-	})
-
-	// Create a session
-	session := sr.GetOrCreateSession("test-session-1")
-	if session == nil {
-		t.Fatal("GetOrCreateSession returned nil")
-	}
-
-	// Delete it
-	sr.DeleteSession("test-session-1")
-
-	// Callback should have been invoked
-	if len(removedIDs) != 1 || removedIDs[0] != "test-session-1" {
-		t.Errorf("onSessionRemoved called with %v, want [test-session-1]", removedIDs)
-	}
-}
-
-func TestSessionRegistry_OnSessionRemoved_Cleanup(t *testing.T) {
-	// Use a very short timeout so cleanup fires quickly
-	sr := NewSessionRegistryWithLimits(10*time.Millisecond, 100)
-	defer sr.Stop()
-
-	var mu sync.Mutex
-	var removedIDs []string
-	sr.SetOnSessionRemoved(func(sessionID string) {
-		mu.Lock()
-		removedIDs = append(removedIDs, sessionID)
-		mu.Unlock()
-	})
-
-	// Create a session
-	session := sr.GetOrCreateSession("cleanup-test-session")
-	if session == nil {
-		t.Fatal("GetOrCreateSession returned nil")
-	}
-
-	// Wait for session to expire and cleanup to run
-	// Cleanup interval = sessionTimeout/2 = 5ms, but clamped to minCleanupInterval (1s)
-	time.Sleep(1500 * time.Millisecond)
-
-	// Callback should have been invoked for the expired session
-	mu.Lock()
-	defer mu.Unlock()
-	if len(removedIDs) != 1 || removedIDs[0] != "cleanup-test-session" {
-		t.Errorf("onSessionRemoved called with %v, want [cleanup-test-session]", removedIDs)
-	}
 }

--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -80,7 +80,7 @@ func (p *AuthToolProvider) ExecuteTool(ctx context.Context, toolName string, arg
 // This implements the logic previously in handleSyntheticAuthTool, but as a core tool.
 //
 // Security features:
-//   - Rate limiting: Prevents OAuth flow abuse by limiting attempts per session
+//   - Rate limiting: Prevents OAuth flow abuse by limiting attempts per user
 //   - Metrics: Tracks login attempts, successes, and failures for monitoring
 func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	serverName, ok := args["server"].(string)
@@ -91,17 +91,23 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 		}, nil
 	}
 
-	// Get session ID early for rate limiting and metrics
+	// Get session ID early for metrics and session registry calls
 	sessionID := getSessionIDFromContext(ctx)
 
+	// Derive userID for rate limiter: prefer the OAuth sub claim, fall back to sessionID for stdio
+	userID := api.GetSubjectFromContext(ctx)
+	if userID == "" {
+		userID = sessionID // fallback for stdio/unauthenticated requests
+	}
+
 	// Check rate limit before processing
-	if p.aggregator.authRateLimiter != nil && !p.aggregator.authRateLimiter.Allow(sessionID, serverName) {
+	if p.aggregator.authRateLimiter != nil && !p.aggregator.authRateLimiter.Allow(userID, serverName) {
 		if p.aggregator.authMetrics != nil {
 			p.aggregator.authMetrics.RecordRateLimitBlock(serverName, sessionID)
 		}
 		remaining := 0
 		if p.aggregator.authRateLimiter != nil {
-			remaining = p.aggregator.authRateLimiter.RemainingAttempts(sessionID)
+			remaining = p.aggregator.authRateLimiter.RemainingAttempts(userID)
 		}
 		return &api.CallToolResult{
 			Content: []interface{}{fmt.Sprintf(
@@ -206,7 +212,7 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 			p.aggregator.authMetrics.RecordLoginSuccess(serverName, sessionID)
 		}
 		if p.aggregator.authRateLimiter != nil {
-			p.aggregator.authRateLimiter.Reset(sessionID)
+			p.aggregator.authRateLimiter.Reset(userID)
 		}
 		return result, nil
 	} else if ShouldUseTokenForwarding(serverInfo) {
@@ -237,7 +243,7 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 			p.aggregator.authMetrics.RecordLoginSuccess(serverName, sessionID)
 		}
 		if p.aggregator.authRateLimiter != nil {
-			p.aggregator.authRateLimiter.Reset(sessionID)
+			p.aggregator.authRateLimiter.Reset(userID)
 		}
 		return result, nil
 	}
@@ -315,12 +321,12 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 		// Try to establish connection using the existing token
 		connectResult, connectErr := p.tryConnectWithToken(ctx, sessionID, serverName, serverInfo.URL, authInfo.Issuer, authInfo.Scope, token.AccessToken)
 		if connectErr == nil {
-			// Record success and reset rate limiter for this session
+			// Record success and reset rate limiter for this user
 			if p.aggregator.authMetrics != nil {
 				p.aggregator.authMetrics.RecordLoginSuccess(serverName, sessionID)
 			}
 			if p.aggregator.authRateLimiter != nil {
-				p.aggregator.authRateLimiter.Reset(sessionID)
+				p.aggregator.authRateLimiter.Reset(userID)
 			}
 			return connectResult, nil
 		}

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -138,12 +138,6 @@ func NewAggregatorServer(aggConfig AggregatorConfig, errorCallback func(error)) 
 	rateLimiter := NewAuthRateLimiter(DefaultAuthRateLimiterConfig())
 	sessionReg := NewSessionRegistry(DefaultSessionTimeout)
 
-	// When a session is removed, also clean up its rate limiter entries to prevent
-	// unbounded growth of the attempts map (see #426).
-	sessionReg.SetOnSessionRemoved(func(sessionID string) {
-		rateLimiter.Reset(sessionID)
-	})
-
 	return &AggregatorServer{
 		config:          aggConfig,
 		registry:        NewServerRegistry(aggConfig.MusterPrefix),

--- a/internal/aggregator/session_registry_test.go
+++ b/internal/aggregator/session_registry_test.go
@@ -1123,6 +1123,61 @@ func TestCreateSessionForSubject_SessionLimit(t *testing.T) {
 	}
 }
 
+func TestSessionRegistry_OnSessionRemoved_DeleteSession(t *testing.T) {
+	sr := NewSessionRegistryWithLimits(30*time.Minute, 100)
+	defer sr.Stop()
+
+	var removedIDs []string
+	sr.SetOnSessionRemoved(func(sessionID string) {
+		removedIDs = append(removedIDs, sessionID)
+	})
+
+	// Create a session
+	session := sr.GetOrCreateSession("test-session-1")
+	if session == nil {
+		t.Fatal("GetOrCreateSession returned nil")
+	}
+
+	// Delete it
+	sr.DeleteSession("test-session-1")
+
+	// Callback should have been invoked
+	if len(removedIDs) != 1 || removedIDs[0] != "test-session-1" {
+		t.Errorf("onSessionRemoved called with %v, want [test-session-1]", removedIDs)
+	}
+}
+
+func TestSessionRegistry_OnSessionRemoved_Cleanup(t *testing.T) {
+	// Use a very short timeout so cleanup fires quickly
+	sr := NewSessionRegistryWithLimits(10*time.Millisecond, 100)
+	defer sr.Stop()
+
+	var mu sync.Mutex
+	var removedIDs []string
+	sr.SetOnSessionRemoved(func(sessionID string) {
+		mu.Lock()
+		removedIDs = append(removedIDs, sessionID)
+		mu.Unlock()
+	})
+
+	// Create a session
+	session := sr.GetOrCreateSession("cleanup-test-session")
+	if session == nil {
+		t.Fatal("GetOrCreateSession returned nil")
+	}
+
+	// Wait for session to expire and cleanup to run
+	// Cleanup interval = sessionTimeout/2 = 5ms, but clamped to minCleanupInterval (1s)
+	time.Sleep(1500 * time.Millisecond)
+
+	// Callback should have been invoked for the expired session
+	mu.Lock()
+	defer mu.Unlock()
+	if len(removedIDs) != 1 || removedIDs[0] != "cleanup-test-session" {
+		t.Errorf("onSessionRemoved called with %v, want [cleanup-test-session]", removedIDs)
+	}
+}
+
 func TestValidateSessionIdentity(t *testing.T) {
 	sr := NewSessionRegistry(5 * time.Minute)
 	defer sr.Stop()


### PR DESCRIPTION
## Summary

- Rekey `AuthRateLimiter` from session ID to user identity (`sub` claim), closing a bypass where users could reset rate limits by creating new sessions
- Remove the `onSessionRemoved` callback wiring for the rate limiter -- entries now self-expire via the existing sliding window cleanup
- Move `TestSessionRegistry_OnSessionRemoved_*` tests to `session_registry_test.go` (they test the callback mechanism, not the rate limiter)

## Approach

In `handleAuthLogin`, a new `userID` variable is derived from `api.GetSubjectFromContext(ctx)` with fallback to `sessionID` for stdio/unauthenticated requests. Only rate limiter calls use `userID`; metrics and session registry calls continue using `sessionID` (those will be updated in Phase 3).

The `onSessionRemoved → rateLimiter.Reset(sessionID)` callback in `NewAggregatorServer` is removed. The chaining code in `initMCPServerWithOAuth` continues to work correctly -- `prevCallback` becomes `nil`, the guard skips it, and `DeleteSessionTrackerEntry` still fires.

Phase 1C of session ID elimination (#440).

Closes #447

## Test plan

- [x] All rate limiter tests pass with renamed user-identity variables
- [x] `TestAuthRateLimiter_PerUserIsolation` (renamed from `PerSessionIsolation`) passes
- [x] Moved `TestSessionRegistry_OnSessionRemoved_*` tests pass in their new location
- [x] Full `./internal/aggregator/` test suite passes
- [x] `go vet ./...` clean
- [x] Code reviewed by `base:code-reviewer` and `code-quality:security-auditor`