### PR TITLE
WIP: feat(teleport): CR-driven transport dispatcher (TB-7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/mark3labs/mcp-go v0.49.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/valkey-io/valkey-go v1.0.74
@@ -64,6 +65,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -74,7 +76,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect

--- a/internal/teleport/dispatcher.go
+++ b/internal/teleport/dispatcher.go
@@ -1,0 +1,328 @@
+package teleport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/muster/internal/api"
+	v1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+)
+
+// configFor builds the api.TeleportClientConfig for a (secret, namespace,
+// appName) triple. Centralizes the field shape so the dispatcher and any
+// future callers stay in sync with the package-level adapter contract.
+func configFor(secret, namespace, appName string) api.TeleportClientConfig {
+	return api.TeleportClientConfig{
+		IdentitySecretName:      secret,
+		IdentitySecretNamespace: namespace,
+		AppName:                 appName,
+	}
+}
+
+// TB-7 — CR-driven transport dispatcher.
+//
+// The dispatcher takes a reconciling *v1alpha1.MCPServer and returns the HTTP
+// clients to use for outbound traffic. It implements the contract documented
+// in PLAN §6 TB-7 and §9 ("How to expose 2nd Teleport app/identity ...",
+// revised 2026-04-29 to explicit fields):
+//
+//   - spec.transport unset                                    → direct-HTTPS,
+//     no Dex client.
+//   - spec.transport.type == "teleport", mcp only             → one mTLS
+//     client; dexClient is nil (token exchange disabled, or forwarded over
+//     direct-HTTPS).
+//   - spec.transport.type == "teleport", mcp + dex            → two mTLS
+//     clients keyed off the explicit (appName, identitySecretRef.Name)
+//     pairs in the CR. No naming-convention derivation.
+//
+// The dispatcher returns a typed error on failure so the aggregator (TB-8) can
+// surface a structured MCPServer.status.conditions[type=TransportReady]
+// without re-parsing error strings.
+
+// DefaultSecretNamespace is the default namespace for tbot-output identity
+// secrets when the dispatcher is constructed without an explicit override.
+// Used because MCPServer.spec.transport.teleport.{mcp,dex}.identitySecretRef
+// is a corev1.LocalObjectReference and carries no namespace; the dispatcher
+// constrains where secrets can be loaded from via security.AllowedNamespaces.
+// Matches PLAN §6 TB-4.
+const DefaultSecretNamespace = "muster-system"
+
+// Sentinel errors. The aggregator (TB-8) uses errors.Is to map these to the
+// canonical MCPServer.status.conditions[type=TransportReady, status=False]
+// reason via MapErrorToCondition.
+var (
+	// ErrSecretMissing is returned when an expected tbot-identity secret does
+	// not exist in the configured secret namespace.
+	ErrSecretMissing = errors.New("teleport identity secret not found")
+	// ErrSecretInvalid is returned when an expected tbot-identity secret
+	// exists but is missing required keys (tlscert, key,
+	// teleport-application-ca.pem) or contains invalid PEM data.
+	ErrSecretInvalid = errors.New("teleport identity secret malformed")
+	// ErrTransportInvalid is returned when spec.transport is structurally
+	// invalid (e.g. type=teleport with no teleport block). CRD-level CEL
+	// catches this at admission; the runtime check is defense-in-depth.
+	ErrTransportInvalid = errors.New("teleport transport spec invalid")
+)
+
+// TransportError wraps a sentinel error with structured context (appName +
+// secret) so the aggregator can produce a human-friendly status message
+// without rebuilding it from the error string. Use errors.Is against the
+// sentinel errors above.
+type TransportError struct {
+	// Sentinel is one of ErrSecretMissing / ErrSecretInvalid /
+	// ErrTransportInvalid. Set on every TransportError.
+	Sentinel error
+	// AppName is the Teleport application name from the CR that triggered
+	// the error. Empty if unavailable.
+	AppName string
+	// Secret is the tbot-identity secret name relevant to the error. Empty
+	// when the error is config-scoped (ErrTransportInvalid).
+	Secret string
+	// Detail carries an underlying error (e.g. a malformed PEM error) when
+	// available. nil when no underlying error exists.
+	Detail error
+}
+
+// Error renders a stable, status-condition-quality message.
+func (e *TransportError) Error() string {
+	switch {
+	case errors.Is(e.Sentinel, ErrSecretMissing):
+		return fmt.Sprintf("secret %q not found (app %q)", e.Secret, e.AppName)
+	case errors.Is(e.Sentinel, ErrSecretInvalid):
+		if e.Detail != nil {
+			return fmt.Sprintf("secret %q is invalid: %v", e.Secret, e.Detail)
+		}
+		return fmt.Sprintf("secret %q is invalid", e.Secret)
+	case errors.Is(e.Sentinel, ErrTransportInvalid):
+		if e.Detail != nil {
+			return fmt.Sprintf("transport spec invalid: %v", e.Detail)
+		}
+		return "transport spec invalid"
+	default:
+		return e.Sentinel.Error()
+	}
+}
+
+// Unwrap exposes both the sentinel and the underlying detail to errors.Is.
+func (e *TransportError) Unwrap() []error {
+	if e.Detail == nil {
+		return []error{e.Sentinel}
+	}
+	return []error{e.Sentinel, e.Detail}
+}
+
+// Canonical MCPServer.status.conditions[type=TransportReady, status=False]
+// reasons. TB-8 sets these verbatim on the CR; TB-12 alerts and TB-13 docs
+// reference them by name.
+const (
+	ReasonSecretMissing = "SecretMissing"
+	ReasonSecretInvalid = "SecretInvalid"
+	ReasonConfigInvalid = "ConfigInvalid"
+	// ReasonTransportError is the catch-all for unexpected dispatcher errors;
+	// TB-8 still surfaces them, just without a structured reason.
+	ReasonTransportError = "TransportError"
+)
+
+// MapErrorToCondition derives the canonical condition (reason, message) for a
+// dispatcher error. TB-8 uses this to write
+// MCPServer.status.conditions[type=TransportReady, status=False] without
+// duplicating the mapping.
+//
+// Returns ("", "") when err is nil so callers can early-return.
+func MapErrorToCondition(err error) (reason, message string) {
+	if err == nil {
+		return "", ""
+	}
+	switch {
+	case errors.Is(err, ErrSecretMissing):
+		return ReasonSecretMissing, err.Error()
+	case errors.Is(err, ErrSecretInvalid):
+		return ReasonSecretInvalid, err.Error()
+	case errors.Is(err, ErrTransportInvalid):
+		return ReasonConfigInvalid, err.Error()
+	default:
+		return ReasonTransportError, err.Error()
+	}
+}
+
+// TransportDispatcher resolves the HTTP clients to use for a reconciling
+// MCPServer. See package-level docs for the contract.
+type TransportDispatcher interface {
+	// ClientsFor returns the HTTP clients to use for the MCP endpoint and
+	// (when token-exchange-over-Teleport is enabled) the Dex token endpoint.
+	//
+	// When mcp.spec.transport is nil the returned mcpClient is a default
+	// http.Client (direct HTTPS) and dexClient is nil; err is nil. Token
+	// exchange in that case still goes through the default client.
+	//
+	// When mcp.spec.transport.type == "teleport" the mcpClient is configured
+	// with mTLS for spec.transport.teleport.mcp; dexClient is non-nil only
+	// when spec.transport.teleport.dex is also set.
+	ClientsFor(ctx context.Context, mcp *v1alpha1.MCPServer) (mcpClient, dexClient *http.Client, err error)
+}
+
+// dispatcher is the default TransportDispatcher implementation backed by the
+// Adapter's per-secret ClientProvider cache.
+type dispatcher struct {
+	adapter         *Adapter
+	secretNamespace string
+}
+
+// NewTransportDispatcher constructs a TransportDispatcher. The k8s client is
+// used to load tbot-identity Secrets from secretNamespace. The CR carries
+// the explicit (appName, identitySecretRef.Name) pairs; the dispatcher does
+// not need a knownClusters allowlist.
+//
+// secretNamespace must be in security.AllowedNamespaces (the dispatcher
+// rejects mismatches up-front to surface the constraint at construction
+// rather than at the first request).
+func NewTransportDispatcher(k8s client.Client, secretNamespace string) (TransportDispatcher, error) {
+	if secretNamespace == "" {
+		secretNamespace = DefaultSecretNamespace
+	}
+	if err := ValidateNamespace(secretNamespace); err != nil {
+		return nil, fmt.Errorf("dispatcher secret namespace: %w", err)
+	}
+
+	return &dispatcher{
+		adapter:         NewAdapterWithClient(k8s),
+		secretNamespace: secretNamespace,
+	}, nil
+}
+
+// ClientsFor implements TransportDispatcher.
+func (d *dispatcher) ClientsFor(ctx context.Context, mcp *v1alpha1.MCPServer) (*http.Client, *http.Client, error) {
+	// Direct-HTTPS path: spec.transport unset.
+	if mcp == nil || mcp.Spec.Transport == nil {
+		incLookup(resultNone)
+		// A freshly constructed http.Client (rather than http.DefaultClient)
+		// keeps the dispatcher's caller from accidentally mutating a
+		// process-global. Zero-value Client uses http.DefaultTransport.
+		return &http.Client{}, nil, nil
+	}
+
+	// Today the only transport type is "teleport"; CEL on the CRD already
+	// enforces type=="teleport" ↔ teleport != nil. Defend in depth here.
+	t := mcp.Spec.Transport
+	if t.Type != "teleport" || t.Teleport == nil {
+		incLookup(resultNone)
+		return &http.Client{}, nil, nil
+	}
+
+	mcpTarget := t.Teleport.MCP
+	if mcpTarget.AppName == "" || mcpTarget.IdentitySecretRef.Name == "" {
+		incLookup(resultConfigInvalid)
+		return nil, nil, &TransportError{
+			Sentinel: ErrTransportInvalid,
+			Detail:   fmt.Errorf("transport.teleport.mcp must declare appName and identitySecretRef"),
+		}
+	}
+
+	// Pre-flight existence check on the MCP secret so callers either get a
+	// configured client or a typed error. The dex secret is checked below
+	// only when the dex target is set.
+	if err := d.checkSecretExists(ctx, mcpTarget.IdentitySecretRef.Name); err != nil {
+		incLookup(resultSecretMissing)
+		return nil, nil, &TransportError{
+			Sentinel: ErrSecretMissing,
+			AppName:  mcpTarget.AppName,
+			Secret:   mcpTarget.IdentitySecretRef.Name,
+			Detail:   err,
+		}
+	}
+
+	mcpClient, err := d.buildClient(ctx, mcpTarget.IdentitySecretRef.Name, mcpTarget.AppName)
+	if err != nil {
+		// buildClient already incremented muster_transport_secret_load_total.
+		// Map any low-level error to ErrSecretInvalid since existence was
+		// proven above; PEM/CA parse failures land here.
+		incLookup(resultSecretInvalid)
+		return nil, nil, &TransportError{
+			Sentinel: ErrSecretInvalid,
+			AppName:  mcpTarget.AppName,
+			Secret:   mcpTarget.IdentitySecretRef.Name,
+			Detail:   err,
+		}
+	}
+
+	// Dex target is optional; CEL guards that it is set when
+	// auth.tokenExchange.enabled=true. The dispatcher returns dexClient=nil
+	// when the CR omits the dex target.
+	if t.Teleport.Dex == nil {
+		incLookup(resultResolved)
+		return mcpClient, nil, nil
+	}
+
+	dexTarget := *t.Teleport.Dex
+	if dexTarget.AppName == "" || dexTarget.IdentitySecretRef.Name == "" {
+		incLookup(resultConfigInvalid)
+		return nil, nil, &TransportError{
+			Sentinel: ErrTransportInvalid,
+			Detail:   fmt.Errorf("transport.teleport.dex must declare appName and identitySecretRef"),
+		}
+	}
+	if err := d.checkSecretExists(ctx, dexTarget.IdentitySecretRef.Name); err != nil {
+		incLookup(resultSecretMissing)
+		return nil, nil, &TransportError{
+			Sentinel: ErrSecretMissing,
+			AppName:  dexTarget.AppName,
+			Secret:   dexTarget.IdentitySecretRef.Name,
+			Detail:   err,
+		}
+	}
+	dexClient, err := d.buildClient(ctx, dexTarget.IdentitySecretRef.Name, dexTarget.AppName)
+	if err != nil {
+		incLookup(resultSecretInvalid)
+		return nil, nil, &TransportError{
+			Sentinel: ErrSecretInvalid,
+			AppName:  dexTarget.AppName,
+			Secret:   dexTarget.IdentitySecretRef.Name,
+			Detail:   err,
+		}
+	}
+
+	incLookup(resultResolved)
+	return mcpClient, dexClient, nil
+}
+
+// checkSecretExists returns ErrSecretMissing-grade details when the secret is
+// absent. Other errors (RBAC, transport) bubble unchanged.
+func (d *dispatcher) checkSecretExists(ctx context.Context, name string) error {
+	if d.adapter.k8sClient == nil {
+		return fmt.Errorf("kubernetes client unavailable")
+	}
+	var s corev1.Secret
+	err := d.adapter.k8sClient.Get(ctx, client.ObjectKey{
+		Name:      name,
+		Namespace: d.secretNamespace,
+	}, &s)
+	if err == nil {
+		return nil
+	}
+	if apierrors.IsNotFound(err) {
+		incSecretLoad(name, resultLoadError)
+		return err
+	}
+	incSecretLoad(name, resultLoadError)
+	return err
+}
+
+// buildClient produces an mTLS-configured http.Client wrapped with the
+// appNameTransport for Teleport's Host-header routing. Reuses the Adapter's
+// per-secret ClientProvider cache so cert reload semantics from PR #307 stay
+// in effect — TB-7 doesn't reinvent cert handling.
+func (d *dispatcher) buildClient(ctx context.Context, secretName, appName string) (*http.Client, error) {
+	cli, err := d.adapter.GetHTTPClientForConfig(ctx, configFor(secretName, d.secretNamespace, appName))
+	if err != nil {
+		incSecretLoad(secretName, resultLoadError)
+		return nil, err
+	}
+	incSecretLoad(secretName, resultLoadOK)
+	return cli, nil
+}

