### PR TITLE
chore: add .klaus/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ logs
 /muster
 # Stress test results
 stress-test-results/
+# Klaus agent workspace
+.klaus/


### PR DESCRIPTION
## Summary

- Add `.klaus/` to `.gitignore` to prevent Klaus agent workspace files (e.g., `last-result.json`) from being tracked in the repository.

Closes #457

## Test plan

- Verified `.klaus/last-result.json` is not currently tracked in git.
- Confirmed `.gitignore` entry will match all files under `.klaus/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)