### PR TITLE
Deduplicate aggregated MCP tools from servers exposing the same tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add `ciliumNetworkPolicy.extraEgress` Helm value to allow configuring additional egress rules per installation.
-- Deduplicate aggregated MCP tools when multiple backend servers share the same `toolPrefix`. Instead of exposing duplicate tools (e.g., two `x_kubernetes_list` entries from two clusters), the aggregator now emits a single tool with a `server` enum parameter for choosing which backend handles the call. Callers omitting `server` get routed to the default.
+- Deduplicate aggregated MCP tools when multiple backend servers expose tools with the same original name. Instead of exposing duplicate tools, the aggregator emits a single tool with a required `server` parameter listing the available backend server names. No `toolPrefix` configuration is needed — deduplication is automatic based on tool names.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add `ciliumNetworkPolicy.extraEgress` Helm value to allow configuring additional egress rules per installation.
+- Deduplicate aggregated MCP tools when multiple backend servers share the same `toolPrefix`. Instead of exposing duplicate tools (e.g., two `x_kubernetes_list` entries from two clusters), the aggregator now emits a single tool with a `server` enum parameter for choosing which backend handles the call. Callers omitting `server` get routed to the default.
 
 ### Changed
 

--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -50,6 +51,12 @@ type ServerRegistry struct {
 	serverPrefixes map[string]string // server name -> configured prefix
 	nameMu         sync.RWMutex
 	musterPrefix   string
+
+	// allMappings tracks all servers that provide each exposed name.
+	// When multiple servers share the same toolPrefix and expose the same tool,
+	// their exposed names collide. This map records every server for deduplication
+	// and multi-server routing (protected by nameMu).
+	allMappings map[string][]resolvedName
 }
 
 // NewServerRegistry creates a new server registry with the specified global prefix.
@@ -71,6 +78,7 @@ func NewServerRegistry(musterPrefix string) *ServerRegistry {
 		nameMapping:    make(map[string]resolvedName),
 		serverPrefixes: make(map[string]string),
 		musterPrefix:   musterPrefix,
+		allMappings:    make(map[string][]resolvedName),
 	}
 }
 
@@ -82,7 +90,20 @@ func (r *ServerRegistry) ExposedToolName(serverName, toolName string) string {
 	r.nameMu.Lock()
 	defer r.nameMu.Unlock()
 	exposed := r.buildExposedNameLocked(serverName, toolName)
-	r.nameMapping[exposed] = resolvedName{serverName: serverName, originalName: toolName, itemType: "tool"}
+	rn := resolvedName{serverName: serverName, originalName: toolName, itemType: "tool"}
+	r.nameMapping[exposed] = rn
+	// Track all servers providing this exposed name for deduplication.
+	existing := r.allMappings[exposed]
+	alreadyTracked := false
+	for _, m := range existing {
+		if m.serverName == serverName {
+			alreadyTracked = true
+			break
+		}
+	}
+	if !alreadyTracked {
+		r.allMappings[exposed] = append(existing, rn)
+	}
 	return exposed
 }
 
@@ -289,6 +310,10 @@ func (r *ServerRegistry) GetAllTools() []mcp.Tool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	// seen tracks exposed name → index in allTools for deduplication.
+	seen := make(map[string]int)
+	// serversByTool tracks which servers provide each exposed tool name.
+	serversByTool := make(map[string][]string)
 	var allTools []mcp.Tool
 	connectedCount := 0
 	authRequiredCount := 0
@@ -317,11 +342,27 @@ func (r *ServerRegistry) GetAllTools() []mcp.Tool {
 			// Apply smart prefixing to avoid name conflicts
 			exposedTool := tool
 			exposedTool.Name = r.ExposedToolName(serverName, tool.Name)
-			allTools = append(allTools, exposedTool)
+
+			if _, exists := seen[exposedTool.Name]; !exists {
+				seen[exposedTool.Name] = len(allTools)
+				serversByTool[exposedTool.Name] = []string{serverName}
+				allTools = append(allTools, exposedTool)
+			} else {
+				serversByTool[exposedTool.Name] = append(serversByTool[exposedTool.Name], serverName)
+			}
 		}
 		info.mu.RUnlock()
 
 		logging.Debug("Aggregator", "Server %s has %d tools", serverName, serverToolCount)
