### PR TITLE
Fix: Restore groups scope in DefaultOAuthCIMDScopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Remove `groups` from `DefaultOAuthCIMDScopes` -- it is Dex-specific and should not be a universal default for CIMD scopes across all providers.
+- Restore `groups` scope in `DefaultOAuthCIMDScopes` -- required for group-based RBAC in downstream services. Provider-level scope filtering in mcp-oauth (e.g., `filterGoogleScopes`, `filterDexScopes`) handles provider differences.
 
 ### Fixed
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -14,11 +14,11 @@ const (
 	// DefaultOAuthCIMDScopes contains the default OAuth scopes for the CIMD.
 	// Operators can customize this via Helm values (muster.oauth.cimdScopes) to add
 	// additional scopes needed by downstream MCP servers (e.g., Google API scopes).
-	// Provider-specific scopes like "groups" (Dex) are NOT included here because
-	// CIMD scopes apply to all providers. Provider-aware scope handling in mcp-oauth
-	// ensures each provider gets the scopes it needs (e.g., Dex gets groups via
-	// agent scopes, Google filters unsupported scopes).
-	DefaultOAuthCIMDScopes = "openid profile email offline_access"
+	// The "groups" scope is included because group claims are required for RBAC
+	// decisions in downstream services like mcp-kubernetes. Provider-level scope
+	// filtering in mcp-oauth handles provider differences (e.g., Google's
+	// filterGoogleScopes strips unsupported scopes like "groups" automatically).
+	DefaultOAuthCIMDScopes = "openid profile email groups offline_access"
 
 	// DefaultOAuthServerProvider is the default OAuth provider for server protection.
 	DefaultOAuthServerProvider = "dex"


### PR DESCRIPTION
## Summary

- Restores `groups` to `DefaultOAuthCIMDScopes` (`openid profile email groups offline_access`)
- The `groups` scope was incorrectly removed in #514 as "Dex-specific", but it is required for group-based RBAC in downstream services like mcp-kubernetes and is mapped for customers
- Provider-level scope filtering in mcp-oauth already handles provider differences correctly: Google's `filterGoogleScopes` strips unsupported scopes, Dex's `filterDexScopes` keeps `groups`

## Test plan

- [x] All unit tests pass
- CI should be green (no behavioral change in tests, only restoring the previously-working default)


Made with [Cursor](https://cursor.com)