### PR TITLE
fix: validate muster CRDs via discovery API instead of namespaced list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Bump `mcp-oauth` to v0.2.86 with Dex scope filtering: non-standard client scopes like `claudeai` (sent by Claude) are now stripped before forwarding to Dex, preventing `invalid_scope` errors. Also includes Google scope filtering and `openid` force-merge from v0.2.84.
+- CRD validation now uses the discovery API instead of listing `MCPServer` resources in the `default` namespace. With namespace-scoped RBAC (a `Role` limited to muster's own namespace), the previous probe failed with `Forbidden`, silently fell back to filesystem mode, and left configured `MCPServer` CRs unstarted (visible in logs as `Found 0 MCPServer definitions for auto-start processing` followed by `Deleting MCPServer service: <name>`).
 
 ## [0.1.0] - 2026-02-23
 

--- a/internal/client/kubernetes_client.go
+++ b/internal/client/kubernetes_client.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +31,8 @@ import (
 // caching, and event-driven updates through informers and watches.
 type kubernetesClient struct {
 	client.Client
-	scheme *runtime.Scheme
+	scheme    *runtime.Scheme
+	discovery discovery.DiscoveryInterface
 }
 
 // NewKubernetesClient creates a new Kubernetes-based muster client.
@@ -61,10 +64,17 @@ func NewKubernetesClient(config *rest.Config) (MusterClient, error) {
 		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
-	// Validate that required CRDs are available
+	// Discovery client is used to validate CRD presence without requiring
+	// namespaced list permissions on the muster CRDs themselves.
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
 	musterClient := &kubernetesClient{
-		Client: k8sClient,
-		scheme: scheme,
+		Client:    k8sClient,
+		scheme:    scheme,
+		discovery: discoveryClient,
 	}
 
 	if err := musterClient.validateCRDs(context.Background()); err != nil {
@@ -306,18 +316,28 @@ func (k *kubernetesClient) Scheme() *runtime.Scheme {
 
 // validateCRDs checks if the required muster CRDs are available in the cluster.
 //
-// This method performs a test API call to verify that the MCPServer CRD is installed
-// and available. If the CRDs are not available, it returns an error, which will
-// trigger fallback to filesystem mode.
+// Validation uses the discovery API to verify that the muster API group is
+// served and exposes the MCPServer kind. This avoids requiring list/get
+// permissions on the muster CRDs in any specific namespace, which is
+// important when muster runs with namespace-scoped RBAC (e.g. a Role limited
+// to its own namespace).
 func (k *kubernetesClient) validateCRDs(ctx context.Context) error {
-	// Try to list MCPServers in the default namespace
-	// This will fail if the CRD is not installed
-	_, err := k.ListMCPServers(ctx, "default")
+	gv := musterv1alpha1.GroupVersion.String()
+	resourceList, err := k.discovery.ServerResourcesForGroupVersion(gv)
 	if err != nil {
-		return fmt.Errorf("MCPServer CRD not available: %w", err)
+		if apierrors.IsNotFound(err) || discovery.IsGroupDiscoveryFailedError(err) {
+			return fmt.Errorf("muster API group %s not registered: %w", gv, err)
+		}
+		return fmt.Errorf("failed to discover muster API group %s: %w", gv, err)
 	}
 
-	return nil
+	for _, r := range resourceList.APIResources {
+		if r.Kind == "MCPServer" {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("MCPServer CRD not available in API group %s", gv)
 }
 
 // CreateEvent creates a Kubernetes Event for the given object.


### PR DESCRIPTION
## Summary

The Kubernetes-backed muster client validates the presence of muster CRDs at startup. The previous probe listed `MCPServer` resources in the hard-coded `default` namespace and treated any error as "CRD not available". When muster runs with namespace-scoped RBAC (a `Role` limited to its own namespace), this probe returns `Forbidden`, the constructor wraps it as "MCPServer CRD not available", and `NewMusterClient` silently falls back to filesystem mode.

Symptom in the wild (BWI demo cluster): configured `MCPServer` CRs were never auto-started and the aggregator only exposed the 11 built-in meta-tools. Logs:

```
KubernetesDetector  Started watching Kubernetes resources in namespace: bwi-backstage
Orchestrator        Found 0 MCPServer definitions for auto-start processing
MCPServerReconciler Deleting MCPServer service: mcp-kubernetes
Aggregator          Received tool update event ... tools=11
```

The `KubernetesDetector` informer kept emitting reconcile events for the existing CR, but the orchestrator's `MCPServerManager` was filesystem-backed and returned NotFound, which the reconciler classified as a delete -- so the service was never started.

## Fix

Switch the probe in `validateCRDs` to the discovery API (`ServerResourcesForGroupVersion`). Discovery checks that the muster API group is served and exposes the `MCPServer` kind without requiring list/get permissions on the muster CRDs in any specific namespace. This works for both cluster-scoped and namespace-scoped RBAC.

- `internal/client/kubernetes_client.go`
  - Add `discovery.DiscoveryInterface` to `kubernetesClient`.
  - Construct a `DiscoveryClient` from the rest config in `NewKubernetesClient`.
  - Rewrite `validateCRDs` to use `ServerResourcesForGroupVersion(musterv1alpha1.GroupVersion)` and look for the `MCPServer` kind.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`, `gofmt`, `goimports`
- [x] `go test ./...`
- [ ] Verified on the affected cluster: roll the muster pod after merging into the chart and confirm the `mcp-kubernetes` MCPServer is auto-started and tools are surfaced through the aggregator.

Made with [Cursor](https://cursor.com)