### PR TITLE
WIP: debug-log incoming bearer tokens

### DIFF
--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -287,6 +287,12 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		if s.debug {
+			if bearer := extractBearerToken(r); bearer != "" {
+				logging.Debug("OAuth", "Incoming bearer token on %s: %s", r.URL.Path, bearer)
+			}
+		}
+
 		// Get user info from context (set by ValidateToken middleware)
 		userInfo, ok := oauth.UserInfoFromContext(ctx)
 		if !ok || userInfo == nil {

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -269,12 +269,30 @@ func (s *OAuthHTTPServer) setupMCPRoutes(mux *http.ServeMux) {
 	// Create middleware to inject access token into context for downstream use
 	accessTokenInjector := s.createAccessTokenInjectorMiddleware(s.mcpHandler)
 
-	// Wrap MCP endpoint with OAuth middleware (ValidateToken validates and adds user info)
-	mux.Handle("/mcp", s.oauthHandler.ValidateToken(accessTokenInjector))
-	mux.Handle("/sse", s.oauthHandler.ValidateToken(accessTokenInjector))
-	mux.Handle("/message", s.oauthHandler.ValidateToken(accessTokenInjector))
+	// Wrap MCP endpoint with OAuth middleware (ValidateToken validates and adds user info).
+	// s.logIncomingBearer wraps ValidateToken so we log every incoming bearer token
+	// regardless of whether ValidateToken accepts or rejects it.
+	mcpChain := s.logIncomingBearer(s.oauthHandler.ValidateToken(accessTokenInjector))
+	mux.Handle("/mcp", mcpChain)
+	mux.Handle("/sse", mcpChain)
+	mux.Handle("/message", mcpChain)
 
 	logging.Info("OAuth", "Protected MCP endpoints with OAuth middleware")
+}
+
+// logIncomingBearer is a debug-only middleware that logs the raw Authorization
+// bearer token for every request on the protected MCP endpoints. It runs
+// BEFORE ValidateToken so tokens that are later rejected (expired, wrong
+// audience, bad signature) are still visible. No-op when s.debug is false.
+func (s *OAuthHTTPServer) logIncomingBearer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.debug {
+			if bearer := extractBearerToken(r); bearer != "" {
+				logging.Debug("OAuth", "Incoming bearer token on %s: %s", r.URL.Path, bearer)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // createAccessTokenInjectorMiddleware creates middleware that injects the user's
@@ -286,12 +304,6 @@ func (s *OAuthHTTPServer) setupMCPRoutes(mux *http.ServeMux) {
 func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-
-		if s.debug {
-			if bearer := extractBearerToken(r); bearer != "" {
-				logging.Debug("OAuth", "Incoming bearer token on %s: %s", r.URL.Path, bearer)
-			}
-		}
 
 		// Get user info from context (set by ValidateToken middleware)
 		userInfo, ok := oauth.UserInfoFromContext(ctx)


### PR DESCRIPTION
## Summary
- Adds a debug-gated log line in the MCP OAuth access-token injector middleware that emits the raw `Authorization: Bearer` token for every incoming request to `/mcp`, `/sse`, or `/message`.
- Only active when `--debug` / `MUSTER_DEBUG=true`. Intended as a troubleshooting aid for inspecting forwarded OIDC ID tokens (claims, issuer, audience).

## Test plan
- [ ] Start `muster serve --debug` and hit `/mcp` with a bearer token; verify the token appears in the log.
- [ ] Start `muster serve` without debug; verify no token is logged.
- [ ] Decide before merging whether full-token logging is acceptable even behind a debug flag, or whether we should truncate / mask.