### PR TITLE
fix: forward underlying tool error to call_tool outer isError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - Bump `mcp-oauth` to v0.2.86 with Dex scope filtering: non-standard client scopes like `claudeai` (sent by Claude) are now stripped before forwarding to Dex, preventing `invalid_scope` errors. Also includes Google scope filtering and `openid` force-merge from v0.2.84.
 - CRD validation now uses the discovery API instead of listing `MCPServer` resources in the `default` namespace. With namespace-scoped RBAC (a `Role` limited to muster's own namespace), the previous probe failed with `Forbidden`, silently fell back to filesystem mode, and left configured `MCPServer` CRs unstarted (visible in logs as `Found 0 MCPServer definitions for auto-start processing` followed by `Deleting MCPServer service: <name>`).
+- `call_tool` meta-tool now forwards the underlying tool's `isError` flag on the outer response. Previously the top-level `isError` was always `false` even when the wrapped tool returned an error, which was misleading for MCP clients that only inspect the top-level flag.
 
 ## [0.1.0] - 2026-02-23
 

--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -303,7 +303,12 @@ func (p *Provider) handleCallTool(ctx context.Context, args map[string]interface
 		return errorResult(fmt.Sprintf("Failed to serialize result: %v", err)), nil
 	}
 
-	return textResult(string(resultJSON)), nil
+	// Propagate the underlying tool's error status to the outer wrapper so that
+	// MCP clients inspecting only the top-level isError field get an accurate signal.
+	return &api.CallToolResult{
+		Content: []interface{}{string(resultJSON)},
+		IsError: result.IsError,
+	}, nil
 }
 
 // handleListResources handles the list_resources meta-tool.

--- a/internal/metatools/handlers_test.go
+++ b/internal/metatools/handlers_test.go
@@ -287,6 +287,33 @@ func TestProvider_HandleCallTool(t *testing.T) {
 		assert.False(t, parsed.IsError)
 	})
 
+	t.Run("forwards underlying tool error to outer IsError", func(t *testing.T) {
+		previous := mock.callToolResult
+		mock.callToolResult = &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{Type: "text", Text: "underlying failure"},
+			},
+			IsError: true,
+		}
+		defer func() { mock.callToolResult = previous }()
+
+		result, err := provider.ExecuteTool(ctx, "call_tool", map[string]interface{}{
+			"name": "some_tool",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError, "outer IsError must mirror the underlying tool's IsError")
+
+		content := result.Content[0].(string)
+		var parsed struct {
+			IsError bool          `json:"isError"`
+			Content []interface{} `json:"content"`
+		}
+		err = json.Unmarshal([]byte(content), &parsed)
+		require.NoError(t, err)
+		assert.True(t, parsed.IsError)
+	})
+
 	t.Run("error for missing name", func(t *testing.T) {
 		result, err := provider.ExecuteTool(ctx, "call_tool", nil)
 		require.NoError(t, err)

--- a/internal/testing/mcp_client.go
+++ b/internal/testing/mcp_client.go
@@ -234,29 +234,19 @@ func (c *mcpTestClient) CallToolDirect(ctx context.Context, toolName string, arg
 
 // unwrapMetaToolResponse extracts the actual tool result from a call_tool meta-tool response.
 // The call_tool meta-tool wraps tool results in a JSON structure for proper serialization.
+//
+// The outer result.IsError mirrors the wrapped tool's IsError (see metatools.handleCallTool),
+// so we unwrap the JSON payload first regardless of the outer flag. An outer IsError=true with
+// a non-JSON payload indicates a meta-tool level failure (e.g. missing arguments).
 func (c *mcpTestClient) unwrapMetaToolResponse(result *mcp.CallToolResult, toolName string) (*mcp.CallToolResult, error) {
 	if result == nil {
 		return nil, fmt.Errorf("nil result from call_tool")
 	}
 
-	// Check if the meta-tool call itself failed
-	if result.IsError {
-		// Extract error message from content
-		var errorMsgs []string
-		for _, content := range result.Content {
-			if textContent, ok := mcp.AsTextContent(content); ok {
-				errorMsgs = append(errorMsgs, textContent.Text)
-			}
-		}
-		return nil, fmt.Errorf("meta-tool error: %s", fmt.Sprintf("%v", errorMsgs))
-	}
-
-	// The call_tool meta-tool returns a single text content containing the wrapped result as JSON
 	if len(result.Content) == 0 {
 		return nil, fmt.Errorf("empty content from call_tool")
 	}
 
-	// Get the JSON string from the first text content
 	textContent, ok := mcp.AsTextContent(result.Content[0])
 	if !ok {
 		return nil, fmt.Errorf("unexpected content type from call_tool")
@@ -272,6 +262,10 @@ func (c *mcpTestClient) unwrapMetaToolResponse(result *mcp.CallToolResult, toolN
 	}
 
 	if err := json.Unmarshal([]byte(textContent.Text), &wrappedResult); err != nil {
+		// No JSON wrapper — this is a meta-tool level failure (e.g. validation error).
+		if result.IsError {
+			return nil, fmt.Errorf("meta-tool error: %s", textContent.Text)
+		}
 		return nil, fmt.Errorf("failed to parse wrapped result: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- The `call_tool` meta-tool always returned `isError: false` on the outer response, even when the wrapped tool returned an error. MCP clients inspecting only the top-level `isError` got a misleading success signal.
- Propagate the wrapped tool's `IsError` onto the outer `CallToolResult` in `handleCallTool`, and adjust the BDD test client's `unwrapMetaToolResponse` to keep unwrapping when the outer flag is true (only fall back to "meta-tool error" when content isn't the wrapped JSON shape).

The extra JSON-in-text wrapping is preserved — per the `CRITICAL` comment in `handleCallTool`, BDD tests and clients rely on the wrapped structure. Removing that wrapping is a larger architectural change (threading native `mcp.Content` through `api.CallToolResult` and the aggregator's `convertToMCPResult`) and should be a separate follow-up if desired.

Fixes giantswarm/roadmap#4281

## Test plan

- [x] `go test ./internal/metatools/ -run TestProvider_HandleCallTool -v` — includes a new subtest `forwards underlying tool error to outer IsError`
- [x] `go test ./internal/metatools/ ./internal/testing/...`
- [x] `go build ./...`
- [ ] Manual: call a tool via `call_tool` that errors in the underlying MCP server and confirm the top-level `isError: true` in the response