### PR TITLE
test: rename sessionID to subject in oauth tests (Phase 6)

### DIFF
--- a/internal/oauth/api_adapter_test.go
+++ b/internal/oauth/api_adapter_test.go
@@ -65,7 +65,7 @@ func TestAdapter_GetToken(t *testing.T) {
 	adapter := NewAdapter(manager)
 
 	// Initially nil
-	token := adapter.GetToken("session", "server")
+	token := adapter.GetToken("user@example.com", "server")
 	if token != nil {
 		t.Error("Expected nil token initially")
 	}
@@ -88,7 +88,7 @@ func TestAdapter_GetTokenByIssuer(t *testing.T) {
 	adapter := NewAdapter(manager)
 
 	// Initially nil
-	token := adapter.GetTokenByIssuer("session", "issuer")
+	token := adapter.GetTokenByIssuer("user@example.com", "issuer")
 	if token != nil {
 		t.Error("Expected nil token initially")
 	}
@@ -111,7 +111,7 @@ func TestAdapter_ClearTokenByIssuer(t *testing.T) {
 	adapter := NewAdapter(manager)
 
 	issuer := "https://auth.example.com"
-	sessionID := "session-123"
+	subject := "user-123"
 
 	// Store a token directly
 	testToken := &pkgoauth.Token{
@@ -121,19 +121,19 @@ func TestAdapter_ClearTokenByIssuer(t *testing.T) {
 		Scope:       "openid",
 		Issuer:      issuer,
 	}
-	manager.client.StoreToken(sessionID, testToken)
+	manager.client.StoreToken(subject, testToken)
 
 	// Verify token exists
-	token := adapter.GetTokenByIssuer(sessionID, issuer)
+	token := adapter.GetTokenByIssuer(subject, issuer)
 	if token == nil {
 		t.Fatal("Expected token before clearing")
 	}
 
 	// Clear the token via adapter
-	adapter.ClearTokenByIssuer(sessionID, issuer)
+	adapter.ClearTokenByIssuer(subject, issuer)
 
 	// Verify token is gone
-	token = adapter.GetTokenByIssuer(sessionID, issuer)
+	token = adapter.GetTokenByIssuer(subject, issuer)
 	if token != nil {
 		t.Error("Expected nil token after clearing")
 	}

--- a/internal/oauth/client_test.go
+++ b/internal/oauth/client_test.go
@@ -70,12 +70,12 @@ func TestClient_GetToken(t *testing.T) {
 	client := NewClient("client-id", "https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
 	defer client.Stop()
 
-	sessionID := "session-123"
+	subject := "user-123"
 	issuer := "https://auth.example.com"
 	scope := "openid profile"
 
 	// Initially no token
-	token := client.GetToken(sessionID, issuer, scope)
+	token := client.GetToken(subject, issuer, scope)
 	if token != nil {
 		t.Error("Expected nil token initially")
 	}
@@ -88,10 +88,10 @@ func TestClient_GetToken(t *testing.T) {
 		Scope:       scope,
 		Issuer:      issuer,
 	}
-	client.StoreToken(sessionID, testToken)
+	client.StoreToken(subject, testToken)
 
 	// Now should be retrievable
-	token = client.GetToken(sessionID, issuer, scope)
+	token = client.GetToken(subject, issuer, scope)
 	if token == nil {
 		t.Fatal("Expected token after storing")
 	}
@@ -105,7 +105,7 @@ func TestClient_GetToken_SSO_FallbackToIssuer(t *testing.T) {
 	client := NewClient("client-id", "https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
 	defer client.Stop()
 
-	sessionID := "session-123"
+	subject := "user-123"
 	issuer := "https://auth.example.com"
 	scope1 := "openid profile"
 	scope2 := "openid email" // Different scope
@@ -118,10 +118,10 @@ func TestClient_GetToken_SSO_FallbackToIssuer(t *testing.T) {
 		Scope:       scope1,
 		Issuer:      issuer,
 	}
-	client.StoreToken(sessionID, testToken)
+	client.StoreToken(subject, testToken)
 
 	// Request with scope2 should still find the token via SSO fallback
-	token := client.GetToken(sessionID, issuer, scope2)
+	token := client.GetToken(subject, issuer, scope2)
 	if token == nil {
 		t.Fatal("Expected token via SSO fallback")
 	}
@@ -254,7 +254,7 @@ func TestClient_GenerateAuthURL(t *testing.T) {
 	defer client.Stop()
 
 	ctx := context.Background()
-	authURL, err := client.GenerateAuthURL(ctx, "session-123", "mcp-kubernetes", server.URL, "openid profile")
+	authURL, err := client.GenerateAuthURL(ctx, "user-123", "mcp-kubernetes", server.URL, "openid profile")
 	if err != nil {
 		t.Fatalf("Failed to generate auth URL: %v", err)
 	}

--- a/internal/oauth/manager_test.go
+++ b/internal/oauth/manager_test.go
@@ -177,7 +177,7 @@ func TestManager_GetToken_NoServerConfig(t *testing.T) {
 	defer manager.Stop()
 
 	// No server registered, should return nil
-	token := manager.GetToken("session-123", "unknown-server")
+	token := manager.GetToken("user-123", "unknown-server")
 	if token != nil {
 		t.Error("Expected nil token for unknown server")
 	}
@@ -185,7 +185,7 @@ func TestManager_GetToken_NoServerConfig(t *testing.T) {
 
 func TestManager_GetToken_NilManager(t *testing.T) {
 	var manager *Manager
-	token := manager.GetToken("session", "server")
+	token := manager.GetToken("user@example.com", "server")
 	if token != nil {
 		t.Error("Expected nil token for nil manager")
 	}
@@ -193,7 +193,7 @@ func TestManager_GetToken_NilManager(t *testing.T) {
 
 func TestManager_GetTokenByIssuer_NilManager(t *testing.T) {
 	var manager *Manager
-	token := manager.GetTokenByIssuer("session", "issuer")
+	token := manager.GetTokenByIssuer("user@example.com", "issuer")
 	if token != nil {
 		t.Error("Expected nil token for nil manager")
 	}
@@ -239,7 +239,7 @@ func TestManager_GetToken_WithToken(t *testing.T) {
 	serverName := "mcp-kubernetes"
 	issuer := "https://auth.example.com"
 	scope := "openid profile"
-	sessionID := "session-123"
+	subject := "user-123"
 
 	// Register the server
 	manager.RegisterServer(serverName, issuer, scope)
@@ -252,10 +252,10 @@ func TestManager_GetToken_WithToken(t *testing.T) {
 		Scope:       scope,
 		Issuer:      issuer,
 	}
-	manager.client.StoreToken(sessionID, testToken)
+	manager.client.StoreToken(subject, testToken)
 
 	// Now GetToken should return the token
-	token := manager.GetToken(sessionID, serverName)
+	token := manager.GetToken(subject, serverName)
 	if token == nil {
 		t.Fatal("Expected token")
 	}
@@ -280,7 +280,7 @@ func TestManager_GetTokenByIssuer(t *testing.T) {
 	defer manager.Stop()
 
 	issuer := "https://auth.example.com"
-	sessionID := "session-123"
+	subject := "user-123"
 
 	// Store a token directly
 	testToken := &pkgoauth.Token{
@@ -290,10 +290,10 @@ func TestManager_GetTokenByIssuer(t *testing.T) {
 		Scope:       "openid",
 		Issuer:      issuer,
 	}
-	manager.client.StoreToken(sessionID, testToken)
+	manager.client.StoreToken(subject, testToken)
 
 	// GetTokenByIssuer should find it
-	token := manager.GetTokenByIssuer(sessionID, issuer)
+	token := manager.GetTokenByIssuer(subject, issuer)
 	if token == nil {
 		t.Fatal("Expected token")
 	}
@@ -318,7 +318,7 @@ func TestManager_ClearTokenByIssuer(t *testing.T) {
 	defer manager.Stop()
 
 	issuer := "https://auth.example.com"
-	sessionID := "session-123"
+	subject := "user-123"
 
 	// Store a token directly
 	testToken := &pkgoauth.Token{
@@ -328,19 +328,19 @@ func TestManager_ClearTokenByIssuer(t *testing.T) {
 		Scope:       "openid",
 		Issuer:      issuer,
 	}
-	manager.client.StoreToken(sessionID, testToken)
+	manager.client.StoreToken(subject, testToken)
 
 	// Verify token exists
-	token := manager.GetTokenByIssuer(sessionID, issuer)
+	token := manager.GetTokenByIssuer(subject, issuer)
 	if token == nil {
 		t.Fatal("Expected token before clearing")
 	}
 
 	// Clear the token
-	manager.ClearTokenByIssuer(sessionID, issuer)
+	manager.ClearTokenByIssuer(subject, issuer)
 
 	// Verify token is gone
-	token = manager.GetTokenByIssuer(sessionID, issuer)
+	token = manager.GetTokenByIssuer(subject, issuer)
 	if token != nil {
 		t.Error("Expected nil token after clearing")
 	}
@@ -349,7 +349,7 @@ func TestManager_ClearTokenByIssuer(t *testing.T) {
 func TestManager_ClearTokenByIssuer_NilManager(t *testing.T) {
 	var manager *Manager
 	// Should not panic
-	manager.ClearTokenByIssuer("session", "issuer")
+	manager.ClearTokenByIssuer("user@example.com", "issuer")
 }
 
 func TestManager_GetCIMDPath(t *testing.T) {
@@ -440,7 +440,7 @@ func TestManager_GetCIMDHandler_NilManager(t *testing.T) {
 func TestManager_CreateAuthChallenge_NilManager(t *testing.T) {
 	var manager *Manager
 	ctx := context.Background()
-	_, err := manager.CreateAuthChallenge(ctx, "session", "server", "", "")
+	_, err := manager.CreateAuthChallenge(ctx, "user@example.com", "server", "", "")
 	if err == nil {
 		t.Error("Expected error for nil manager")
 	}
@@ -496,7 +496,7 @@ func TestManager_CreateAuthChallenge(t *testing.T) {
 	scope := "openid profile"
 
 	ctx := context.Background()
-	_, err := manager.CreateAuthChallenge(ctx, "session-123", "mcp-server", issuer, scope)
+	_, err := manager.CreateAuthChallenge(ctx, "user-123", "mcp-server", issuer, scope)
 	// Expected to fail because the issuer doesn't return valid metadata
 	if err == nil {
 		// If it succeeds (unlikely), that's also fine

--- a/internal/oauth/state_store_test.go
+++ b/internal/oauth/state_store_test.go
@@ -11,13 +11,13 @@ func TestStateStore_GenerateAndValidate(t *testing.T) {
 	ss := NewStateStore()
 	defer ss.Stop()
 
-	sessionID := "session-123"
+	subject := "user-123"
 	serverName := "mcp-kubernetes"
 	issuer := "https://auth.example.com"
 	codeVerifier := "test-code-verifier-abc123"
 
 	// Generate state
-	encodedState, err := ss.GenerateState(sessionID, serverName, issuer, codeVerifier)
+	encodedState, err := ss.GenerateState(subject, serverName, issuer, codeVerifier)
 	if err != nil {
 		t.Fatalf("Failed to generate state: %v", err)
 	}
@@ -33,8 +33,8 @@ func TestStateStore_GenerateAndValidate(t *testing.T) {
 	}
 
 	// Verify state contents
-	if state.Subject != sessionID {
-		t.Errorf("Expected subject %q, got %q", sessionID, state.Subject)
+	if state.Subject != subject {
+		t.Errorf("Expected subject %q, got %q", subject, state.Subject)
 	}
 
 	if state.ServerName != serverName {
@@ -59,7 +59,7 @@ func TestStateStore_ValidateRemovesState(t *testing.T) {
 	ss := NewStateStore()
 	defer ss.Stop()
 
-	encodedState, err := ss.GenerateState("session", "server", "issuer", "verifier")
+	encodedState, err := ss.GenerateState("user@example.com", "server", "issuer", "verifier")
 	if err != nil {
 		t.Fatalf("Failed to generate state: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestStateStore_ValidateInvalidState(t *testing.T) {
 
 	// Test with valid JSON but non-existent nonce
 	fakeState := OAuthState{
-		Subject:    "session",
+		Subject:    "user@example.com",
 		ServerName: "server",
 		Nonce:      "non-existent-nonce",
 		CreatedAt:  time.Now(),
@@ -118,7 +118,7 @@ func TestStateStore_CodeVerifierNotInEncodedState(t *testing.T) {
 
 	codeVerifier := "super-secret-verifier"
 
-	encodedState, err := ss.GenerateState("session", "server", "issuer", codeVerifier)
+	encodedState, err := ss.GenerateState("user@example.com", "server", "issuer", codeVerifier)
 	if err != nil {
 		t.Fatalf("Failed to generate state: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestStateStore_Delete(t *testing.T) {
 	ss := NewStateStore()
 	defer ss.Stop()
 
-	encodedState, err := ss.GenerateState("session", "server", "issuer", "verifier")
+	encodedState, err := ss.GenerateState("user@example.com", "server", "issuer", "verifier")
 	if err != nil {
 		t.Fatalf("Failed to generate state: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestStateStore_Delete(t *testing.T) {
 	}
 
 	// Regenerate a new state for the delete test
-	encodedState2, err := ss.GenerateState("session", "server", "issuer", "verifier")
+	encodedState2, err := ss.GenerateState("user@example.com", "server", "issuer", "verifier")
 	if err != nil {
 		t.Fatalf("Failed to generate state: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestStateStore_UniqueNonces(t *testing.T) {
 
 	// Generate multiple states and verify nonces are unique
 	for i := 0; i < 100; i++ {
-		encodedState, err := ss.GenerateState("session", "server", "issuer", "verifier")
+		encodedState, err := ss.GenerateState("user@example.com", "server", "issuer", "verifier")
 		if err != nil {
 			t.Fatalf("Failed to generate state: %v", err)
 		}
@@ -219,7 +219,7 @@ func TestStateStore_Cleanup(t *testing.T) {
 	defer ss.Stop()
 
 	// Generate a state
-	_, err := ss.GenerateState("session", "server", "https://issuer.com", "verifier")
+	_, err := ss.GenerateState("user@example.com", "server", "https://issuer.com", "verifier")
 	if err != nil {
 		t.Fatalf("Failed to generate state: %v", err)
 	}

--- a/internal/oauth/token_store_test.go
+++ b/internal/oauth/token_store_test.go
@@ -12,7 +12,7 @@ func TestTokenStore_StoreAndGet(t *testing.T) {
 	defer ts.Stop()
 
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid profile",
 	}
@@ -64,7 +64,7 @@ func TestTokenStore_GetExpiredToken(t *testing.T) {
 	defer ts.Stop()
 
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid",
 	}
@@ -92,7 +92,7 @@ func TestTokenStore_GetByIssuer(t *testing.T) {
 
 	// Store a token
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid profile email",
 	}
@@ -108,7 +108,7 @@ func TestTokenStore_GetByIssuer(t *testing.T) {
 	ts.Store(key, token)
 
 	// Retrieve by issuer (different scope should still find it)
-	retrieved := ts.GetByIssuer("session-123", "https://auth.example.com")
+	retrieved := ts.GetByIssuer("user-123", "https://auth.example.com")
 	if retrieved == nil {
 		t.Fatal("Expected to retrieve token by issuer, got nil")
 	}
@@ -122,9 +122,9 @@ func TestTokenStore_GetByIssuerNotFound(t *testing.T) {
 	ts := NewTokenStore()
 	defer ts.Stop()
 
-	// Store a token for different session
+	// Store a token for a different user
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid",
 	}
@@ -138,14 +138,14 @@ func TestTokenStore_GetByIssuerNotFound(t *testing.T) {
 
 	ts.Store(key, token)
 
-	// Try to retrieve with different session
-	retrieved := ts.GetByIssuer("different-session", "https://auth.example.com")
+	// Try to retrieve with different user
+	retrieved := ts.GetByIssuer("different-user", "https://auth.example.com")
 	if retrieved != nil {
-		t.Errorf("Expected nil for different session, got %v", retrieved)
+		t.Errorf("Expected nil for different user, got %v", retrieved)
 	}
 
 	// Try to retrieve with different issuer
-	retrieved = ts.GetByIssuer("session-123", "https://different-issuer.com")
+	retrieved = ts.GetByIssuer("user-123", "https://different-issuer.com")
 	if retrieved != nil {
 		t.Errorf("Expected nil for different issuer, got %v", retrieved)
 	}
@@ -156,7 +156,7 @@ func TestTokenStore_Delete(t *testing.T) {
 	defer ts.Stop()
 
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid",
 	}
@@ -188,12 +188,12 @@ func TestTokenStore_DeleteByUser(t *testing.T) {
 	ts := NewTokenStore()
 	defer ts.Stop()
 
-	sessionID := "session-to-delete"
+	subject := "user-to-delete"
 
-	// Store multiple tokens for the same session
+	// Store multiple tokens for the same subject
 	for i, issuer := range []string{"https://issuer1.com", "https://issuer2.com", "https://issuer3.com"} {
 		key := TokenKey{
-			Subject: sessionID,
+			Subject: subject,
 			Issuer:  issuer,
 			Scope:   "openid",
 		}
@@ -206,9 +206,9 @@ func TestTokenStore_DeleteByUser(t *testing.T) {
 		ts.Store(key, token)
 	}
 
-	// Store a token for different session
+	// Store a token for a different user
 	otherKey := TokenKey{
-		Subject: "other-session",
+		Subject: "other-user",
 		Issuer:  "https://issuer1.com",
 		Scope:   "openid",
 	}
@@ -224,17 +224,17 @@ func TestTokenStore_DeleteByUser(t *testing.T) {
 		t.Errorf("Expected 4 tokens, got %d", ts.Count())
 	}
 
-	// Delete all tokens for the session
-	ts.DeleteByUser(sessionID)
+	// Delete all tokens for the subject
+	ts.DeleteByUser(subject)
 
-	// Verify only 1 token remains (the other session)
+	// Verify only 1 token remains (the other user)
 	if ts.Count() != 1 {
 		t.Errorf("Expected 1 token after deletion, got %d", ts.Count())
 	}
 
-	// Verify the remaining token is from the other session
+	// Verify the remaining token is from the other user
 	if ts.Get(otherKey) == nil {
-		t.Error("Token from other session should still exist")
+		t.Error("Token from other user should still exist")
 	}
 }
 
@@ -250,7 +250,7 @@ func TestTokenStore_Count(t *testing.T) {
 	// Add tokens
 	for i := 0; i < 5; i++ {
 		key := TokenKey{
-			Subject: "session",
+			Subject: "user@example.com",
 			Issuer:  "issuer",
 			Scope:   string(rune('a' + i)),
 		}
@@ -266,13 +266,13 @@ func TestTokenStore_DeleteByIssuer(t *testing.T) {
 	ts := NewTokenStore()
 	defer ts.Stop()
 
-	sessionID := "session-123"
+	subject := "user-123"
 	issuerToDelete := "https://issuer-to-delete.com"
 	issuerToKeep := "https://issuer-to-keep.com"
 
-	// Store tokens for the same session with different issuers
+	// Store tokens for the same subject with different issuers
 	key1 := TokenKey{
-		Subject: sessionID,
+		Subject: subject,
 		Issuer:  issuerToDelete,
 		Scope:   "openid",
 	}
@@ -284,7 +284,7 @@ func TestTokenStore_DeleteByIssuer(t *testing.T) {
 	})
 
 	key2 := TokenKey{
-		Subject: sessionID,
+		Subject: subject,
 		Issuer:  issuerToDelete,
 		Scope:   "profile", // Same issuer, different scope
 	}
@@ -296,7 +296,7 @@ func TestTokenStore_DeleteByIssuer(t *testing.T) {
 	})
 
 	key3 := TokenKey{
-		Subject: sessionID,
+		Subject: subject,
 		Issuer:  issuerToKeep,
 		Scope:   "openid",
 	}
@@ -307,9 +307,9 @@ func TestTokenStore_DeleteByIssuer(t *testing.T) {
 		Issuer:      issuerToKeep,
 	})
 
-	// Store token for different session (should not be affected)
+	// Store token for different user (should not be affected)
 	key4 := TokenKey{
-		Subject: "other-session",
+		Subject: "other-user",
 		Issuer:  issuerToDelete,
 		Scope:   "openid",
 	}
@@ -325,8 +325,8 @@ func TestTokenStore_DeleteByIssuer(t *testing.T) {
 		t.Errorf("Expected 4 tokens, got %d", ts.Count())
 	}
 
-	// Delete tokens for session-123 and issuerToDelete
-	ts.DeleteByIssuer(sessionID, issuerToDelete)
+	// Delete tokens for user-123 and issuerToDelete
+	ts.DeleteByIssuer(subject, issuerToDelete)
 
 	// Verify we have 2 tokens remaining
 	if ts.Count() != 2 {
@@ -346,7 +346,7 @@ func TestTokenStore_DeleteByIssuer(t *testing.T) {
 		t.Error("Token 3 (different issuer) should still exist")
 	}
 	if ts.Get(key4) == nil {
-		t.Error("Token 4 (different session) should still exist")
+		t.Error("Token 4 (different user) should still exist")
 	}
 }
 
@@ -356,7 +356,7 @@ func TestTokenStore_DeleteByIssuer_NoMatch(t *testing.T) {
 
 	// Store a token
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid",
 	}
@@ -367,8 +367,8 @@ func TestTokenStore_DeleteByIssuer_NoMatch(t *testing.T) {
 		Issuer:      "https://auth.example.com",
 	})
 
-	// Try to delete with non-matching session
-	ts.DeleteByIssuer("non-existent-session", "https://auth.example.com")
+	// Try to delete with non-matching user
+	ts.DeleteByIssuer("non-existent-user", "https://auth.example.com")
 
 	// Token should still exist
 	if ts.Count() != 1 {
@@ -376,7 +376,7 @@ func TestTokenStore_DeleteByIssuer_NoMatch(t *testing.T) {
 	}
 
 	// Try to delete with non-matching issuer
-	ts.DeleteByIssuer("session-123", "https://non-existent-issuer.com")
+	ts.DeleteByIssuer("user-123", "https://non-existent-issuer.com")
 
 	// Token should still exist
 	if ts.Count() != 1 {
@@ -427,22 +427,22 @@ func TestToken_IsExpired(t *testing.T) {
 	}
 }
 
-// TestTokenStore_SessionIsolation verifies that tokens from different sessions
+// TestTokenStore_SubjectIsolation verifies that tokens from different subjects
 // are completely isolated. This is critical for multi-user security - users
 // MUST NOT be able to access each other's OAuth tokens.
-func TestTokenStore_SessionIsolation(t *testing.T) {
+func TestTokenStore_SubjectIsolation(t *testing.T) {
 	ts := NewTokenStore()
 	defer ts.Stop()
 
-	// Simulate two different users with different session IDs
-	user1Session := "uuid-user1-session-abc123"
-	user2Session := "uuid-user2-session-def456"
+	// Simulate two different users with different subjects
+	user1Subject := "user1@example.com"
+	user2Subject := "user2@example.com"
 	commonIssuer := "https://auth.example.com"
 	commonScope := "openid profile"
 
 	// User 1 stores their token
 	user1Key := TokenKey{
-		Subject: user1Session,
+		Subject: user1Subject,
 		Issuer:  commonIssuer,
 		Scope:   commonScope,
 	}
@@ -455,9 +455,9 @@ func TestTokenStore_SessionIsolation(t *testing.T) {
 	}
 	ts.Store(user1Key, user1Token)
 
-	// User 2 stores their token (same issuer and scope, different session)
+	// User 2 stores their token (same issuer and scope, different subject)
 	user2Key := TokenKey{
-		Subject: user2Session,
+		Subject: user2Subject,
 		Issuer:  commonIssuer,
 		Scope:   commonScope,
 	}
@@ -488,9 +488,9 @@ func TestTokenStore_SessionIsolation(t *testing.T) {
 		t.Errorf("User 2 got wrong token: expected user2-secret-token, got %s", retrievedUser2Token.AccessToken)
 	}
 
-	// CRITICAL SECURITY CHECK: User 1's session should not retrieve User 2's token
+	// CRITICAL SECURITY CHECK: User 1's subject should not retrieve User 2's token
 	wrongKey := TokenKey{
-		Subject: user1Session,
+		Subject: user1Subject,
 		Issuer:  commonIssuer,
 		Scope:   "different-scope", // Even with same issuer, different scope = no token
 	}
@@ -498,15 +498,15 @@ func TestTokenStore_SessionIsolation(t *testing.T) {
 		t.Error("Should not get token for non-matching scope")
 	}
 
-	// CRITICAL SECURITY CHECK: GetByIssuer respects session boundaries
-	user1IssuerToken := ts.GetByIssuer(user1Session, commonIssuer)
+	// CRITICAL SECURITY CHECK: GetByIssuer respects subject boundaries
+	user1IssuerToken := ts.GetByIssuer(user1Subject, commonIssuer)
 	if user1IssuerToken == nil || user1IssuerToken.AccessToken != "user1-secret-token" {
-		t.Error("GetByIssuer should return User 1's token for User 1's session")
+		t.Error("GetByIssuer should return User 1's token for User 1's subject")
 	}
 
-	user2IssuerToken := ts.GetByIssuer(user2Session, commonIssuer)
+	user2IssuerToken := ts.GetByIssuer(user2Subject, commonIssuer)
 	if user2IssuerToken == nil || user2IssuerToken.AccessToken != "user2-secret-token" {
-		t.Error("GetByIssuer should return User 2's token for User 2's session")
+		t.Error("GetByIssuer should return User 2's token for User 2's subject")
 	}
 
 	// CRITICAL: Verify token count (exactly 2 tokens, one per user)
@@ -521,7 +521,7 @@ func TestTokenStore_Cleanup(t *testing.T) {
 
 	// Store a token
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid",
 	}
@@ -548,7 +548,7 @@ func TestTokenStore_CleanupExpiredTokens(t *testing.T) {
 
 	// Store an expired token
 	key := TokenKey{
-		Subject: "session-123",
+		Subject: "user-123",
 		Issuer:  "https://auth.example.com",
 		Scope:   "openid",
 	}

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -353,7 +353,7 @@ func (h *TestToolsHandler) handleSimulateOAuthCallback(ctx context.Context, args
 
 		// Note: The token is now stored in muster's OAuth manager.
 		// The NEXT call to any protected tool (or the authenticate tool) will:
-		// 1. Find the token via GetTokenByIssuer(sessionID, issuer)
+		// 1. Find the token via GetTokenByIssuer(subject, issuer)
 		// 2. Use it to connect to the protected MCP server
 		// 3. Make the protected tools available
 		// We do NOT call authenticate a second time here - that was a workaround


### PR DESCRIPTION
## Summary

- Rename `sessionID` variables to `subject` across all 5 test files in `internal/oauth/`, aligning test code with the production function signatures that already use `subject`
- Update session-like string values (`"session-123"`, `"session"`, etc.) to subject-like values (`"user-123"`, `"user@example.com"`, etc.) in `TokenKey{Subject: ...}` constructions and function call arguments
- Rename `TestTokenStore_SessionIsolation` to `TestTokenStore_SubjectIsolation` with matching variable/comment/assertion updates
- Update `GetTokenByIssuer(sessionID, issuer)` comment in `internal/testing/test_tools.go`

## Approach

This is Phase 6 of the muster session ID elimination (parent: #440). Phases 1-5 migrated all production code to use `subject` (OAuth sub claim) instead of muster session IDs. This phase completes the cleanup by aligning test files with the production API surface.

Changes are purely cosmetic renames in test files and one comment -- no behavioral changes. Out-of-scope files (`response_processor_test.go`, `oauth_http_test.go`, production code with protocol-level `sessionID`) are intentionally untouched.

Closes #466

## Test plan

- [x] `go test ./internal/oauth/...` passes
- [x] `go test ./internal/testing/...` passes
- [x] No `sessionID` variable names remain in `internal/oauth/*_test.go`
- [x] No `"session-*"` values passed as `Subject` parameters in oauth tests
- [x] `response_processor_test.go` and `oauth_http_test.go` are untouched
- [x] Reviewed by `base:code-reviewer` -- no findings
- [x] Reviewed by `code-quality:security-auditor` -- no findings

Generated with [Claude Code](https://claude.com/claude-code)