### PR TITLE
fix: use defaultUser fallback for CapabilityCache invalidation on stdio logout

### DIFF
--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -442,9 +442,14 @@ func (p *AuthToolProvider) handleAuthLogout(ctx context.Context, args map[string
 	}
 
 	// Invalidate CapabilityCache so that GetAllToolsForUser no longer returns
-	// cached tools for this server after logout.
+	// cached tools for this server after logout. Use the same defaultUser
+	// fallback that session_connection_helper uses when populating the cache,
+	// so stdio sessions (which have no OAuth sub claim) are correctly evicted.
 	sub := api.GetSubjectFromContext(ctx)
-	if sub != "" && p.aggregator.capabilityCache != nil {
+	if sub == "" {
+		sub = defaultUser
+	}
+	if p.aggregator.capabilityCache != nil {
 		p.aggregator.capabilityCache.Invalidate(sub, serverName)
 	}
 


### PR DESCRIPTION
## Summary

- Fix stale CapabilityCache entries surviving logout in stdio transport mode

## Approach

`handleAuthLogout` skipped cache invalidation when the OAuth subject was empty (stdio transport), but `session_connection_helper` populated the cache under the `"default-user"` key. This left stale tools visible after logout in stdio mode.

Mirrors the `defaultUser` fallback already used at cache population time so that stdio sessions are correctly evicted on logout. The HTTP logout paths (`DELETE /user-tokens`, `DELETE /auth/{server}`) are not affected because they 401 early when subject is empty.

Relates to #452

## Test plan

- [x] All aggregator unit tests pass
- [x] `oauth-sso-reconnect-after-relogin` integration test passes
- [x] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)