### PR TITLE
ci: fix goconst violation in cmd/create.go

### DIFF
--- a/cmd/call.go
+++ b/cmd/call.go
@@ -187,7 +187,7 @@ func parseCallArguments(toolName string, osArgs []string) map[string]interface{}
 // everything else stays as string.
 func coerceValue(s string) interface{} {
 	switch s {
-	case "true": //nolint:goconst
+	case stringTrue:
 		return true
 	case "false":
 		return false

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -12,6 +12,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// stringTrue is the string form of a boolean true used by CLI flag parsing.
+const stringTrue = "true"
+
 var createFlags cli.CommandFlags
 
 // Available resource types for create operations
@@ -167,7 +170,7 @@ func parseServiceParameters(serviceClassName string) map[string]interface{} {
 					i++ // Skip the next argument since we consumed it
 				} else {
 					// Boolean flag
-					params[paramArg] = "true"
+					params[paramArg] = stringTrue
 				}
 			}
 		}
@@ -249,7 +252,7 @@ func processMCPServerFlag(args map[string]interface{}, flagName, flagValue strin
 		}
 	case "autoStart", "auto-start":
 		if hasValue {
-			args["autoStart"] = flagValue == "true"
+			args["autoStart"] = flagValue == stringTrue
 		} else {
 			args["autoStart"] = true
 		}

--- a/cmd/standalone.go
+++ b/cmd/standalone.go
@@ -53,5 +53,5 @@ func init() {
 	standaloneCmd.Flags().AddFlagSet(agentCmd.Flags())
 	standaloneCmd.Flags().AddFlagSet(serveCmd.Flags())
 
-	standaloneCmd.Flags().Lookup("silent").DefValue = "true" //nolint:goconst
+	standaloneCmd.Flags().Lookup("silent").DefValue = stringTrue
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -173,7 +173,7 @@ func parseWorkflowParameters(workflowName string) map[string]interface{} {
 					i++ // Skip the next argument since we consumed it
 				} else {
 					// Boolean flag
-					params[paramArg] = "true"
+					params[paramArg] = stringTrue
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

`golangci-lint` (a required check in main's branch protection) was failing PR #589 with:

```
cmd/create.go:170:25: string `true` has 5 occurrences, make it a constant (goconst)
```

Two of those 5 sites had been worked around with `//nolint:goconst`. This PR introduces a `stringTrue` package-level const in `cmd/create.go` and replaces all 5 occurrences, dropping the local suppressions.

Sites updated:
- `cmd/create.go` — `parseServiceParameters` boolean-flag default; `processMCPServerFlag` `autoStart` comparison
- `cmd/standalone.go` — `silent` flag `DefValue`
- `cmd/call.go` — `coerceValue` switch case (drop `//nolint:goconst`)
- `cmd/start.go` — `parseWorkflowParameters` boolean-flag default

## Test plan

- [x] `go build ./cmd/...` succeeds
- [x] `go test ./cmd/...` passes
- [x] `golangci-lint run -E=gosec -E=goconst -E=govet ./cmd/...` reports `0 issues.`
- [ ] CI pre-commit job passes on this PR
- [ ] After merge: rebase #589 (`@renovatebot rebase`) to confirm its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)