### PR TITLE
Fix: Show SSO connection progress during muster auth login

### DIFF
--- a/cmd/auth_helpers.go
+++ b/cmd/auth_helpers.go
@@ -410,8 +410,9 @@ const (
 
 // waitForSSOCompletion polls auth://status until no servers are in sso_pending state.
 // It reuses a single connected client for all polls to avoid creating many connections.
+// The optional progressFn is called on each poll with the current status.
 // Returns the final auth status (which may still contain sso_pending servers on timeout).
-func waitForSSOCompletion(ctx context.Context, handler api.AuthHandler, endpoint string) (*pkgoauth.AuthStatusResponse, error) {
+func waitForSSOCompletion(ctx context.Context, handler api.AuthHandler, endpoint string, progressFn func(*pkgoauth.AuthStatusResponse)) (*pkgoauth.AuthStatusResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, DefaultSSOWaitTimeout)
 	defer cancel()
 
@@ -436,11 +437,31 @@ func waitForSSOCompletion(ctx context.Context, handler api.AuthHandler, endpoint
 				continue // transient error, keep polling
 			}
 			lastStatus = status
+			if progressFn != nil {
+				progressFn(status)
+			}
 			if !hasSSOPending(status) {
 				return status, nil
 			}
 		}
 	}
+}
+
+// countSSOProgress counts connected and total SSO-enabled servers from an auth status response.
+func countSSOProgress(status *pkgoauth.AuthStatusResponse) (connected, total int) {
+	if status == nil {
+		return 0, 0
+	}
+	for _, srv := range status.Servers {
+		if !srv.TokenForwardingEnabled && !srv.TokenExchangeEnabled {
+			continue
+		}
+		total++
+		if srv.Status == pkgoauth.ServerStatusConnected {
+			connected++
+		}
+	}
+	return connected, total
 }
 
 // hasSSOPending returns true if any server in the auth status response is in sso_pending state.

--- a/cmd/auth_login.go
+++ b/cmd/auth_login.go
@@ -134,7 +134,7 @@ func loginToMCPServer(ctx context.Context, handler api.AuthHandler, aggregatorEn
 		}
 		if serverInfo.Status == pkgoauth.ServerStatusSSOPending {
 			authPrint("SSO authentication is in progress for '%s'. Waiting for completion...\n", serverName)
-			finalStatus, err := waitForSSOCompletion(ctx, handler, aggregatorEndpoint)
+			finalStatus, err := waitForSSOCompletion(ctx, handler, aggregatorEndpoint, nil)
 			if err != nil {
 				authPrint("Warning: Timed out waiting for SSO to complete for '%s'.\n", serverName)
 				authPrintln("SSO may still complete in the background. Check with: muster auth status --server " + serverName)
@@ -223,27 +223,39 @@ func loginToAll(ctx context.Context, handler api.AuthHandler, aggregatorEndpoint
 // then prints a summary of any that failed. Returns nil on success or timeout
 // (timeout is not treated as an error since SSO may still complete).
 func waitAndPrintSSOSummary(ctx context.Context, handler api.AuthHandler, endpoint string) error {
-	authStatus, err := waitForSSOCompletion(ctx, handler, endpoint)
+	authPrint("Establishing SSO connections...")
+
+	progressFn := func(status *pkgoauth.AuthStatusResponse) {
+		connected, total := countSSOProgress(status)
+		if total > 0 {
+			authPrint("\rEstablishing SSO connections (%d/%d)...", connected, total)
+		}
+	}
+
+	authStatus, err := waitForSSOCompletion(ctx, handler, endpoint, progressFn)
 	if err != nil {
-		// Timeout or connection failure -- not fatal, SSO continues in background
+		authPrintln()
 		if authStatus != nil && hasSSOPending(authStatus) {
 			authPrintln("Note: Some SSO servers are still connecting. Check with: muster auth status")
 		}
 		return nil
 	}
 
-	// Print summary of SSO results
 	var failedSSO []string
 	for _, srv := range authStatus.Servers {
 		if srv.SSOAttemptFailed && (srv.TokenForwardingEnabled || srv.TokenExchangeEnabled) {
 			failedSSO = append(failedSSO, srv.Name)
 		}
 	}
+
 	if len(failedSSO) > 0 {
-		authPrint("\nSSO failed for %d server(s):\n", len(failedSSO))
+		authPrintln()
+		authPrint("SSO failed for %d server(s):\n", len(failedSSO))
 		for _, name := range failedSSO {
 			authPrint("  - %s\n", name)
 		}
+	} else {
+		authPrintln(" done")
 	}
 	return nil
 }

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1849,13 +1849,11 @@ func (a *AggregatorServer) handleUserTokensDeletion(w http.ResponseWriter, r *ht
 		return
 	}
 
-	// Clear all downstream tokens for this user via the OAuthHandler.
 	oauthHandler := api.GetOAuthHandler()
 	if oauthHandler != nil && oauthHandler.IsEnabled() {
 		oauthHandler.DeleteTokensByUser(sub)
 	}
 
-	// Invalidate all CapabilityCache entries for this user on full logout.
 	if a.capabilityCache != nil {
 		a.capabilityCache.InvalidateUser(sub)
 	}

--- a/internal/cli/auth_adapter.go
+++ b/internal/cli/auth_adapter.go
@@ -354,7 +354,6 @@ func (a *AuthAdapter) interactiveLogin(ctx context.Context, mgr *oauth.AuthManag
 	}
 
 	fmt.Printf("\nSuccessfully authenticated to %s\n", endpoint)
-	fmt.Println("SSO-enabled servers will be connected automatically on first request.")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Show live SSO progress during `muster auth login` (`Establishing SSO connections (12/18)...`) instead of silently blocking for up to 30 seconds with no output
- Remove misleading "SSO-enabled servers will be connected automatically on first request" message since the login command synchronously waits for SSO completion

## Context

This is a UX-only fix extracted from investigation of #468. The underlying security issue (per-subject state keying prevents proper per-device logout cleanup) is tracked in #468 and requires a larger refactoring to introduce per-token-family state isolation.

## Test plan

- [x] All 164 BDD scenarios pass
- [x] All unit tests pass
- [x] Verified against live gazelle aggregator: logout + login shows real SSO progress

Made with [Cursor](https://cursor.com)