### PR TITLE
ci: fix pre-commit failures introduced by admin UI

### DIFF
--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -38,7 +38,7 @@ func TestHandleList_html(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
@@ -67,7 +67,7 @@ func TestHandleList_json(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
 		t.Fatalf("expected json content-type, got %s", ct)
 	}
@@ -104,7 +104,7 @@ func TestHandleDetail_rendersDecodedJWT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
@@ -143,7 +143,7 @@ func TestHandleDetail_notFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
@@ -162,7 +162,7 @@ func TestHandleDelete_callsCallbackAndRedirects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("expected 303, got %d", resp.StatusCode)
 	}
@@ -186,7 +186,7 @@ func TestHandleReconnect_callsCallbackAndRedirects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("expected 303, got %d", resp.StatusCode)
 	}
@@ -213,7 +213,7 @@ func TestHandleMCPList_html(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
@@ -243,7 +243,7 @@ func TestHandleMCPDetail_rendersMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
@@ -265,7 +265,7 @@ func TestHandleMCPDetail_notFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}

--- a/internal/admin/templates/layout.html.tmpl
+++ b/internal/admin/templates/layout.html.tmpl
@@ -9,9 +9,9 @@
 <header>
 <div class="header-brand">
 <div class="icon-container">
-<img src="https://s.giantswarm.io/app-icons/muster/1/light.svg" 
-     alt="Muster" 
-     class="muster-icon" 
+<img src="https://s.giantswarm.io/app-icons/muster/1/light.svg"
+     alt="Muster"
+     class="muster-icon"
      onerror="this.style.display='none'"/>
 </div>
 <strong>muster</strong>


### PR DESCRIPTION
## Summary

PR #579 (Admin web UI) introduced `internal/admin/` with patterns that pre-commit had already cleaned up repo-wide in PR #585. As a result, `pre-commit run --all-files` is failing on main, which in turn fails CI for every renovate PR (currently #589 and #590).

This PR brings `internal/admin/` up to the same standard so pre-commit is green again.

- **errcheck**: 9 sites in `internal/admin/handlers_test.go` rewritten as `defer func() { _ = resp.Body.Close() }()` — same pattern PR #585 applied across the repo (304 sites).
- **trailing-whitespace**: stripped from `internal/admin/templates/layout.html.tmpl` (3 lines on the `<img>` element).

No behavioral changes.

## Test plan

- [x] `go build ./internal/admin/...` succeeds
- [x] `go test ./internal/admin/...` passes
- [x] No remaining `defer resp.Body.Close()` in the file
- [x] No remaining trailing whitespace under `internal/admin/`
- [ ] CI pre-commit job passes on this PR
- [ ] After merge: rebase #589 / #590 to confirm their pre-commit goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)