### PR TITLE
Fix: Use list_tools meta-tool for REPL tool cache instead of native tools/list

### DIFF
--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	agentoauth "github.com/giantswarm/muster/internal/agent/oauth"
+	"github.com/giantswarm/muster/internal/metatools"
 )
 
 // TransportType defines the transport type for MCP connections.
@@ -454,32 +455,18 @@ func (c *Client) initialize(ctx context.Context) error {
 // This method handles both initial loading and refresh scenarios, with intelligent
 // diff tracking for notification-driven updates.
 //
+// It calls the list_tools meta-tool (rather than native tools/list) to discover
+// all actual tools (core_*, x_*, workflow_*) exposed through the aggregator.
+//
 // Args:
 //   - ctx: Context for cancellation and timeout control
 //   - initial: Whether this is the first time loading tools (affects diff display)
-//
-// The method performs the following operations:
-//   - Sends tools/list request to the MCP server
-//   - Updates the local tool cache (if caching is enabled)
-//   - Displays differences from the previous cache state (if not initial)
-//   - Handles errors with appropriate logging
-//
-// This method is called automatically during initialization and when tool
-// change notifications are received.
 func (c *Client) listTools(ctx context.Context, initial bool) error {
-	req := mcp.ListToolsRequest{}
-
-	// Log request only if logger is available
 	if c.logger != nil {
-		c.logger.Request("tools/list", req.Params)
+		c.logger.Info("Listing available tools...")
 	}
 
-	// Create timeout context to prevent hanging operations
-	timeoutCtx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
-
-	// Send request
-	result, err := c.client.ListTools(timeoutCtx, req)
+	result, err := c.callToolDirect(ctx, metatools.ToolListTools, map[string]interface{}{})
 	if err != nil {
 		if c.logger != nil {
 			c.logger.Error("ListTools failed: %v", err)
@@ -487,37 +474,113 @@ func (c *Client) listTools(ctx context.Context, initial bool) error {
 		return err
 	}
 
-	// Log response only if logger is available
-	if c.logger != nil {
-		c.logger.Response("tools/list", result)
+	if result.IsError {
+		var errorMsgs []string
+		for _, content := range result.Content {
+			if textContent, ok := mcp.AsTextContent(content); ok {
+				errorMsgs = append(errorMsgs, textContent.Text)
+			}
+		}
+		joined := strings.Join(errorMsgs, "; ")
+		if c.logger != nil {
+			c.logger.Error("list_tools failed: %s", joined)
+		}
+		return fmt.Errorf("list_tools failed: %s", joined)
 	}
 
-	// Only do caching and diff comparison if caching is enabled
+	tools, err := c.parseListToolsResponse(result)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Error("Failed to parse list_tools response: %v", err)
+		}
+		return err
+	}
+
+	if c.logger != nil {
+		c.logger.Success("Found %d tools", len(tools))
+	}
+
 	if c.cacheEnabled {
-		// Compare with cache if not initial to show what changed
 		if !initial {
 			c.mu.RLock()
 			oldTools := c.toolCache
 			c.mu.RUnlock()
 
-			// Update cache with new data
 			c.mu.Lock()
-			c.toolCache = result.Tools
+			c.toolCache = tools
 			c.mu.Unlock()
 
-			// Show differences only if logger is available
 			if c.logger != nil {
-				c.showToolDiff(oldTools, result.Tools)
+				c.showToolDiff(oldTools, tools)
 			}
 		} else {
-			// Initial load - just populate the cache
 			c.mu.Lock()
-			c.toolCache = result.Tools
+			c.toolCache = tools
 			c.mu.Unlock()
 		}
 	}
 
 	return nil
+}
+
+// parseListToolsResponse extracts []mcp.Tool from a list_tools meta-tool response.
+func (c *Client) parseListToolsResponse(result *mcp.CallToolResult) ([]mcp.Tool, error) {
+	for _, content := range result.Content {
+		textContent, ok := mcp.AsTextContent(content)
+		if !ok {
+			continue
+		}
+
+		var response metatools.ListToolsResponse
+		if err := json.Unmarshal([]byte(textContent.Text), &response); err != nil {
+			return nil, fmt.Errorf("failed to parse list_tools response: %w", err)
+		}
+
+		tools := make([]mcp.Tool, len(response.Tools))
+		for i, t := range response.Tools {
+			tools[i] = mcp.Tool{
+				Name:        t.Name,
+				Description: t.Description,
+				InputSchema: convertInputSchema(t.InputSchema),
+			}
+		}
+		return tools, nil
+	}
+
+	return nil, fmt.Errorf("no content in list_tools response")
+}
+
+// convertInputSchema converts the untyped InputSchema from ToolInfo into mcp.ToolInputSchema.
+func convertInputSchema(raw interface{}) mcp.ToolInputSchema {
+	schema := mcp.ToolInputSchema{
+		Type: "object",
+	}
+	if raw == nil {
+		return schema
+	}
+
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return schema
+	}
+
+	if t, ok := m["type"].(string); ok {
+		schema.Type = t
+	}
+	if props, ok := m["properties"].(map[string]interface{}); ok {
+		schema.Properties = props
+	}
+	if req, ok := m["required"].([]interface{}); ok {
+		required := make([]string, 0, len(req))
+		for _, r := range req {
+			if s, ok := r.(string); ok {
+				required = append(required, s)
+			}
+		}
+		schema.Required = required
+	}
+
+	return schema
 }
 
 // listResources retrieves all available resources from the MCP server and updates the cache.

--- a/internal/agent/client_test.go
+++ b/internal/agent/client_test.go
@@ -65,32 +65,6 @@ func TestShowToolDiff(t *testing.T) {
 	client.showToolDiff(oldTools, newTools)
 }
 
-func TestCountTools(t *testing.T) {
-	logger := NewLogger(false, false, false)
-
-	// Test with map structure
-	result1 := map[string]interface{}{
-		"tools": []interface{}{
-			map[string]interface{}{"name": "tool1"},
-			map[string]interface{}{"name": "tool2"},
-			map[string]interface{}{"name": "tool3"},
-		},
-	}
-	assert.Equal(t, 3, logger.countTools(result1))
-
-	// Test with empty tools
-	result2 := map[string]interface{}{
-		"tools": []interface{}{},
-	}
-	assert.Equal(t, 0, logger.countTools(result2))
-
-	// Test with invalid structure
-	result3 := map[string]interface{}{
-		"nottools": "something",
-	}
-	assert.Equal(t, -1, logger.countTools(result3))
-}
-
 func TestGetToolByName(t *testing.T) {
 	logger := NewLogger(false, false, false)
 	client := NewClient("http://localhost:8090/mcp", logger, TransportStreamableHTTP)

--- a/internal/agent/logger.go
+++ b/internal/agent/logger.go
@@ -250,19 +250,20 @@ func (l *Logger) Success(format string, args ...interface{}) {
 // messages, while JSON-RPC mode shows complete protocol details.
 //
 // Args:
-//   - method: The MCP method name (e.g., "tools/list", "initialize")
+//   - method: The MCP method name (e.g., "initialize", "resources/list")
 //   - params: The request args (logged in JSON-RPC mode only)
 //
 // In simple mode, this maps method names to user-friendly messages.
 // In JSON-RPC mode, this shows complete request details with proper formatting.
+//
+// Note: tool listing is handled via the list_tools meta-tool and logs
+// directly through Info/Success rather than through this method.
 func (l *Logger) Request(method string, params interface{}) {
 	if !l.jsonRPCMode {
 		// Simple mode - just log what we're doing with user-friendly messages
 		switch method {
 		case "initialize":
 			l.Info("Initializing MCP session...")
-		case "tools/list":
-			l.Info("Listing available tools...")
 		case "resources/list":
 			l.Info("Listing available resources...")
 		case "prompts/list":
@@ -311,14 +312,6 @@ func (l *Logger) Response(method string, result interface{}) {
 				}
 			} else {
 				l.Success("Session initialized successfully")
-			}
-		case "tools/list":
-			// Try to count tools
-			toolCount := l.countTools(result)
-			if toolCount >= 0 {
-				l.Success("Found %d tools", toolCount)
-			} else {
-				l.Success("Retrieved tool list")
 			}
 		case "resources/list":
 			// Try to count resources
@@ -458,41 +451,6 @@ func (l *Logger) prettyJSON(v interface{}) string {
 func (l *Logger) Write(p []byte) (n int, err error) {
 	l.Debug("%s", string(p))
 	return len(p), nil
-}
-
-// countTools attempts to count the number of tools in a tools/list response.
-// This is used by the simple logging mode to provide meaningful summary
-// information instead of raw protocol details.
-//
-// Args:
-//   - result: The response result from a tools/list operation
-//
-// Returns:
-//   - Number of tools found, or -1 if count cannot be determined
-func (l *Logger) countTools(result interface{}) int {
-	// Try to extract tools array from various response structures
-	switch v := result.(type) {
-	case map[string]interface{}:
-		if tools, ok := v["tools"]; ok {
-			if toolsArray, ok := tools.([]interface{}); ok {
-				return len(toolsArray)
-			}
-		}
-	}
-
-	// Try type assertion for the specific ListToolsResult type
-	type toolsResult struct {
-		Tools []interface{} `json:"tools"`
-	}
-
-	if jsonBytes, err := json.Marshal(result); err == nil {
-		var tr toolsResult
-		if err := json.Unmarshal(jsonBytes, &tr); err == nil && tr.Tools != nil {
-			return len(tr.Tools)
-		}
-	}
-
-	return -1 // Indicate we couldn't count
 }
 
 // countResources attempts to count the number of resources in a resources/list response.


### PR DESCRIPTION
## Summary

- **`Client.listTools()`** now calls the `list_tools` meta-tool via `callToolDirect()` instead of native `tools/list`, so `toolCache` contains all actual tools (core_*, x_*, workflow_*) rather than only the 11 meta-tools
- Adds `parseListToolsResponse()` and `convertInputSchema()` helpers to properly convert `ToolInfo` entries into `[]mcp.Tool` with full `InputSchema` for tab completion support
- Removes dead `"tools/list"` cases from the logger's `Request()`/`Response()` methods and the unused `countTools()` function + its test

This fixes tab completion, the "Found N tools" startup message, and `findTool()` lookup after PR #474 stopped exposing downstream tools via native `tools/list`.

## Test plan

- [x] `make test` passes (all unit tests green)
- [x] BDD scenarios pass
- [x] Manual: `muster repl` shows correct tool count at startup
- [x] Manual: tab completion lists all actual tools, not just meta-tools


Made with [Cursor](https://cursor.com)