+	}
+
+	// For deduplicated tools backed by multiple servers, inject a "server" parameter.
+	for exposedName, servers := range serversByTool {
+		if len(servers) <= 1 {
+			continue
+		}
+		idx := seen[exposedName]
+		allTools[idx] = addServerParam(allTools[idx], servers)
 	}
 
 	logging.Debug("Aggregator", "GetAllTools: returning %d tools from %d connected servers (%d servers require auth, use core_auth_login)",
@@ -413,6 +454,34 @@ func (r *ServerRegistry) ResolveToolName(exposedName string) (serverName, origin
 		return "", "", fmt.Errorf("name %s is a %s, not a tool", exposedName, m.itemType)
 	}
 	return m.serverName, m.originalName, nil
+}
+
+// ResolveToolNameForServer resolves an exposed tool name to a specific server.
+// If the requested server does not provide this tool, an error is returned.
+func (r *ServerRegistry) ResolveToolNameForServer(exposedName, targetServer string) (originalName string, err error) {
+	r.nameMu.RLock()
+	mappings := r.allMappings[exposedName]
+	r.nameMu.RUnlock()
+	for _, m := range mappings {
+		if m.serverName == targetServer && m.itemType == "tool" {
+			return m.originalName, nil
+		}
+	}
+	return "", fmt.Errorf("server %s does not provide tool %s", targetServer, exposedName)
+}
+
+// GetToolServerNames returns all server names that provide a given exposed tool name.
+func (r *ServerRegistry) GetToolServerNames(exposedName string) []string {
+	r.nameMu.RLock()
+	mappings := r.allMappings[exposedName]
+	r.nameMu.RUnlock()
+	names := make([]string, 0, len(mappings))
+	for _, m := range mappings {
+		if m.itemType == "tool" {
+			names = append(names, m.serverName)
+		}
+	}
+	return names
 }
 
 // ResolvePromptName resolves an exposed (prefixed) prompt name back to its source server and original name.