--- a/internal/teleport/dispatcher_test.go
+++ b/internal/teleport/dispatcher_test.go
@@ -187,8 +187,8 @@ func TestDispatcher_ResolvedBothTargets(t *testing.T) {
 	const ns = "muster-system"
 	const mcpApp = "mcp-kubernetes-glean"
 	const dexApp = "dex-glean"
-	const mcpSecretName = "tbot-identity-mcp-glean"
-	const dexSecretName = "tbot-identity-tx-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean" // #nosec G101 -- test fixture; not a credential.
+	const dexSecretName = "tbot-identity-tx-glean"  // #nosec G101 -- test fixture; not a credential.
 	mcpSecret, mcpCertPEM := makeIdentitySecret(t, mcpSecretName, ns)
 	dexSecret, dexCertPEM := makeIdentitySecret(t, dexSecretName, ns)
 	if string(mcpCertPEM) == string(dexCertPEM) {
@@ -258,7 +258,7 @@ func TestDispatcher_ResolvedMCPOnly(t *testing.T) {
 
 	const ns = "muster-system"
 	const mcpApp = "mcp-kubernetes-glean"
-	const mcpSecretName = "tbot-identity-mcp-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean" // #nosec G101 -- test fixture; not a credential.
 	mcpSecret, _ := makeIdentitySecret(t, mcpSecretName, ns)
 
 	k8s := newFakeK8s(t, mcpSecret).Build()
@@ -291,8 +291,8 @@ func TestDispatcher_MCPSecretMissing(t *testing.T) {
 	const ns = "muster-system"
 	const mcpApp = "mcp-kubernetes-glean"
 	const dexApp = "dex-glean"
-	const mcpSecretName = "tbot-identity-mcp-glean"
-	const dexSecretName = "tbot-identity-tx-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean" // #nosec G101 -- test fixture; not a credential.
+	const dexSecretName = "tbot-identity-tx-glean"  // #nosec G101 -- test fixture; not a credential.
 	// Only the dex secret exists; mcp secret is missing.
 	dexSecret, _ := makeIdentitySecret(t, dexSecretName, ns)
 
@@ -353,8 +353,8 @@ func TestDispatcher_DexSecretInvalid(t *testing.T) {
 	const ns = "muster-system"
 	const mcpApp = "mcp-kubernetes-glean"
 	const dexApp = "dex-glean"
-	const mcpSecretName = "tbot-identity-mcp-glean"
-	const dexSecretName = "tbot-identity-tx-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean" // #nosec G101 -- test fixture; not a credential.
+	const dexSecretName = "tbot-identity-tx-glean"  // #nosec G101 -- test fixture; not a credential.
 	mcpSecret, _ := makeIdentitySecret(t, mcpSecretName, ns)
 	// Malformed dex secret — exists but contents fail PEM/cert load.
 	badDex := &corev1.Secret{

--- a/internal/teleport/dispatcher_test.go
+++ b/internal/teleport/dispatcher_test.go
@@ -1,0 +1,415 @@
+package teleport
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+)
+
+// ----- helpers -----
+
+// newFakeK8s builds a fake controller-runtime client with the corev1 scheme
+// registered and the supplied Secrets pre-loaded.
+func newFakeK8s(t *testing.T, secrets ...*corev1.Secret) *fake.ClientBuilder {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	objs := make([]runtime.Object, 0, len(secrets))
+	for _, s := range secrets {
+		objs = append(objs, s)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...)
+}
+
+// makeIdentitySecret produces a tbot-output-shaped Secret with the keys the
+// dispatcher's underlying ClientProvider requires (tlscert, key, CA).
+func makeIdentitySecret(t *testing.T, name, namespace string) (*corev1.Secret, []byte) {
+	t.Helper()
+	certPEM, keyPEM, caPEM := generateTestCertificatePEMs(t)
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data: map[string][]byte{
+			DefaultCertFile: certPEM,
+			DefaultKeyFile:  keyPEM,
+			DefaultCAFile:   caPEM,
+		},
+	}, certPEM
+}
+
+// makeMCPServer builds a minimal MCPServer with the requested transport.
+func makeMCPServer(transport *v1alpha1.MCPServerTransport) *v1alpha1.MCPServer {
+	return &v1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha1.MCPServerSpec{
+			Type:      "streamable-http",
+			URL:       "https://example.test/mcp",
+			Transport: transport,
+		},
+	}
+}
+
+// teleportTransport is a constructor shortcut for cleaner test cases. The
+// CR carries explicit (appName, identitySecretRef.Name) pairs per the
+// reshape (PLAN §6 TB-0 revised 2026-04-29). dexAppName="" omits the dex
+// target entirely.
+func teleportTransport(mcpAppName, mcpSecret, dexAppName, dexSecret string) *v1alpha1.MCPServerTransport {
+	tt := &v1alpha1.MCPServerTransport{
+		Type: "teleport",
+		Teleport: &v1alpha1.TeleportTransport{
+			MCP: v1alpha1.TeleportTarget{
+				AppName: mcpAppName,
+				IdentitySecretRef: corev1.LocalObjectReference{
+					Name: mcpSecret,
+				},
+			},
+		},
+	}
+	if dexAppName != "" {
+		tt.Teleport.Dex = &v1alpha1.TeleportTarget{
+			AppName: dexAppName,
+			IdentitySecretRef: corev1.LocalObjectReference{
+				Name: dexSecret,
+			},
+		}
+	}
+	return tt
+}
+
+// appNameFromTransport unwraps an http.Client's transport stack and returns
+// the appName of the appNameTransport. Used to assert that the dispatcher
+// wired the right Host-header rewrite onto each client.
+func appNameFromTransport(t *testing.T, c *http.Client) string {
+	t.Helper()
+	if c == nil || c.Transport == nil {
+		t.Fatal("expected non-nil transport")
+	}
+	ant, ok := c.Transport.(*appNameTransport)
+	if !ok {
+		t.Fatalf("expected *appNameTransport, got %T", c.Transport)
+	}
+	return ant.appName
+}
+
+// tlsLeafSerial returns the leaf-cert serial (decimal) — used to assert
+// distinct certs are wired into distinct clients without depending on CN
+// uniqueness.
+func tlsLeafSerial(t *testing.T, c *http.Client) string {
+	t.Helper()
+	cert := tlsLeafCert(t, c)
+	return cert.SerialNumber.String()
+}
+
+func tlsLeafCert(t *testing.T, c *http.Client) *x509.Certificate {
+	t.Helper()
+	if c == nil || c.Transport == nil {
+		t.Fatal("expected non-nil transport")
+	}
+	var rt http.RoundTripper = c.Transport
+	if ant, ok := rt.(*appNameTransport); ok {
+		rt = ant.base
+	}
+	tr, ok := rt.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", rt)
+	}
+	if tr.TLSClientConfig == nil || len(tr.TLSClientConfig.Certificates) == 0 {
+		t.Fatal("expected TLS client cert configured")
+	}
+	der := tr.TLSClientConfig.Certificates[0].Certificate
+	if len(der) == 0 {
+		t.Fatal("TLS Certificate has no DER bytes")
+	}
+	cert, err := x509.ParseCertificate(der[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return cert
+}
+
+// silence "unused" on the typed tls import when only x509 is referenced via
+// the helpers; tls.Config is part of the http.Transport field.
+var _ = tls.VersionTLS12
+
+// ----- tests -----
+
+// (a) — transport unset → plain client; result="none".
+func TestDispatcher_TransportUnset(t *testing.T) {
+	resetMetricsForTest()
+	t.Cleanup(resetMetricsForTest)
+
+	k8s := newFakeK8s(t).Build()
+	d, err := NewTransportDispatcher(k8s, "muster-system")
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+
+	mcp, dex, err := d.ClientsFor(context.Background(), makeMCPServer(nil))
+	if err != nil {
+		t.Fatalf("ClientsFor: %v", err)
+	}
+	if mcp == nil {
+		t.Fatal("expected non-nil mcp client for direct-HTTPS path")
+	}
+	if dex != nil {
+		t.Fatal("expected nil dex client when transport is unset")
+	}
+
+	expected := `
+# HELP muster_transport_lookup_total Number of CR-driven transport-dispatcher lookups, by outcome.
+# TYPE muster_transport_lookup_total counter
+muster_transport_lookup_total{result="none"} 1
+`
+	if err := testutil.CollectAndCompare(transportLookupTotal, strings.NewReader(expected)); err != nil {
+		t.Fatalf("metric mismatch: %v", err)
+	}
+}
+
+// (b) — both targets set + both secrets present → two configured clients.
+// This is the canonical "Teleport-routed CR with token exchange" path.
+func TestDispatcher_ResolvedBothTargets(t *testing.T) {
+	resetMetricsForTest()
+	t.Cleanup(resetMetricsForTest)
+
+	const ns = "muster-system"
+	const mcpApp = "mcp-kubernetes-glean"
+	const dexApp = "dex-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean"
+	const dexSecretName = "tbot-identity-tx-glean"
+	mcpSecret, mcpCertPEM := makeIdentitySecret(t, mcpSecretName, ns)
+	dexSecret, dexCertPEM := makeIdentitySecret(t, dexSecretName, ns)
+	if string(mcpCertPEM) == string(dexCertPEM) {
+		t.Fatal("test fixture: mcp and dex secrets accidentally got the same cert")
+	}
+
+	k8s := newFakeK8s(t, mcpSecret, dexSecret).Build()
+	d, err := NewTransportDispatcher(k8s, ns)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+
+	mcp, dex, err := d.ClientsFor(context.Background(), makeMCPServer(teleportTransport(mcpApp, mcpSecretName, dexApp, dexSecretName)))
+	if err != nil {
+		t.Fatalf("ClientsFor: %v", err)
+	}
+	if mcp == nil || dex == nil {
+		t.Fatalf("expected both clients, got mcp=%v dex=%v", mcp, dex)
+	}
+	if mcp == dex {
+		t.Fatal("expected distinct clients (per Q4: 2 secrets per remote MC)")
+	}
+
+	// Each client is wrapped with appNameTransport; verify the Host header
+	// was set to the explicit app name on each.
+	if got := appNameFromTransport(t, mcp); got != mcpApp {
+		t.Errorf("mcp client Host=%q, want %q", got, mcpApp)
+	}
+	if got := appNameFromTransport(t, dex); got != dexApp {
+		t.Errorf("dex client Host=%q, want %q", got, dexApp)
+	}
+
+	// Distinctness via cert serial (regenerated per call).
+	mcpSerial := tlsLeafSerial(t, mcp)
+	dexSerial := tlsLeafSerial(t, dex)
+	if mcpSerial == "" || dexSerial == "" {
+		t.Fatal("expected non-empty leaf serials on both clients")
+	}
+	if mcpSerial == dexSerial {
+		t.Errorf("mcp and dex clients carry the same cert serial %q — secrets not distinct", mcpSerial)
+	}
+
+	expectedLookup := `
+# HELP muster_transport_lookup_total Number of CR-driven transport-dispatcher lookups, by outcome.
+# TYPE muster_transport_lookup_total counter
+muster_transport_lookup_total{result="resolved"} 1
+`
+	if err := testutil.CollectAndCompare(transportLookupTotal, strings.NewReader(expectedLookup)); err != nil {
+		t.Fatalf("lookup metric mismatch: %v", err)
+	}
+	expectedLoad := `
+# HELP muster_transport_secret_load_total Number of tbot-identity Secret load attempts, by secret name and outcome.
+# TYPE muster_transport_secret_load_total counter
+muster_transport_secret_load_total{result="ok",secret="tbot-identity-mcp-glean"} 1
+muster_transport_secret_load_total{result="ok",secret="tbot-identity-tx-glean"} 1
+`
+	if err := testutil.CollectAndCompare(transportSecretLoadTotal, strings.NewReader(expectedLoad)); err != nil {
+		t.Fatalf("load metric mismatch: %v", err)
+	}
+}
+
+// (c) — Dex target nil (token exchange disabled or forwarded) → mcp client
+// only; dexClient is nil; result="resolved".
+func TestDispatcher_ResolvedMCPOnly(t *testing.T) {
+	resetMetricsForTest()
+	t.Cleanup(resetMetricsForTest)
+
+	const ns = "muster-system"
+	const mcpApp = "mcp-kubernetes-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean"
+	mcpSecret, _ := makeIdentitySecret(t, mcpSecretName, ns)
+
+	k8s := newFakeK8s(t, mcpSecret).Build()
+	d, err := NewTransportDispatcher(k8s, ns)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+
+	mcp, dex, err := d.ClientsFor(context.Background(), makeMCPServer(teleportTransport(mcpApp, mcpSecretName, "", "")))
+	if err != nil {
+		t.Fatalf("ClientsFor: %v", err)
+	}
+	if mcp == nil {
+		t.Fatal("expected non-nil mcp client")
+	}
+	if dex != nil {
+		t.Fatal("expected nil dex client when dex target is omitted")
+	}
+	if got := appNameFromTransport(t, mcp); got != mcpApp {
+		t.Errorf("mcp client Host=%q, want %q", got, mcpApp)
+	}
+}
+
+// (d) — MCP secret missing → ErrSecretMissing + result="secret_missing".
+// Asserts the secret name from the CR appears in the error.
+func TestDispatcher_MCPSecretMissing(t *testing.T) {
+	resetMetricsForTest()
+	t.Cleanup(resetMetricsForTest)
+
+	const ns = "muster-system"
+	const mcpApp = "mcp-kubernetes-glean"
+	const dexApp = "dex-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean"
+	const dexSecretName = "tbot-identity-tx-glean"
+	// Only the dex secret exists; mcp secret is missing.
+	dexSecret, _ := makeIdentitySecret(t, dexSecretName, ns)
+
+	k8s := newFakeK8s(t, dexSecret).Build()
+	d, err := NewTransportDispatcher(k8s, ns)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+
+	_, _, err = d.ClientsFor(context.Background(), makeMCPServer(teleportTransport(mcpApp, mcpSecretName, dexApp, dexSecretName)))
+	if err == nil {
+		t.Fatal("expected error for missing secret")
+	}
+	if !errors.Is(err, ErrSecretMissing) {
+		t.Fatalf("expected ErrSecretMissing, got %v", err)
+	}
+	var te *TransportError
+	if !errors.As(err, &te) {
+		t.Fatalf("expected *TransportError, got %T", err)
+	}
+	if te.Secret != mcpSecretName {
+		t.Errorf("TransportError.Secret=%q want %q", te.Secret, mcpSecretName)
+	}
+	if te.AppName != mcpApp {
+		t.Errorf("TransportError.AppName=%q want %q", te.AppName, mcpApp)
+	}
+
+	reason, _ := MapErrorToCondition(err)
+	if reason != ReasonSecretMissing {
+		t.Errorf("reason=%q want %q", reason, ReasonSecretMissing)
+	}
+
+	expectedLookup := `
+# HELP muster_transport_lookup_total Number of CR-driven transport-dispatcher lookups, by outcome.
+# TYPE muster_transport_lookup_total counter
+muster_transport_lookup_total{result="secret_missing"} 1
+`
+	if err := testutil.CollectAndCompare(transportLookupTotal, strings.NewReader(expectedLookup)); err != nil {
+		t.Fatalf("lookup metric mismatch: %v", err)
+	}
+	expectedLoad := `
+# HELP muster_transport_secret_load_total Number of tbot-identity Secret load attempts, by secret name and outcome.
+# TYPE muster_transport_secret_load_total counter
+muster_transport_secret_load_total{result="error",secret="tbot-identity-mcp-glean"} 1
+`
+	if err := testutil.CollectAndCompare(transportSecretLoadTotal, strings.NewReader(expectedLoad)); err != nil {
+		t.Fatalf("load metric mismatch: %v", err)
+	}
+}
+
+// (e) — Dex secret invalid (exists but has malformed PEM data) →
+// ErrSecretInvalid + result="secret_invalid". MCP secret is present and
+// valid, so the failure point is specifically the dex secret.
+func TestDispatcher_DexSecretInvalid(t *testing.T) {
+	resetMetricsForTest()
+	t.Cleanup(resetMetricsForTest)
+
+	const ns = "muster-system"
+	const mcpApp = "mcp-kubernetes-glean"
+	const dexApp = "dex-glean"
+	const mcpSecretName = "tbot-identity-mcp-glean"
+	const dexSecretName = "tbot-identity-tx-glean"
+	mcpSecret, _ := makeIdentitySecret(t, mcpSecretName, ns)
+	// Malformed dex secret — exists but contents fail PEM/cert load.
+	badDex := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: dexSecretName, Namespace: ns},
+		Data: map[string][]byte{
+			DefaultCertFile: []byte("not a real PEM"),
+			DefaultKeyFile:  []byte("not a real key"),
+			DefaultCAFile:   []byte("not a real CA"),
+		},
+	}
+
+	k8s := newFakeK8s(t, mcpSecret, badDex).Build()
+	d, err := NewTransportDispatcher(k8s, ns)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+
+	_, _, err = d.ClientsFor(context.Background(), makeMCPServer(teleportTransport(mcpApp, mcpSecretName, dexApp, dexSecretName)))
+	if err == nil {
+		t.Fatal("expected error for invalid dex secret")
+	}
+	if !errors.Is(err, ErrSecretInvalid) {
+		t.Fatalf("expected ErrSecretInvalid, got %v", err)
+	}
+	var te *TransportError
+	if !errors.As(err, &te) {
+		t.Fatalf("expected *TransportError, got %T", err)
+	}
+	if te.Secret != dexSecretName {
+		t.Errorf("TransportError.Secret=%q want %q", te.Secret, dexSecretName)
+	}
+	if te.AppName != dexApp {
+		t.Errorf("TransportError.AppName=%q want %q", te.AppName, dexApp)
+	}
+
+	reason, _ := MapErrorToCondition(err)
+	if reason != ReasonSecretInvalid {
+		t.Errorf("reason=%q want %q", reason, ReasonSecretInvalid)
+	}
+}
+
+// Disallowed namespace at construction is rejected up-front (preserves the
+// security.go allow-list constraint called out in the brief).
+func TestDispatcher_RejectsDisallowedNamespace(t *testing.T) {
+	k8s := newFakeK8s(t).Build()
+	_, err := NewTransportDispatcher(k8s, "kube-system")
+	if err == nil {
+		t.Fatal("expected error when secretNamespace is outside the allow-list")
+	}
+}
+
+// MapErrorToCondition is total — nil in, ("","") out.
+func TestMapErrorToCondition_Nil(t *testing.T) {
+	r, m := MapErrorToCondition(nil)
+	if r != "" || m != "" {
+		t.Errorf("MapErrorToCondition(nil)=(%q,%q) want empty", r, m)
+	}
+}

--- a/internal/teleport/dispatcher_test.go
+++ b/internal/teleport/dispatcher_test.go
@@ -118,7 +118,7 @@ func tlsLeafCert(t *testing.T, c *http.Client) *x509.Certificate {
 	if c == nil || c.Transport == nil {
 		t.Fatal("expected non-nil transport")
 	}
-	var rt http.RoundTripper = c.Transport
+	rt := http.RoundTripper(c.Transport)
 	if ant, ok := rt.(*appNameTransport); ok {
 		rt = ant.base
 	}

--- a/internal/teleport/metrics.go
+++ b/internal/teleport/metrics.go
@@ -1,0 +1,61 @@
+package teleport
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metric label values for muster_transport_lookup_total.
+const (
+	resultResolved      = "resolved"
+	resultSecretMissing = "secret_missing"
+	resultSecretInvalid = "secret_invalid"
+	resultConfigInvalid = "config_invalid"
+	resultNone          = "none"
+
+	// Metric label values for muster_transport_secret_load_total.
+	resultLoadOK    = "ok"
+	resultLoadError = "error"
+)
+
+// transportLookupTotal counts dispatcher.ClientsFor calls partitioned by
+// outcome. PLAN §6 TB-7. result="none" covers the spec.transport-unset path
+// so we can audit how many CRs run through the direct-HTTPS bypass.
+var transportLookupTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "muster_transport_lookup_total",
+		Help: "Number of CR-driven transport-dispatcher lookups, by outcome.",
+	},
+	[]string{"result"},
+)
+
+// transportSecretLoadTotal counts tbot-identity Secret load attempts
+// partitioned by secret name + outcome. PLAN §6 TB-7. Drives TB-12's
+// MusterTransportSecretMissing alert.
+var transportSecretLoadTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "muster_transport_secret_load_total",
+		Help: "Number of tbot-identity Secret load attempts, by secret name and outcome.",
+	},
+	[]string{"secret", "result"},
+)
+
+// incLookup is the dispatcher's hook into transportLookupTotal. Tiny wrapper
+// keeps callers free of label-value typos.
+func incLookup(result string) {
+	transportLookupTotal.WithLabelValues(result).Inc()
+}
+
+// incSecretLoad is the dispatcher's hook into transportSecretLoadTotal.
+func incSecretLoad(secret, result string) {
+	transportSecretLoadTotal.WithLabelValues(secret, result).Inc()
+}
+
+// resetMetricsForTest clears both metric vectors. Tests use this to assert on
+// counter state without fighting cross-test pollution; promauto registers
+// against the global registry so each test would otherwise observe whatever
+// the previous test recorded.
+func resetMetricsForTest() {
+	transportLookupTotal.Reset()
+	transportSecretLoadTotal.Reset()
+}


