### PR TITLE
feat(oauth): align with mcp-oauth v0.2.117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - Add `muster call` command for direct MCP tool invocation from the CLI. Supports `--key=value` arguments and `--json` for complex payloads, with tab completion for tool names.
 - Add `ciliumNetworkPolicy.allowClusterIngress` Helm value to allow egress to in-cluster services on HTTP/HTTPS ports (e.g. Dex OIDC via ingress LoadBalancer IP).
+- OAuth encryption keys can now be supplied as either base64 (`openssl rand -base64 32`) or hex (`openssl rand -hex 32`); the format is auto-detected.
+- Agent OAuth client now validates the RFC 9207 `iss` parameter on the authorization callback (defense-in-depth against AS mix-up attacks). Servers that omit `iss` are still accepted.
+- Authorization-server discovery now also serves `/.well-known/openid-configuration` and per-path Protected Resource Metadata at `/.well-known/oauth-protected-resource/mcp` (additive — RFC 9728 / OpenID Connect Discovery).
 
 ### Changed
 
 - Restore `groups` scope in `DefaultOAuthCIMDScopes` -- required for group-based RBAC in downstream services. Provider-level scope filtering in mcp-oauth (e.g., `filterGoogleScopes`, `filterDexScopes`) handles provider differences.
+- Bump `mcp-oauth` to v0.2.117. Adopts `oauth.NewServerWithCombined` and `Handler.RegisterOAuthRoutes` to simplify server wiring; the authorization callback now includes the RFC 9207 `iss` parameter automatically. **Operational note:** mcp-oauth now rejects low-entropy AES-256 token-encryption keys (fewer than 16 distinct byte values). Real keys generated with `openssl rand -base64 32` or `openssl rand -hex 32` are unaffected; placeholder keys (all zeros, repeated bytes) will fail at startup with a clear error — rotate before upgrading.
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/giantswarm/mcp-oauth v0.2.104
+	github.com/giantswarm/mcp-oauth v0.2.117
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.10

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.104 h1:RMQzudRXsQKURrGFUVz27zf0e/bRU01NrPjy2WS1aLs=
-github.com/giantswarm/mcp-oauth v0.2.104/go.mod h1:l3qR16J9TWUggTrb3FpRxegW7bI339LDwA3LQK/jnWI=
+github.com/giantswarm/mcp-oauth v0.2.117 h1:yU8s0NpwIqFbiT5pit5ZA3KVo2hLPUOycFcjVdfsjNE=
+github.com/giantswarm/mcp-oauth v0.2.117/go.mod h1:l3qR16J9TWUggTrb3FpRxegW7bI339LDwA3LQK/jnWI=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/agent/oauth/callback_server.go
+++ b/internal/agent/oauth/callback_server.go
@@ -31,6 +31,11 @@ type CallbackResult struct {
 	// State is the state parameter to verify against the original request.
 	State string
 
+	// Iss is the RFC 9207 issuer identifier returned in the authorization
+	// response. Non-conforming servers omit it; callers must treat empty
+	// as "not advertised" rather than "did not match".
+	Iss string
+
 	// Error is the error code if the authorization failed.
 	Error string
 
@@ -156,6 +161,7 @@ func (s *CallbackServer) processCallback(w http.ResponseWriter, r *http.Request)
 	result := &CallbackResult{
 		Code:             query.Get("code"),
 		State:            query.Get("state"),
+		Iss:              query.Get("iss"),
 		Error:            query.Get("error"),
 		ErrorDescription: query.Get("error_description"),
 	}

--- a/internal/agent/oauth/client.go
+++ b/internal/agent/oauth/client.go
@@ -288,6 +288,27 @@ func (c *Client) WaitForCallback(ctx context.Context) (*oauth2.Token, error) {
 		return nil, errors.New("state mismatch - possible CSRF attack")
 	}
 
+	// Verify iss (RFC 9207) to defend against authorization-server mix-up
+	// attacks when the client talks to multiple ASes. Non-conforming servers
+	// omit the param; treat empty as "not advertised", not as a mismatch.
+	if result.Iss != "" {
+		expected := flow.IssuerURL
+		if flow.Metadata != nil && flow.Metadata.Issuer != "" {
+			expected = flow.Metadata.Issuer
+		}
+		if result.Iss != expected {
+			slog.Debug("OAuth iss mismatch detected - possible AS mix-up attack",
+				"server_url", flow.ServerURL,
+				"expected_iss", expected,
+				"received_iss", result.Iss,
+			)
+			c.mu.Lock()
+			c.cancelCurrentFlow()
+			c.mu.Unlock()
+			return nil, fmt.Errorf("iss mismatch: got %q, expected %q", result.Iss, expected)
+		}
+	}
+
 	// Check for error from authorization server using mcp-oauth error parsing
 	if result.IsError() {
 		slog.Debug("OAuth authorization failed",

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -3,7 +3,6 @@ package aggregator
 import (
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -19,6 +18,7 @@ import (
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/config"
 	internalmcp "github.com/giantswarm/muster/internal/mcpserver"
+	musteroauth "github.com/giantswarm/muster/internal/oauth"
 	"github.com/giantswarm/muster/internal/server"
 	"github.com/giantswarm/muster/pkg/logging"
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
@@ -554,7 +554,7 @@ func createEncryptor(oauthCfg config.OAuthServerConfig) *security.Encryptor {
 	if oauthCfg.EncryptionKey == "" {
 		return nil
 	}
-	keyBytes, err := base64.StdEncoding.DecodeString(oauthCfg.EncryptionKey)
+	keyBytes, err := musteroauth.DecodeEncryptionKey(oauthCfg.EncryptionKey)
 	if err != nil {
 		logging.WarnWithAttrs("Aggregator", "Failed to decode encryption key for Valkey stores",
 			slog.String("error", err.Error()))

--- a/internal/oauth/encryption_key.go
+++ b/internal/oauth/encryption_key.go
@@ -1,0 +1,27 @@
+package oauth
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/mcp-oauth/security"
+)
+
+// DecodeEncryptionKey decodes an AES-256 token-encryption key from either
+// base64 (the historical muster format, what `openssl rand -base64 32`
+// produces) or hex (`openssl rand -hex 32`). Both forms are accepted so
+// operators can use whichever encoding their secret tooling emits.
+//
+// The format is detected by trying base64 first and falling back to hex.
+// mcp-oauth's security.KeyFromBase64 / KeyFromHex both validate that the
+// decoded key is exactly 32 bytes; security.NewEncryptor additionally
+// rejects low-entropy keys (v0.2.109).
+func DecodeEncryptionKey(s string) ([]byte, error) {
+	if key, err := security.KeyFromBase64(s); err == nil {
+		return key, nil
+	}
+	key, err := security.KeyFromHex(s)
+	if err != nil {
+		return nil, fmt.Errorf("encryption key is neither valid base64 nor hex: %w", err)
+	}
+	return key, nil
+}

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/config"
+	musteroauth "github.com/giantswarm/muster/internal/oauth"
 	"github.com/giantswarm/muster/pkg/logging"
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 )
@@ -202,30 +203,18 @@ func (s *OAuthHTTPServer) CreateMux() http.Handler {
 }
 
 // setupOAuthRoutes registers OAuth 2.1 endpoints on the mux.
+//
+// Delegates to mcp-oauth's bundle helper, which registers the flow endpoints
+// (/oauth/authorize, /oauth/callback, /oauth/token, /oauth/revoke,
+// /oauth/register, /oauth/introspect — gated on EnableIntrospectionEndpoint),
+// the Protected Resource Metadata routes (RFC 9728) for both the root and
+// the /mcp sub-path, and the Authorization Server Metadata routes (RFC 8414
+// + OpenID Connect Discovery).
 func (s *OAuthHTTPServer) setupOAuthRoutes(mux *http.ServeMux) {
-	// Protected Resource Metadata endpoint (RFC 9728)
-	mux.HandleFunc("/.well-known/oauth-protected-resource", s.oauthHandler.ServeProtectedResourceMetadata)
-
-	// Authorization Server Metadata endpoint (RFC 8414)
-	mux.HandleFunc("/.well-known/oauth-authorization-server", s.oauthHandler.ServeAuthorizationServerMetadata)
-
-	// Dynamic Client Registration endpoint (RFC 7591)
-	mux.HandleFunc("/oauth/register", s.oauthHandler.ServeClientRegistration)
-
-	// OAuth Authorization endpoint
-	mux.HandleFunc("/oauth/authorize", s.oauthHandler.ServeAuthorization)
-
-	// OAuth Token endpoint
-	mux.HandleFunc("/oauth/token", s.oauthHandler.ServeToken)
-
-	// OAuth Callback endpoint (from provider)
-	mux.HandleFunc("/oauth/callback", s.oauthHandler.ServeCallback)
-
-	// Token Revocation endpoint (RFC 7009)
-	mux.HandleFunc("/oauth/revoke", s.oauthHandler.ServeTokenRevocation)
-
-	// Token Introspection endpoint (RFC 7662)
-	mux.HandleFunc("/oauth/introspect", s.oauthHandler.ServeTokenIntrospection)
+	s.oauthHandler.RegisterOAuthRoutes(mux, oauth.OAuthRoutesOptions{
+		MCPPath:         "/mcp",
+		IncludeMetadata: true,
+	})
 
 	logging.Info("OAuth", "Registered OAuth 2.1 endpoints")
 }
@@ -595,13 +584,13 @@ func createOAuthServer(cfg config.OAuthServerConfig, debug bool) (*oauth.Server,
 		return nil, nil, fmt.Errorf("unsupported OAuth provider: %s (supported: %s, %s)", cfg.Provider, OAuthProviderDex, OAuthProviderGoogle)
 	}
 
-	// Create storage backend based on configuration
-	var tokenStore storage.TokenStore
-	var clientStore storage.ClientStore
-	var flowStore storage.FlowStore
+	// Create storage backend based on configuration. Both memory.Store and
+	// valkey.Store satisfy storage.Combined (TokenStore + ClientStore + FlowStore),
+	// so a single handle is enough.
+	var combinedStore storage.Combined
 
 	switch cfg.Storage.Type {
-	case "valkey":
+	case storage.BackendValkey:
 		if cfg.Storage.Valkey.URL == "" {
 			return nil, nil, fmt.Errorf("valkey URL is required when using valkey storage")
 		}
@@ -631,7 +620,7 @@ func createOAuthServer(cfg config.OAuthServerConfig, debug bool) (*oauth.Server,
 
 		// Set up encryption if key is provided
 		if cfg.EncryptionKey != "" {
-			keyBytes, err := base64.StdEncoding.DecodeString(cfg.EncryptionKey)
+			keyBytes, err := musteroauth.DecodeEncryptionKey(cfg.EncryptionKey)
 			if err != nil {
 				valkeyStore.Close()
 				return nil, nil, fmt.Errorf("failed to decode encryption key: %w", err)
@@ -645,20 +634,15 @@ func createOAuthServer(cfg config.OAuthServerConfig, debug bool) (*oauth.Server,
 			logger.Info("Token encryption at rest enabled for Valkey storage (AES-256-GCM)")
 		}
 
-		tokenStore = valkeyStore
-		clientStore = valkeyStore
-		flowStore = valkeyStore
+		combinedStore = valkeyStore
 		logger.Info("Using Valkey storage backend", "address", cfg.Storage.Valkey.URL)
 
-	case "memory", "":
-		memStore := memory.New()
-		tokenStore = memStore
-		clientStore = memStore
-		flowStore = memStore
+	case storage.BackendMemory, "":
+		combinedStore = memory.New()
 		logger.Info("Using in-memory storage backend")
 
 	default:
-		return nil, nil, fmt.Errorf("unsupported OAuth storage type: %s (supported: memory, valkey)", cfg.Storage.Type)
+		return nil, nil, fmt.Errorf("unsupported OAuth storage type: %s (supported: %s, %s)", cfg.Storage.Type, storage.BackendMemory, storage.BackendValkey)
 	}
 
 	// Set defaults
@@ -686,6 +670,7 @@ func createOAuthServer(cfg config.OAuthServerConfig, debug bool) (*oauth.Server,
 		RegistrationAccessToken:          cfg.RegistrationToken,
 		MaxClientsPerIP:                  maxClientsPerIP,
 		EnableClientIDMetadataDocuments:  cfg.EnableCIMD,
+		EnableIntrospectionEndpoint:      true,
 		TrustedPublicRegistrationSchemes: cfg.TrustedPublicRegistrationSchemes,
 		AllowLocalhostRedirectURIs:       cfg.AllowLocalhostRedirectURIs,
 		TrustedAudiences:                 cfg.TrustedAudiences,
@@ -699,12 +684,12 @@ func createOAuthServer(cfg config.OAuthServerConfig, debug bool) (*oauth.Server,
 		},
 	}
 
-	// Create OAuth server
-	oauthSrv, err := oauth.NewServer(
+	// Create OAuth server. Both memory and valkey backends implement
+	// storage.Combined, so we use the single-store constructor instead of
+	// passing the same handle three times.
+	oauthSrv, err := oauth.NewServerWithCombined(
 		provider,
-		tokenStore,
-		clientStore,
-		flowStore,
+		combinedStore,
 		serverConfig,
 		logger,
 	)
@@ -712,9 +697,10 @@ func createOAuthServer(cfg config.OAuthServerConfig, debug bool) (*oauth.Server,
 		return nil, nil, fmt.Errorf("failed to create OAuth server: %w", err)
 	}
 
-	// Set up encryption if key provided (for memory storage)
-	if cfg.EncryptionKey != "" && cfg.Storage.Type != "valkey" {
-		keyBytes, err := base64.StdEncoding.DecodeString(cfg.EncryptionKey)
+	// Set up encryption if key provided (for memory storage; valkey wires the
+	// encryptor onto the store directly above).
+	if cfg.EncryptionKey != "" && cfg.Storage.Type != storage.BackendValkey {
+		keyBytes, err := musteroauth.DecodeEncryptionKey(cfg.EncryptionKey)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to decode encryption key: %w", err)
 		}
@@ -749,7 +735,7 @@ func createOAuthServer(cfg config.OAuthServerConfig, debug bool) (*oauth.Server,
 	oauthSrv.SetClientRegistrationRateLimiter(clientRegRL)
 	logger.Info("Client registration rate limiting enabled", "maxClientsPerIP", maxClientsPerIP)
 
-	return oauthSrv, tokenStore, nil
+	return oauthSrv, combinedStore, nil
 }
 
 // createHTTPClientWithCA creates an HTTP client that trusts certificates signed by


### PR DESCRIPTION
## Summary

- Bumps `mcp-oauth` v0.2.104 → v0.2.117 and adopts the new helpers: `NewServerWithCombined`, `RegisterOAuthRoutes`, `storage.BackendMemory`/`Valkey` constants.
- Encryption keys now accepted as base64 *or* hex (auto-detected); agent OAuth client validates the RFC 9207 `iss` parameter for AS mix-up protection.
- **Operational note:** v0.2.109 rejects low-entropy AES keys at startup. Real `openssl rand -base64 32` / `-hex 32` keys are unaffected; rotate any placeholder keys before deploying.

## Test plan

- [x] `make test` (all 30 packages green)
- [x] `go vet ./...`
- [ ] Manual: confirm authorization callback URL contains `iss=<configured issuer>`
- [ ] Manual: confirm a placeholder encryption key (e.g. all zeros) fails startup with the upstream error

🤖 Generated with [Claude Code](https://claude.com/claude-code)