### PR TITLE
feat: Align CapabilityCache TTL with access token lifetime

### DIFF
--- a/internal/aggregator/capability_cache.go
+++ b/internal/aggregator/capability_cache.go
@@ -111,6 +111,48 @@ func (c *CapabilityCache) SetWithTTL(sessionID, serverName string, tools []mcp.T
 	c.mu.Unlock()
 }
 
+// Touch resets the TTL for a specific session+server cache entry without
+// re-fetching capabilities. This is used to renew cache lifetime when the
+// session's access token is refreshed or the session is actively used.
+// Returns true if the entry was found and touched, false otherwise.
+func (c *CapabilityCache) Touch(sessionID, serverName string) bool {
+	now := time.Now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := CacheKey{SessionID: sessionID, ServerName: serverName}
+	entry, ok := c.entries[key]
+	if !ok {
+		return false
+	}
+
+	entry.ExpiresAt = now.Add(c.defaultTTL)
+	entry.graceDeadline = now.Add(2 * c.defaultTTL)
+	return true
+}
+
+// TouchSession resets the TTL for all cache entries belonging to a session.
+// This is used to renew cache lifetime when the session's access token is
+// refreshed, keeping capabilities alive for the full token lifetime.
+// Returns the number of entries touched.
+func (c *CapabilityCache) TouchSession(sessionID string) int {
+	now := time.Now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	count := 0
+	for key, entry := range c.entries {
+		if key.SessionID == sessionID {
+			entry.ExpiresAt = now.Add(c.defaultTTL)
+			entry.graceDeadline = now.Add(2 * c.defaultTTL)
+			count++
+		}
+	}
+	return count
+}
+
 // InvalidateSession removes all cached entries for a session (e.g., on logout
 // via token family revocation).
 func (c *CapabilityCache) InvalidateSession(sessionID string) {

--- a/internal/aggregator/capability_cache_test.go
+++ b/internal/aggregator/capability_cache_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCapabilityCache_GetSetRoundTrip(t *testing.T) {
-	cache := NewCapabilityCache(5 * time.Minute)
+	cache := NewCapabilityCache(30 * time.Minute)
 	defer cache.Stop()
 
 	tools := []mcp.Tool{{Name: "tool1"}}
@@ -30,7 +30,7 @@ func TestCapabilityCache_GetSetRoundTrip(t *testing.T) {
 }
 
 func TestCapabilityCache_GetNonexistent(t *testing.T) {
-	cache := NewCapabilityCache(5 * time.Minute)
+	cache := NewCapabilityCache(30 * time.Minute)
 	defer cache.Stop()
 
 	entry, ok := cache.Get("nouser", "noserver")
@@ -39,7 +39,7 @@ func TestCapabilityCache_GetNonexistent(t *testing.T) {
 }
 
 func TestCapabilityCache_SetOverwritesPrevious(t *testing.T) {
-	cache := NewCapabilityCache(5 * time.Minute)
+	cache := NewCapabilityCache(30 * time.Minute)
 	defer cache.Stop()
 
 	cache.Set("user1", "server1", []mcp.Tool{{Name: "old"}}, nil, nil)
@@ -100,7 +100,7 @@ func TestCapabilityCache_SetWithTTL(t *testing.T) {
 }
 
 func TestCapabilityCache_InvalidateViaSubjectSessions(t *testing.T) {
-	cache := NewCapabilityCache(5 * time.Minute)
+	cache := NewCapabilityCache(30 * time.Minute)
 	defer cache.Stop()
 
 	tracker := newSubjectSessionTracker()
@@ -128,7 +128,7 @@ func TestCapabilityCache_InvalidateViaSubjectSessions(t *testing.T) {
 }
 
 func TestCapabilityCache_InvalidateServer(t *testing.T) {
-	cache := NewCapabilityCache(5 * time.Minute)
+	cache := NewCapabilityCache(30 * time.Minute)
 	defer cache.Stop()
 
 	cache.Set("session-A", "server1", []mcp.Tool{{Name: "t1"}}, nil, nil)
@@ -149,7 +149,7 @@ func TestCapabilityCache_InvalidateServer(t *testing.T) {
 }
 
 func TestCapabilityCache_InvalidateSpecific(t *testing.T) {
-	cache := NewCapabilityCache(5 * time.Minute)
+	cache := NewCapabilityCache(30 * time.Minute)
 	defer cache.Stop()
 
 	cache.Set("session-A", "server1", []mcp.Tool{{Name: "t1"}}, nil, nil)
@@ -165,7 +165,7 @@ func TestCapabilityCache_InvalidateSpecific(t *testing.T) {
 }
 
 func TestCapabilityCache_ConcurrentAccess(t *testing.T) {
-	cache := NewCapabilityCache(5 * time.Minute)
+	cache := NewCapabilityCache(30 * time.Minute)
 	defer cache.Stop()
 
 	var wg sync.WaitGroup
@@ -244,6 +244,78 @@ func TestCapabilityCache_StopHaltsCleanup(t *testing.T) {
 
 	// Calling Stop again should not block.
 	cache.Stop()
+}
+
+func TestCapabilityCache_Touch(t *testing.T) {
+	ttl := 50 * time.Millisecond
+	cache := NewCapabilityCache(ttl)
+	defer cache.Stop()
+
+	cache.Set("session-A", "server1", []mcp.Tool{{Name: "t1"}}, nil, nil)
+
+	// Wait until the entry is expired but still within grace
+	time.Sleep(ttl + 10*time.Millisecond)
+	entry, ok := cache.Get("session-A", "server1")
+	require.True(t, ok)
+	assert.True(t, entry.IsExpired(), "entry should be expired before touch")
+
+	// Touch should renew the TTL
+	touched := cache.Touch("session-A", "server1")
+	assert.True(t, touched)
+
+	entry, ok = cache.Get("session-A", "server1")
+	require.True(t, ok)
+	assert.False(t, entry.IsExpired(), "entry should be fresh after touch")
+	assert.Equal(t, "t1", entry.Tools[0].Name, "capabilities should be preserved")
+}
+
+func TestCapabilityCache_TouchNonexistent(t *testing.T) {
+	cache := NewCapabilityCache(5 * time.Minute)
+	defer cache.Stop()
+
+	touched := cache.Touch("no-session", "no-server")
+	assert.False(t, touched)
+}
+
+func TestCapabilityCache_TouchSession(t *testing.T) {
+	ttl := 50 * time.Millisecond
+	cache := NewCapabilityCache(ttl)
+	defer cache.Stop()
+
+	cache.Set("session-A", "server1", []mcp.Tool{{Name: "t1"}}, nil, nil)
+	cache.Set("session-A", "server2", []mcp.Tool{{Name: "t2"}}, nil, nil)
+	cache.Set("session-B", "server1", []mcp.Tool{{Name: "t3"}}, nil, nil)
+
+	// Wait until entries are expired
+	time.Sleep(ttl + 10*time.Millisecond)
+	entry, _ := cache.Get("session-A", "server1")
+	require.True(t, entry.IsExpired())
+
+	// TouchSession should renew all entries for session-A
+	count := cache.TouchSession("session-A")
+	assert.Equal(t, 2, count)
+
+	// session-A entries should be fresh
+	entry, ok := cache.Get("session-A", "server1")
+	require.True(t, ok)
+	assert.False(t, entry.IsExpired(), "session-A/server1 should be fresh after touch")
+
+	entry, ok = cache.Get("session-A", "server2")
+	require.True(t, ok)
+	assert.False(t, entry.IsExpired(), "session-A/server2 should be fresh after touch")
+
+	// session-B should still be expired
+	entry, ok = cache.Get("session-B", "server1")
+	require.True(t, ok)
+	assert.True(t, entry.IsExpired(), "session-B should not be affected")
+}
+
+func TestCapabilityCache_TouchSessionNonexistent(t *testing.T) {
+	cache := NewCapabilityCache(5 * time.Minute)
+	defer cache.Stop()
+
+	count := cache.TouchSession("no-session")
+	assert.Equal(t, 0, count)
 }
 
 func TestCacheEntry_IsExpired(t *testing.T) {

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -270,7 +270,7 @@ func NewAggregatorServer(aggConfig AggregatorConfig, errorCallback func(error)) 
 		errorCallback:   errorCallback,
 		authRateLimiter: rateLimiter,
 		authMetrics:     NewAuthMetrics(),
-		capabilityCache: NewCapabilityCache(5 * time.Minute),
+		capabilityCache: NewCapabilityCache(server.DefaultAccessTokenTTL),
 		ssoTracker:      newSSOTracker(),
 		subjectSessions: newSubjectSessionTracker(),
 	}
@@ -364,6 +364,15 @@ func (a *AggregatorServer) Start(ctx context.Context) error {
 	// gain access to all SSO-enabled MCP servers.
 	api.RegisterSessionInitCallback(a.handleSessionInit)
 	api.RegisterSessionInitPrepareCallback(a.handleSessionInitPrepare)
+
+	// Register session activity callback to renew capability cache TTLs.
+	// On every authenticated request for an already-initialized session,
+	// this resets the cache TTL so entries survive for the full token lifetime.
+	api.RegisterSessionActivityCallback(func(sessionID string) {
+		if a.capabilityCache != nil {
+			a.capabilityCache.TouchSession(sessionID)
+		}
+	})
 
 	// Register this aggregator as the MetaToolsDataProvider (Issue #343)
 	// This enables the metatools package to access tools, resources, and prompts

--- a/internal/aggregator/server_auth_list_test.go
+++ b/internal/aggregator/server_auth_list_test.go
@@ -139,7 +139,7 @@ func TestListServersRequiringAuth(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		cache := NewCapabilityCache(5 * time.Minute)
+		cache := NewCapabilityCache(30 * time.Minute)
 		defer cache.Stop()
 		cache.Set("test-session", "cached-server",
 			[]mcp.Tool{{Name: "t"}}, nil, nil)

--- a/internal/aggregator/server_logout_test.go
+++ b/internal/aggregator/server_logout_test.go
@@ -250,7 +250,7 @@ func TestHandleAuthServerDeletion(t *testing.T) {
 		api.RegisterOAuthHandler(&issuerMockOAuthHandler{enabled: true})
 		t.Cleanup(func() { api.RegisterOAuthHandler(nil) })
 
-		cache := NewCapabilityCache(5 * time.Minute)
+		cache := NewCapabilityCache(30 * time.Minute)
 		cache.Set("session-A", "target-server", nil, nil, nil)
 		cache.Set("session-B", "target-server", nil, nil, nil)
 

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -146,6 +146,17 @@ type OAuthHandler interface {
 	Stop()
 }
 
+// SessionActivityCallback is called on every authenticated MCP request for an
+// already-initialized session. The aggregator registers this callback to renew
+// capability cache TTLs, keeping cache entries alive as long as the session's
+// token is valid and the user is actively making requests.
+//
+// Args:
+//   - sessionID: The session ID (token family) whose cache entries should be renewed
+//
+// This callback is lightweight (just a TTL reset) and safe to call on every request.
+type SessionActivityCallback func(sessionID string)
+
 // oauthHandler stores the registered OAuth handler implementation.
 var oauthHandler OAuthHandler
 var oauthMutex sync.RWMutex
@@ -159,6 +170,7 @@ type SessionInitPrepareCallback func(sub string)
 // sessionInitCallback stores the registered session initialization callback.
 var sessionInitCallback SessionInitCallback
 var sessionInitPrepareCallback SessionInitPrepareCallback
+var sessionActivityCallback SessionActivityCallback
 var sessionInitMutex sync.RWMutex
 
 // RegisterSessionInitCallback registers a callback for session initialization.
@@ -203,6 +215,27 @@ func GetSessionInitPrepareCallback() SessionInitPrepareCallback {
 	sessionInitMutex.RLock()
 	defer sessionInitMutex.RUnlock()
 	return sessionInitPrepareCallback
+}
+
+// RegisterSessionActivityCallback registers a callback for session activity.
+// This callback is triggered on every authenticated MCP request for an
+// already-initialized session, enabling the aggregator to renew cache TTLs.
+//
+// Thread-safe: Yes, protected by sessionInitMutex.
+func RegisterSessionActivityCallback(cb SessionActivityCallback) {
+	sessionInitMutex.Lock()
+	defer sessionInitMutex.Unlock()
+	sessionActivityCallback = cb
+}
+
+// GetSessionActivityCallback returns the registered session activity callback.
+// Returns nil if no callback has been registered.
+//
+// Thread-safe: Yes, protected by sessionInitMutex read lock.
+func GetSessionActivityCallback() SessionActivityCallback {
+	sessionInitMutex.RLock()
+	defer sessionInitMutex.RUnlock()
+	return sessionActivityCallback
 }
 
 // RegisterOAuthHandler registers the OAuth handler implementation.

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -401,9 +401,13 @@ func (s *OAuthHTTPServer) triggerSessionInitIfNeeded(ctx context.Context, r *htt
 	now := time.Now()
 
 	// Session ID changes on re-authentication (new login = new token family).
-	// If we've already seen this session, just update last access time.
+	// If we've already seen this session, just update last access time and
+	// renew capability cache TTLs so they survive for the full token lifetime.
 	if _, exists := s.sessionInitTracker.Load(sessionID); exists {
 		s.sessionInitTracker.Store(sessionID, sessionTrackerEntry{lastAccess: now})
+		if activityCb := api.GetSessionActivityCallback(); activityCb != nil {
+			activityCb(sessionID)
+		}
 		logging.Debug("OAuth", "SSO: Session %s already initialized, skipping", logging.TruncateIdentifier(sessionID))
 		return
 	}


### PR DESCRIPTION
## Summary

- **Part A**: Changed `NewCapabilityCache(5 * time.Minute)` to use `server.DefaultAccessTokenTTL` (30 minutes), aligning cache lifetime with the access token. The grace period (2x TTL = 60 minutes) provides stale-while-revalidate coverage for the full session.
- **Part B**: Added `Touch(sessionID, serverName)` and `TouchSession(sessionID)` methods to `CapabilityCache` that reset TTL without re-fetching capabilities. Integrated via `SessionActivityCallback` through the API service locator: on every authenticated request for an already-initialized session, the middleware renews all cache entries for that session.
- Updated existing test TTLs from 5 to 30 minutes for consistency with production code.

## Approach

The root cause was a TTL mismatch: cache entries expired after 5 minutes while access tokens were valid for 30 minutes. Combined with the one-shot `sessionInitTracker`, SSO tools would vanish ~10 minutes into a session and never recover.

The fix is two-pronged:
1. **Immediate**: Align the default TTL so cache entries don't expire prematurely.
2. **Proper**: Add a Touch mechanism triggered on every authenticated request, so cache entries survive as long as the session is active. This uses the existing service locator pattern (`internal/api`) to avoid cross-package imports between `server` and `aggregator`.

No regression in cache invalidation on logout (`InvalidateSession`), server deregistration (`InvalidateServer`), or manual invalidation.

Closes #480
Relates to #478

## Test plan

- [x] New unit tests for `Touch()` and `TouchSession()` (including nonexistent entries)
- [x] Existing cache tests pass with updated TTL values
- [x] All aggregator, API, and server package tests pass
- [x] Code formatted with `goimports` and `go fmt`
- [x] No build errors across the full project

🤖 Generated with [Claude Code](https://claude.com/claude-code)