### PR TITLE
Fix: Restore SSO logout block removed in #489

### DIFF
--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -329,6 +329,21 @@ func (p *AuthToolProvider) handleAuthLogout(ctx context.Context, args map[string
 		}, nil
 	}
 
+	// SSO servers are connected/disconnected automatically -- manual logout is not supported.
+	if ShouldUseTokenExchange(serverInfo) || ShouldUseTokenForwarding(serverInfo) {
+		logging.Debug("AuthTools", "Rejecting manual auth_logout for SSO server %s (session %s)",
+			serverName, logging.TruncateIdentifier(sessionID))
+		return &api.CallToolResult{
+			Content: []interface{}{fmt.Sprintf(
+				"Server '%s' uses SSO and is managed automatically.\n\n"+
+					"Manual logout via core_auth_logout is not supported for SSO servers.\n"+
+					"To disconnect, re-authenticate to muster or contact your administrator.",
+				serverName,
+			)},
+			IsError: true,
+		}, nil
+	}
+
 	// Clear tokens for this server's issuer ONLY if no other server shares it
 	// and it is not muster's upstream issuer. Clearing a shared issuer token
 	// would break other servers (or muster itself) that rely on the same token.

--- a/internal/testing/scenarios/oauth-sso-reconnect-after-relogin.yaml
+++ b/internal/testing/scenarios/oauth-sso-reconnect-after-relogin.yaml
@@ -2,13 +2,15 @@ name: "oauth-sso-reconnect-after-relogin"
 category: "behavioral"
 concept: "mcpserver"
 description: |
-  Tests SSO session lifecycle: login establishes connections, logout clears
-  them, and re-login re-establishes them.
+  Tests SSO session lifecycle: login establishes connections, manual logout
+  is rejected for SSO servers, and re-login re-establishes connections after
+  session revocation.
 
   SSO connections are established synchronously during the OAuth login flow
-  (SessionCreationHandler). After logout from an individual SSO server the
-  capability store entry is removed and the server shows as auth_required.
-  A fresh login re-establishes the connection.
+  (SessionCreationHandler). Manual logout via core_auth_logout is blocked for
+  SSO servers because their lifecycle is managed automatically. To disconnect,
+  users must re-authenticate to muster (which revokes the old session and
+  creates a new one with fresh SSO connections).
 tags: ["oauth", "sso", "session", "relogin", "token-forwarding", "regression"]
 timeout: "2m"
 
@@ -99,23 +101,22 @@ steps:
         - "Connection verified"
 
   # =========================================================================
-  # PHASE 2: Logout clears cache, re-login reconnects
+  # PHASE 2: Manual logout is blocked for SSO servers
   # =========================================================================
 
-  - id: logout-from-server
-    description: "Logout from SSO server clears cached capabilities"
+  - id: logout-from-sso-server-rejected
+    description: "Manual logout from SSO server is rejected"
     tool: "core_auth_logout"
     args:
       server: "relogin-sso-server"
     expected:
-      success: true
+      success: false
       contains:
-        - "logged out"
+        - "SSO"
+        - "not supported"
 
-  # After logout, the SSO server is no longer connected for this session.
-  # SSO connections are only established during login, not on every request.
-  - id: verify-disconnected-after-logout
-    description: "Verify server shows as auth_required after logout"
+  - id: verify-still-connected-after-rejected-logout
+    description: "SSO server remains connected after rejected logout"
     tool: "test_read_auth_status"
     args:
       server: "relogin-sso-server"
@@ -123,11 +124,14 @@ steps:
       success: true
       contains:
         - "relogin-sso-server"
-        - "auth_required"
+        - "connected"
 
-  # Re-login re-establishes SSO connections via SessionCreationHandler.
+  # =========================================================================
+  # PHASE 3: Re-login re-establishes SSO connections
+  # =========================================================================
+
   - id: muster-reauth
-    description: "Re-authenticate to muster to re-establish SSO"
+    description: "Re-authenticate to muster to get a fresh session with SSO"
     tool: "test_muster_auth_login"
     args: {}
     expected:
@@ -137,7 +141,7 @@ steps:
         - "ID token stored"
 
   - id: verify-reconnected-after-relogin
-    description: "Verify SSO server reconnected after re-login"
+    description: "Verify SSO server connected in the new session"
     tool: "test_read_auth_status"
     args:
       server: "relogin-sso-server"


### PR DESCRIPTION
## Summary

- Restores the `core_auth_logout` rejection for SSO servers (token exchange and token forwarding) that was incorrectly removed during the merge of #489
- Updates the `oauth-sso-reconnect-after-relogin` scenario to verify the rejection instead of expecting a successful logout

## Context

During the merge of #489, the SSO logout block was removed to fix a failing BDD scenario. This was an incorrect decision made without consulting the author. The correct fix is to update the scenario to match the intended behavior: SSO servers are managed automatically and manual logout is not supported.

## Test plan

- [x] All unit tests pass (`make test` with `-race`)
- [x] All 164 BDD scenarios pass (`muster test --parallel 50`)
- [x] Code formatted with `goimports` and `go fmt`

Made with [Cursor](https://cursor.com)