### PR DESCRIPTION
## Status: WIP / Draft

Stacked on **#601** (TB-0 — `spec.transport.teleport` explicit fields).
**Do not merge until #601 lands.**

## Summary

Implements PLAN §6 TB-7 — the CR-driven transport dispatcher in `internal/teleport`.

The dispatcher takes a reconciling `*v1alpha1.MCPServer` and returns the HTTP clients to use for outbound traffic:

- `spec.transport` unset → plain `http.Client` (direct HTTPS, customer-Muster default)
- `spec.transport.type == teleport` with `mcp` only → one mTLS client; dexClient is nil
- `spec.transport.type == teleport` with `mcp + dex` → two mTLS clients keyed off the explicit `(appName, identitySecretRef.Name)` pairs from the CR

After the TB-0 explicit-fields reshape (revised 2026-04-29), the dispatcher reads the app names and Secret names verbatim from the CR — no `<role>-<cluster>` derivation.

## What changed

- `internal/teleport/dispatcher.go` — new file. `TransportDispatcher` interface + default implementation backed by the existing `Adapter`'s per-secret `ClientProvider` cache (cert-reload semantics from PR #307 preserved).
- `internal/teleport/metrics.go` — new file. `muster_transport_lookup_total{result=resolved|secret_missing|secret_invalid|config_invalid|none}` and `muster_transport_secret_load_total{secret,result=ok|error}` via `promauto`.
- `internal/teleport/dispatcher_test.go` — new file. Five-case unit test covering the dispatcher contract: (a) transport unset → plain client; (b) both targets set + secrets present → two distinct mTLS clients with correct cert serials and Host-header rewrites; (c) Dex omitted → mcp-only resolution; (d) MCP secret missing → `ErrSecretMissing`; (e) Dex secret malformed → `ErrSecretInvalid`. Metrics asserted via `testutil.CollectAndCompare`.
- Sentinel errors + `MapErrorToCondition` for TB-8 to map dispatcher errors to canonical `MCPServer.status.conditions[type=TransportReady, status=False]` reasons (`SecretMissing`, `SecretInvalid`, `ConfigInvalid`, `TransportError`).

`NewTransportDispatcher(k8s, secretNamespace)` — no `knownClusters` argument (the CR carries every appName + secret name explicitly, so no aggregator-side allowlist is needed). `secretNamespace` is retained because `LocalObjectReference` carries no namespace and `security.AllowedNamespaces` still constrains where Secrets can be loaded from.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/teleport/...`
- [x] `go test ./...` (whole tree)
- [x] `goimports -l .` (empty)
- [ ] CI green on the stacked PR
- [ ] Reviewer dry-run of TB-8 wiring on top

## Stack

1. #601 — TB-0 (CRD `spec.transport` explicit fields) ← **base**
2. **This PR** — TB-7 dispatcher
3. TB-8 (aggregator wiring) — follow-up PR

## References

- PLAN.md §6 TB-7
- PLAN.md §9 (How to expose 2nd Teleport app/identity, revised 2026-04-29)