@@ -643,7 +712,21 @@ func (r *ServerRegistry) GetAllToolsForSession(ctx context.Context, store Capabi
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	seen := make(map[string]int)
+	serversByTool := make(map[string][]string)
 	var allTools []mcp.Tool
+
+	addTool := func(serverName string, tool mcp.Tool) {
+		exposedTool := tool
+		exposedTool.Name = r.ExposedToolName(serverName, tool.Name)
+		if _, exists := seen[exposedTool.Name]; !exists {
+			seen[exposedTool.Name] = len(allTools)
+			serversByTool[exposedTool.Name] = []string{serverName}
+			allTools = append(allTools, exposedTool)
+		} else {
+			serversByTool[exposedTool.Name] = append(serversByTool[exposedTool.Name], serverName)
+		}
+	}
 
 	for serverName, info := range r.servers {
 		if info.RequiresSessionAuth() {
@@ -655,9 +738,7 @@ func (r *ServerRegistry) GetAllToolsForSession(ctx context.Context, store Capabi
 				continue
 			}
 			for _, tool := range caps.Tools {
-				exposedTool := tool
-				exposedTool.Name = r.ExposedToolName(serverName, tool.Name)
-				allTools = append(allTools, exposedTool)
+				addTool(serverName, tool)
 			}
 			continue
 		}
@@ -668,11 +749,18 @@ func (r *ServerRegistry) GetAllToolsForSession(ctx context.Context, store Capabi
 
 		info.mu.RLock()
 		for _, tool := range info.Tools {
-			exposedTool := tool
-			exposedTool.Name = r.ExposedToolName(serverName, tool.Name)
-			allTools = append(allTools, exposedTool)
+			addTool(serverName, tool)
 		}
 		info.mu.RUnlock()
+	}
+
+	// For deduplicated tools backed by multiple servers, inject a "server" parameter.
+	for exposedName, servers := range serversByTool {
+		if len(servers) <= 1 {
+			continue
+		}
+		idx := seen[exposedName]
+		allTools[idx] = addServerParam(allTools[idx], servers)
 	}
 
 	return allTools
@@ -788,4 +876,33 @@ func (r *ServerRegistry) IsOAuthServer(serverName string) bool {
 		return false
 	}
 	return info.RequiresSessionAuth()
+}
+
+// addServerParam returns a copy of the tool with a "server" enum parameter
+// injected into its input schema. This allows callers to choose which backend
+// server should handle the call when the same tool is provided by multiple servers.
+func addServerParam(tool mcp.Tool, servers []string) mcp.Tool {
+	sorted := make([]string, len(servers))
+	copy(sorted, servers)
+	sort.Strings(sorted)
+
+	// Build the enum values as []interface{} so JSON schema serialisation works.
+	enumVals := make([]interface{}, len(sorted))
+	for i, s := range sorted {
+		enumVals[i] = s
+	}
+
+	if tool.InputSchema.Properties == nil {
+		tool.InputSchema.Properties = make(map[string]any)
+	}
+	tool.InputSchema.Properties["server"] = map[string]interface{}{
+		"type":        "string",
+		"description": "Target server to execute this tool on. Available: " + strings.Join(sorted, ", "),
+		"enum":        enumVals,
+	}
+
+	// Update description to note multi-server availability.
+	tool.Description = tool.Description + " (available on servers: " + strings.Join(sorted, ", ") + ")"
+
+	return tool
 }

--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -52,10 +52,10 @@ type ServerRegistry struct {
 	nameMu         sync.RWMutex
 	musterPrefix   string
 
-	// allMappings tracks all servers that provide each exposed name.
-	// When multiple servers share the same toolPrefix and expose the same tool,
-	// their exposed names collide. This map records every server for deduplication
-	// and multi-server routing (protected by nameMu).
+	// allMappings tracks all servers that provide each exposed tool name.
+	// When multiple servers expose a tool with the same original name, they are
+	// deduplicated into a single exposed entry with a required "server" parameter.
+	// This map records every server for routing (protected by nameMu).
 	allMappings map[string][]resolvedName
 }
 
@@ -92,18 +92,6 @@ func (r *ServerRegistry) ExposedToolName(serverName, toolName string) string {
 	exposed := r.buildExposedNameLocked(serverName, toolName)
 	rn := resolvedName{serverName: serverName, originalName: toolName, itemType: "tool"}
 	r.nameMapping[exposed] = rn
-	// Track all servers providing this exposed name for deduplication.
-	existing := r.allMappings[exposed]
-	alreadyTracked := false
-	for _, m := range existing {
-		if m.serverName == serverName {
-			alreadyTracked = true
-			break
-		}
-	}
-	if !alreadyTracked {
-		r.allMappings[exposed] = append(existing, rn)
-	}
 	return exposed
 }
 
@@ -310,20 +298,18 @@ func (r *ServerRegistry) GetAllTools() []mcp.Tool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// seen tracks exposed name → index in allTools for deduplication.
-	seen := make(map[string]int)
-	// serversByTool tracks which servers provide each exposed tool name.
-	serversByTool := make(map[string][]string)
-	var allTools []mcp.Tool
+	type toolEntry struct {
+		serverName string
+		tool       mcp.Tool
+	}
+
+	// Pass 1: Group tools by their original (backend) name across all connected servers.
+	toolsByOrigName := make(map[string][]toolEntry)
 	connectedCount := 0
 	authRequiredCount := 0
-	totalServerCount := 0
 
 	for serverName, info := range r.servers {
-		totalServerCount++
-
 		// Per ADR-008: Servers requiring authentication do NOT expose any tools
-		// Users must use core_auth_login to authenticate first
 		if info.RequiresSessionAuth() {
 			authRequiredCount++
 			logging.Debug("Aggregator", "Server %s requires auth, no tools exposed (use core_auth_login)", serverName)
@@ -337,32 +323,36 @@ func (r *ServerRegistry) GetAllTools() []mcp.Tool {
 		connectedCount++
 
 		info.mu.RLock()
-		serverToolCount := len(info.Tools)
 		for _, tool := range info.Tools {
-			// Apply smart prefixing to avoid name conflicts
-			exposedTool := tool
-			exposedTool.Name = r.ExposedToolName(serverName, tool.Name)
-
-			if _, exists := seen[exposedTool.Name]; !exists {
-				seen[exposedTool.Name] = len(allTools)
-				serversByTool[exposedTool.Name] = []string{serverName}
-				allTools = append(allTools, exposedTool)
-			} else {
-				serversByTool[exposedTool.Name] = append(serversByTool[exposedTool.Name], serverName)
-			}
+			toolsByOrigName[tool.Name] = append(toolsByOrigName[tool.Name], toolEntry{
+				serverName: serverName,
+				tool:       tool,
+			})
 		}
 		info.mu.RUnlock()
-
-		logging.Debug("Aggregator", "Server %s has %d tools", serverName, serverToolCount)
 	}
 
-	// For deduplicated tools backed by multiple servers, inject a "server" parameter.
-	for exposedName, servers := range serversByTool {
-		if len(servers) <= 1 {
-			continue
+	// Pass 2: Build deduplicated tool list.
+	var allTools []mcp.Tool
+	for origName, entries := range toolsByOrigName {
+		if len(entries) == 1 {
+			// Single server: use normal prefixed name.
+			tool := entries[0].tool
+			tool.Name = r.ExposedToolName(entries[0].serverName, origName)
+			allTools = append(allTools, tool)
+		} else {
+			// Multiple servers expose the same tool: expose once with a required "server" parameter.
+			tool := entries[0].tool
+			exposedName := r.musterPrefix + "_" + origName
+			tool.Name = exposedName
+			servers := make([]string, len(entries))
+			for i, e := range entries {
+				servers[i] = e.serverName
+			}
+			tool = addServerParam(tool, servers)
+			r.registerDeduplicatedTool(exposedName, origName, servers)
+			allTools = append(allTools, tool)
 		}
-		idx := seen[exposedName]
-		allTools[idx] = addServerParam(allTools[idx], servers)
 	}
 
 	logging.Debug("Aggregator", "GetAllTools: returning %d tools from %d connected servers (%d servers require auth, use core_auth_login)",
@@ -712,21 +702,13 @@ func (r *ServerRegistry) GetAllToolsForSession(ctx context.Context, store Capabi
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	seen := make(map[string]int)
-	serversByTool := make(map[string][]string)
-	var allTools []mcp.Tool
-
-	addTool := func(serverName string, tool mcp.Tool) {
-		exposedTool := tool
-		exposedTool.Name = r.ExposedToolName(serverName, tool.Name)
-		if _, exists := seen[exposedTool.Name]; !exists {
-			seen[exposedTool.Name] = len(allTools)
-			serversByTool[exposedTool.Name] = []string{serverName}
-			allTools = append(allTools, exposedTool)
-		} else {
-			serversByTool[exposedTool.Name] = append(serversByTool[exposedTool.Name], serverName)
-		}
+	type toolEntry struct {
+		serverName string
+		tool       mcp.Tool
 	}
+
+	// Pass 1: Group tools by original name across all servers (including OAuth).
+	toolsByOrigName := make(map[string][]toolEntry)
 
 	for serverName, info := range r.servers {
 		if info.RequiresSessionAuth() {
@@ -738,7 +720,10 @@ func (r *ServerRegistry) GetAllToolsForSession(ctx context.Context, store Capabi
 				continue
 			}
 			for _, tool := range caps.Tools {
-				addTool(serverName, tool)
+				toolsByOrigName[tool.Name] = append(toolsByOrigName[tool.Name], toolEntry{
+					serverName: serverName,
+					tool:       tool,
+				})
 			}
 			continue
 		}
@@ -749,18 +734,33 @@ func (r *ServerRegistry) GetAllToolsForSession(ctx context.Context, store Capabi
 
 		info.mu.RLock()
 		for _, tool := range info.Tools {
-			addTool(serverName, tool)
+			toolsByOrigName[tool.Name] = append(toolsByOrigName[tool.Name], toolEntry{
+				serverName: serverName,
+				tool:       tool,
+			})
 		}
 		info.mu.RUnlock()
 	}
 
-	// For deduplicated tools backed by multiple servers, inject a "server" parameter.
-	for exposedName, servers := range serversByTool {
-		if len(servers) <= 1 {
-			continue
+	// Pass 2: Build deduplicated tool list.
+	var allTools []mcp.Tool
+	for origName, entries := range toolsByOrigName {
+		if len(entries) == 1 {
+			tool := entries[0].tool
+			tool.Name = r.ExposedToolName(entries[0].serverName, origName)
+			allTools = append(allTools, tool)
+		} else {
+			tool := entries[0].tool
+			exposedName := r.musterPrefix + "_" + origName
+			tool.Name = exposedName
+			servers := make([]string, len(entries))
+			for i, e := range entries {
+				servers[i] = e.serverName
+			}
+			tool = addServerParam(tool, servers)
+			r.registerDeduplicatedTool(exposedName, origName, servers)
+			allTools = append(allTools, tool)
 		}
-		idx := seen[exposedName]
-		allTools[idx] = addServerParam(allTools[idx], servers)
 	}
 
 	return allTools
@@ -878,9 +878,27 @@ func (r *ServerRegistry) IsOAuthServer(serverName string) bool {
 	return info.RequiresSessionAuth()
 }
 
-// addServerParam returns a copy of the tool with a "server" enum parameter
-// injected into its input schema. This allows callers to choose which backend
-// server should handle the call when the same tool is provided by multiple servers.
+// registerDeduplicatedTool records reverse-lookup mappings for a tool that is
+// exposed under a single deduplicated name (e.g. x_list_pods) but provided by
+// multiple backend servers. Caller must NOT hold nameMu.
+func (r *ServerRegistry) registerDeduplicatedTool(exposedName, originalName string, serverNames []string) {
+	r.nameMu.Lock()
+	defer r.nameMu.Unlock()
+
+	mappings := make([]resolvedName, len(serverNames))
+	for i, sn := range serverNames {
+		mappings[i] = resolvedName{serverName: sn, originalName: originalName, itemType: "tool"}
+	}
+	r.allMappings[exposedName] = mappings
+	// Set nameMapping to first entry so ResolveToolName can still find it.
+	if len(mappings) > 0 {
+		r.nameMapping[exposedName] = mappings[0]
+	}
+}
+
+// addServerParam returns a copy of the tool with a required "server" enum
+// parameter injected into its input schema. Callers must specify which backend
+// server should handle the call.
 func addServerParam(tool mcp.Tool, servers []string) mcp.Tool {
 	sorted := make([]string, len(servers))
 	copy(sorted, servers)
@@ -900,6 +918,9 @@ func addServerParam(tool mcp.Tool, servers []string) mcp.Tool {
 		"description": "Target server to execute this tool on. Available: " + strings.Join(sorted, ", "),
 		"enum":        enumVals,
 	}
+
+	// Make "server" a required parameter.
+	tool.InputSchema.Required = append(tool.InputSchema.Required, "server")
 
 	// Update description to note multi-server availability.
 	tool.Description = tool.Description + " (available on servers: " + strings.Join(sorted, ", ") + ")"

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1700,12 +1701,10 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 	sessionID := getSessionIDFromContext(ctx)
 
 	// If the caller specified a "server" argument (injected by tool deduplication),
-	// use it to override the default name resolution and remove it from args
-	// before forwarding to the backend.
+	// extract it for routing and remove it from args before forwarding.
 	var targetServer string
 	if serverArg, ok := args["server"].(string); ok && serverArg != "" {
 		targetServer = serverArg
-		// Remove "server" from args so it is not forwarded to the backend tool.
 		cleanArgs := make(map[string]interface{}, len(args)-1)
 		for k, v := range args {
 			if k != "server" {
@@ -1715,17 +1714,29 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 		args = cleanArgs
 	}
 
-	serverName, originalName, err := a.registry.ResolveToolName(toolName)
-
-	// If a specific server was requested and differs from the default resolution,
-	// resolve against that server instead.
-	if targetServer != "" && (err != nil || serverName != targetServer) {
-		origName, resolveErr := a.registry.ResolveToolNameForServer(toolName, targetServer)
-		if resolveErr == nil {
-			serverName = targetServer
-			originalName = origName
-			err = nil
+	// For tools available on multiple servers, the "server" parameter is required.
+	if targetServer == "" {
+		servers := a.registry.GetToolServerNames(toolName)
+		if len(servers) > 1 {
+			sort.Strings(servers)
+			return nil, fmt.Errorf("tool %s is available on multiple servers (%s); the 'server' parameter is required",
+				toolName, strings.Join(servers, ", "))
 		}
+	}
+
+	var serverName, originalName string
+	var err error
+
+	if targetServer != "" {
+		// Resolve against the explicitly requested server.
+		originalName, err = a.registry.ResolveToolNameForServer(toolName, targetServer)
+		if err == nil {
+			serverName = targetServer
+		}
+	}
+	if serverName == "" {
+		// Fall back to default resolution (single-server tools).
+		serverName, originalName, err = a.registry.ResolveToolName(toolName)
 	}
 
 	if err == nil {
@@ -1752,6 +1763,10 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 			}
 			logging.DebugWithAttrs("Aggregator", "Server requires auth, trying on-demand client",
 				slog.String("server", serverName), slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
+			// If the server was explicitly targeted (dedup tool), use the already-resolved names directly.
+			if targetServer != "" {
+				return a.callToolWithTokenExchangeRetry(ctx, serverName, originalName, args, sessionID, sub)
+			}
 			_, sessionOriginalName, sessionErr := a.resolveUserTool(sessionID, toolName)
 			if sessionErr == nil {
 				logging.DebugWithAttrs("Aggregator", "Using on-demand client",

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1699,7 +1699,35 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 	sub := getUserSubjectFromContext(ctx)
 	sessionID := getSessionIDFromContext(ctx)
 
+	// If the caller specified a "server" argument (injected by tool deduplication),
+	// use it to override the default name resolution and remove it from args
+	// before forwarding to the backend.
+	var targetServer string
+	if serverArg, ok := args["server"].(string); ok && serverArg != "" {
+		targetServer = serverArg
+		// Remove "server" from args so it is not forwarded to the backend tool.
+		cleanArgs := make(map[string]interface{}, len(args)-1)
+		for k, v := range args {
+			if k != "server" {
+				cleanArgs[k] = v
+			}
+		}
+		args = cleanArgs
+	}
+
 	serverName, originalName, err := a.registry.ResolveToolName(toolName)
+
+	// If a specific server was requested and differs from the default resolution,
+	// resolve against that server instead.
+	if targetServer != "" && (err != nil || serverName != targetServer) {
+		origName, resolveErr := a.registry.ResolveToolNameForServer(toolName, targetServer)
+		if resolveErr == nil {
+			serverName = targetServer
+			originalName = origName
+			err = nil
+		}
+	}
+
 	if err == nil {
 		logging.DebugWithAttrs("Aggregator", "Tool found in registry",
 			slog.String("tool", toolName), slog.String("server", serverName), slog.String("original", originalName))

--- a/internal/aggregator/server_test.go
+++ b/internal/aggregator/server_test.go
@@ -162,7 +162,7 @@ func TestAggregatorServer_HandlerTracking(t *testing.T) {
 
 	// Verify tools are available
 	tools := server.GetTools()
-	assert.Len(t, tools, 4) // tool1, tool2, and shared-tool from each server (all prefixed)
+	assert.Len(t, tools, 3) // tool1, tool2, and deduplicated shared-tool
 
 	// Verify tools are tracked by checking they exist in GetTools()
 	toolMap := make(map[string]bool)
@@ -171,8 +171,8 @@ func TestAggregatorServer_HandlerTracking(t *testing.T) {
 	}
 	assert.True(t, toolMap["x_server1_tool1"])
 	assert.True(t, toolMap["x_server2_tool2"])
-	assert.True(t, toolMap["x_server1_shared-tool"])
-	assert.True(t, toolMap["x_server2_shared-tool"])
+	// shared-tool is deduplicated: exposed as x_shared-tool with required "server" param
+	assert.True(t, toolMap["x_shared-tool"])
 
 	// Deregister server1
 	err = server.DeregisterServer("server1")
@@ -191,9 +191,8 @@ func TestAggregatorServer_HandlerTracking(t *testing.T) {
 		toolMap2[tool.Name] = true
 	}
 	assert.False(t, toolMap2["x_server1_tool1"])
-	assert.False(t, toolMap2["x_server1_shared-tool"])
 	assert.True(t, toolMap2["x_server2_tool2"])
-	// After deregistering server1, shared-tool from server2 is still prefixed
+	// After deregistering server1, shared-tool is only on server2 (normal prefixed name)
 	assert.True(t, toolMap2["x_server2_shared-tool"])
 }
 

--- a/internal/metatools/formatters.go
+++ b/internal/metatools/formatters.go
@@ -101,8 +101,9 @@ func (f *Formatters) FormatToolsListJSON(tools []mcp.Tool) (string, error) {
 //	}
 func (f *Formatters) FormatToolsListWithAuthJSON(tools []mcp.Tool, serversRequiringAuth []api.ServerAuthInfo) (string, error) {
 	type ToolInfo struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		Name        string   `json:"name"`
+		Description string   `json:"description"`
+		Servers     []string `json:"servers,omitempty"`
 	}
 
 	type Response struct {
@@ -115,6 +116,20 @@ func (f *Formatters) FormatToolsListWithAuthJSON(tools []mcp.Tool, serversRequir
 		toolList[i] = ToolInfo{
 			Name:        tool.Name,
 			Description: tool.Description,
+		}
+		// If the tool has an injected "server" enum parameter, expose the server list.
+		if serverProp, ok := tool.InputSchema.Properties["server"]; ok {
+			if serverMap, ok := serverProp.(map[string]interface{}); ok {
+				if enumVals, ok := serverMap["enum"].([]interface{}); ok {
+					servers := make([]string, 0, len(enumVals))
+					for _, v := range enumVals {
+						if s, ok := v.(string); ok {
+							servers = append(servers, s)
+						}
+					}
+					toolList[i].Servers = servers
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Feature

When multiple backend MCP servers expose tools with the same original name, the aggregator now automatically deduplicates them into a single exposed tool with a required `server` parameter. The deduplicated tool uses only the muster prefix and the original tool name — no server name in the tool name.

**Before** — two kubernetes MCP servers (`kubernetes-graveler`, `kubernetes-gazelle`) both exposing `kubernetes_api_resources` produced duplicate tools:

```
x_kubernetes-graveler_kubernetes_api_resources
x_kubernetes-graveler_kubernetes_apply
x_kubernetes-graveler_kubernetes_get
...
x_kubernetes-gazelle_kubernetes_api_resources
x_kubernetes-gazelle_kubernetes_apply
x_kubernetes-gazelle_kubernetes_get
...
```

(38 tools — every tool duplicated)

**After** — the aggregator detects that `kubernetes_api_resources` exists on multiple servers and exposes a single deduplicated tool:

```
x_kubernetes_api_resources
x_kubernetes_apply
x_kubernetes_get
x_list_port_forward_sessions
...
```

(19 tools — each with a required `server` parameter)

Each deduplicated tool has a required `server` enum parameter listing the available backends:

```json
{
  "name": "x_kubernetes_api_resources",
  "description": "... (available on servers: kubernetes-gazelle, kubernetes-graveler)",
  "inputSchema": {
    "properties": {
      "server": {
        "type": "string",
        "description": "Target server to execute this tool on. Available: kubernetes-gazelle, kubernetes-graveler",
        "enum": ["kubernetes-gazelle", "kubernetes-graveler"]
      }
    },
    "required": ["server"]
  }
}
```

Tools unique to a single server continue to use the normal prefixed naming: `x_{serverName}_{toolName}`.

## Test Procedure

### Unit Tests

```
$ go test ./internal/aggregator/ -run TestAggregatorServer_HandlerTracking -v
=== RUN   TestAggregatorServer_HandlerTracking
--- PASS: TestAggregatorServer_HandlerTracking (0.20s)
PASS

$ go test ./internal/aggregator/ -run TestServerRegistry -v
=== RUN   TestServerRegistry_AlwaysPrefixing
=== RUN   TestServerRegistry_AlwaysPrefixing/All_tools_get_prefixed
=== RUN   TestServerRegistry_AlwaysPrefixing/Tools_with_same_names_get_prefixed
=== RUN   TestServerRegistry_AlwaysPrefixing/Multiple_servers_with_same_tool
--- PASS: TestServerRegistry_AlwaysPrefixing (0.00s)
=== RUN   TestServerRegistry_ResolveName
=== RUN   TestServerRegistry_ResolveName/x_serverA_unique_tool
=== RUN   TestServerRegistry_ResolveName/x_serverA_shared_tool
=== RUN   TestServerRegistry_ResolveName/x_serverB_shared_tool
=== RUN   TestServerRegistry_ResolveName/x_serverA_unique_prompt
=== RUN   TestServerRegistry_ResolveName/x_serverB_shared_prompt
=== RUN   TestServerRegistry_ResolveName/x_serverC_shared_prompt
=== RUN   TestServerRegistry_ResolveName/non_existent
--- PASS: TestServerRegistry_ResolveName (0.00s)
PASS
```

### Integration Test

With two MCP servers both exposing the same tools:

1. **Tool listing** — `list_tools` returns deduplicated tools instead of duplicates
2. **Calling without `server`** — Returns an error: `tool x_kubernetes_api_resources is available on multiple servers (kubernetes-gazelle, kubernetes-graveler); the 'server' parameter is required`
3. **Calling with `server`** — Routes to the correct backend, stripping the `server` param before forwarding
4. **Server deregistration** — When a server is removed, its tools revert to normal prefixed naming on the remaining server

## Changes

- **`internal/aggregator/registry.go`** — Rewrote `GetAllTools` and `GetAllToolsForSession` with a two-pass algorithm: Pass 1 groups tools by their original backend name across all connected servers; Pass 2 builds the exposed list where single-server tools get prefixed normally (`x_{serverName}_{toolName}`) and multi-server tools are deduplicated as `x_{originalToolName}` with a required `server` enum parameter. Added `registerDeduplicatedTool` for reverse-lookup mappings. Made `server` a required field in `addServerParam`.
- **`internal/aggregator/server.go`** — Updated `CallToolInternal` to enforce the required `server` parameter for multi-server tools (returns an error if omitted instead of routing to a default). Added explicit-server resolution path and auth short-circuit for deduplicated tools targeting OAuth servers.
- **`internal/aggregator/server_test.go`** — Updated `TestAggregatorServer_HandlerTracking` to expect 3 tools (deduplicated `x_shared-tool`) instead of 4 (duplicate `x_server1_shared-tool` + `x_server2_shared-tool`).
- **`CHANGELOG.md`** — Added changelog entry.