### PR TITLE
Add tbot identity material to muster helm chart (TB-4)

### DIFF
--- a/helm/muster/templates/_helpers.tpl
+++ b/helm/muster/templates/_helpers.tpl
@@ -131,4 +131,3 @@ error.
   secretName: {{ $a.identitySecret | quote }}
 {{- end }}
 {{- end }}
-

--- a/helm/muster/templates/_helpers.tpl
+++ b/helm/muster/templates/_helpers.tpl
@@ -68,3 +68,112 @@ Create the namespace for muster resource discovery
 {{- define "muster.namespace" -}}
 {{- .Values.muster.namespace | default .Release.Namespace }}
 {{- end }}
+
+{{/*
+tbot ServiceAccount name. Distinct from muster's SA — tbot authenticates
+to Teleport via the kubernetes join method using a projected token from
+this SA, audience-bound to the Teleport cluster.
+*/}}
+{{- define "muster.tbot.serviceAccountName" -}}
+{{- printf "%s-tbot" (include "muster.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+tbot ConfigMap name.
+*/}}
+{{- define "muster.tbot.configMapName" -}}
+{{- printf "%s-tbot-config" (include "muster.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+tbot Deployment name.
+*/}}
+{{- define "muster.tbot.deploymentName" -}}
+{{- printf "%s-tbot" (include "muster.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+muster.tbot.outputs
+
+Returns the canonical list of derived (cluster, role) tbot outputs as a
+YAML list of dicts. Each entry has:
+  name        — unique key (used for collision detection: "<role>-<cluster>")
+  appName     — Teleport application name ("<role>-<cluster>")
+  secretName  — Kubernetes Secret name written by tbot
+                ("tbot-identity-mcp-<cluster>" or "tbot-identity-tx-<cluster>")
+
+Per PLAN §6 TB-4 the role tags in secret names are abbreviated:
+  mcp-kubernetes  -> "mcp" (secret tbot-identity-mcp-<cluster>)
+  dex             -> "tx"  (secret tbot-identity-tx-<cluster>)
+
+The Teleport-side appName uses the full role name ("mcp-kubernetes-<cluster>",
+"dex-<cluster>") because that name is what matches the Teleport apps list
+locked in TB-1/TB-2.
+
+apps[] entries override clusters[]-derived entries with the same `name` key
+(escape hatch for non-conformant Teleport-side names). Duplicate names within
+apps[] are a templating-time error.
+*/}}
+{{- define "muster.tbot.outputs" -}}
+{{- $cfg := .Values.transport.teleport -}}
+{{- $derived := list -}}
+{{- range $idx, $cluster := (default (list) $cfg.clusters) -}}
+  {{- if not $cluster.name -}}
+    {{- fail (printf "transport.teleport.clusters[%d].name is required" $idx) -}}
+  {{- end -}}
+  {{- $derived = append $derived (dict
+      "name" (printf "mcp-kubernetes-%s" $cluster.name)
+      "appName" (printf "mcp-kubernetes-%s" $cluster.name)
+      "secretName" (printf "tbot-identity-mcp-%s" $cluster.name)
+  ) -}}
+  {{- $derived = append $derived (dict
+      "name" (printf "dex-%s" $cluster.name)
+      "appName" (printf "dex-%s" $cluster.name)
+      "secretName" (printf "tbot-identity-tx-%s" $cluster.name)
+  ) -}}
+{{- end -}}
+{{/* Detect duplicates within apps[] (template-time fail per PLAN §6 TB-4). */}}
+{{- $seen := dict -}}
+{{- range $idx, $a := (default (list) $cfg.apps) -}}
+  {{- if not $a.name -}}
+    {{- fail (printf "transport.teleport.apps[%d].name is required" $idx) -}}
+  {{- end -}}
+  {{- if hasKey $seen $a.name -}}
+    {{- fail (printf "transport.teleport.apps: duplicate entry name %q" $a.name) -}}
+  {{- end -}}
+  {{- $_ := set $seen $a.name true -}}
+{{- end -}}
+{{/* Index derived list by name for override lookup. */}}
+{{- $byName := dict -}}
+{{- range $derived -}}
+  {{- $_ := set $byName .name . -}}
+{{- end -}}
+{{/* Apply apps[] overrides (replace same-name entries from clusters[]). */}}
+{{- range $a := (default (list) $cfg.apps) -}}
+  {{- $entry := dict
+      "name" $a.name
+      "appName" (default $a.name $a.appName)
+      "secretName" (required (printf "transport.teleport.apps[%s].secretName is required" $a.name) $a.secretName)
+  -}}
+  {{- $_ := set $byName $a.name $entry -}}
+{{- end -}}
+{{/* Emit a stable, ordered list. clusters[] entries first, in definition order;
+     then any apps[]-only entries (those whose name was not produced by clusters[]). */}}
+{{- $emitted := dict -}}
+{{- range $derived -}}
+  {{- $entry := index $byName .name -}}
+  {{- $_ := set $emitted .name true -}}
+- name: {{ $entry.name | quote }}
+  appName: {{ $entry.appName | quote }}
+  secretName: {{ $entry.secretName | quote }}
+{{ end -}}
+{{- range $a := (default (list) $cfg.apps) -}}
+  {{- if not (hasKey $emitted $a.name) -}}
+    {{- $entry := index $byName $a.name }}
+- name: {{ $entry.name | quote }}
+  appName: {{ $entry.appName | quote }}
+  secretName: {{ $entry.secretName | quote }}
+{{ end -}}
+{{- end -}}
+{{- end }}
+

--- a/helm/muster/templates/_helpers.tpl
+++ b/helm/muster/templates/_helpers.tpl
@@ -95,85 +95,40 @@ tbot Deployment name.
 {{/*
 muster.tbot.outputs
 
-Returns the canonical list of derived (cluster, role) tbot outputs as a
-YAML list of dicts. Each entry has:
-  name        — unique key (used for collision detection: "<role>-<cluster>")
-  appName     — Teleport application name ("<role>-<cluster>")
-  secretName  — Kubernetes Secret name written by tbot
-                ("tbot-identity-mcp-<cluster>" or "tbot-identity-tx-<cluster>")
+Returns the canonical list of tbot outputs as a YAML list of dicts. Each
+entry has:
+  appName     — Teleport application name (verbatim from values.apps[].appName)
+  secretName  — Kubernetes Secret name written by tbot (verbatim from
+                values.apps[].identitySecret)
 
-Per PLAN §6 TB-4 the role tags in secret names are abbreviated:
-  mcp-kubernetes  -> "mcp" (secret tbot-identity-mcp-<cluster>)
-  dex             -> "tx"  (secret tbot-identity-tx-<cluster>)
+Reshape (PLAN §6 TB-0 revised 2026-04-29 + TB-4 follow-up): the chart no
+longer derives app or secret names from a cluster symbol. Every entry is
+stated explicitly under transport.teleport.apps[], and matches what the
+MCPServer CR carries in spec.transport.teleport.{mcp,dex}.{appName,
+identitySecretRef.name}.
 
-The Teleport-side appName uses the full role name ("mcp-kubernetes-<cluster>",
-"dex-<cluster>") because that name is what matches the Teleport apps list
-locked in TB-1/TB-2.
-
-apps[] entries override clusters[]-derived entries with the same `name` key
-(escape hatch for non-conformant Teleport-side names). Duplicate names within
-apps[] are a templating-time error.
+Duplicate appName values within apps[] are a template-time error.
+Missing appName or identitySecret on any apps[] entry is a template-time
+error.
 */}}
 {{- define "muster.tbot.outputs" -}}
 {{- $cfg := .Values.transport.teleport -}}
-{{- $derived := list -}}
-{{- range $idx, $cluster := (default (list) $cfg.clusters) -}}
-  {{- if not $cluster.name -}}
-    {{- fail (printf "transport.teleport.clusters[%d].name is required" $idx) -}}
-  {{- end -}}
-  {{- $derived = append $derived (dict
-      "name" (printf "mcp-kubernetes-%s" $cluster.name)
-      "appName" (printf "mcp-kubernetes-%s" $cluster.name)
-      "secretName" (printf "tbot-identity-mcp-%s" $cluster.name)
-  ) -}}
-  {{- $derived = append $derived (dict
-      "name" (printf "dex-%s" $cluster.name)
-      "appName" (printf "dex-%s" $cluster.name)
-      "secretName" (printf "tbot-identity-tx-%s" $cluster.name)
-  ) -}}
-{{- end -}}
-{{/* Detect duplicates within apps[] (template-time fail per PLAN §6 TB-4). */}}
 {{- $seen := dict -}}
 {{- range $idx, $a := (default (list) $cfg.apps) -}}
-  {{- if not $a.name -}}
-    {{- fail (printf "transport.teleport.apps[%d].name is required" $idx) -}}
+  {{- if not $a.appName -}}
+    {{- fail (printf "transport.teleport.apps[%d].appName is required" $idx) -}}
   {{- end -}}
-  {{- if hasKey $seen $a.name -}}
-    {{- fail (printf "transport.teleport.apps: duplicate entry name %q" $a.name) -}}
+  {{- if not $a.identitySecret -}}
+    {{- fail (printf "transport.teleport.apps[%d].identitySecret is required (appName=%q)" $idx $a.appName) -}}
   {{- end -}}
-  {{- $_ := set $seen $a.name true -}}
+  {{- if hasKey $seen $a.appName -}}
+    {{- fail (printf "transport.teleport.apps: duplicate appName %q" $a.appName) -}}
+  {{- end -}}
+  {{- $_ := set $seen $a.appName true -}}
 {{- end -}}
-{{/* Index derived list by name for override lookup. */}}
-{{- $byName := dict -}}
-{{- range $derived -}}
-  {{- $_ := set $byName .name . -}}
-{{- end -}}
-{{/* Apply apps[] overrides (replace same-name entries from clusters[]). */}}
-{{- range $a := (default (list) $cfg.apps) -}}
-  {{- $entry := dict
-      "name" $a.name
-      "appName" (default $a.name $a.appName)
-      "secretName" (required (printf "transport.teleport.apps[%s].secretName is required" $a.name) $a.secretName)
-  -}}
-  {{- $_ := set $byName $a.name $entry -}}
-{{- end -}}
-{{/* Emit a stable, ordered list. clusters[] entries first, in definition order;
-     then any apps[]-only entries (those whose name was not produced by clusters[]). */}}
-{{- $emitted := dict -}}
-{{- range $derived -}}
-  {{- $entry := index $byName .name -}}
-  {{- $_ := set $emitted .name true -}}
-- name: {{ $entry.name | quote }}
-  appName: {{ $entry.appName | quote }}
-  secretName: {{ $entry.secretName | quote }}
-{{ end -}}
-{{- range $a := (default (list) $cfg.apps) -}}
-  {{- if not (hasKey $emitted $a.name) -}}
-    {{- $entry := index $byName $a.name }}
-- name: {{ $entry.name | quote }}
-  appName: {{ $entry.appName | quote }}
-  secretName: {{ $entry.secretName | quote }}
-{{ end -}}
-{{- end -}}
+{{- range $a := (default (list) $cfg.apps) }}
+- appName: {{ $a.appName | quote }}
+  secretName: {{ $a.identitySecret | quote }}
+{{- end }}
 {{- end }}
 

--- a/helm/muster/templates/deployment.yaml
+++ b/helm/muster/templates/deployment.yaml
@@ -32,6 +32,59 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.transport.teleport.enabled }}
+      # TB-4 readiness gate: block muster startup until tbot has written every
+      # derived identity Secret. A missing Secret >5min crashloops the init
+      # container, which is the desired signal — muster should not race with
+      # tbot on a fresh deploy.
+      initContainers:
+        - name: tbot-identity-wait
+          image: "{{ .Values.transport.teleport.readinessGate.image.repository }}:{{ .Values.transport.teleport.readinessGate.image.tag }}"
+          imagePullPolicy: {{ .Values.transport.teleport.readinessGate.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              SECRETS="{{- range (include "muster.tbot.outputs" . | fromYamlArray) }} {{ .secretName }}{{- end }}"
+              DEADLINE=$(( $(date +%s) + {{ .Values.transport.teleport.readinessGate.timeoutSeconds }} ))
+              while :; do
+                missing=""
+                for s in $SECRETS; do
+                  if ! kubectl get secret "$s" -n "$POD_NAMESPACE" >/dev/null 2>&1; then
+                    missing="$missing $s"
+                  fi
+                done
+                if [ -z "$missing" ]; then
+                  echo "tbot-identity-wait: all identity secrets present"
+                  exit 0
+                fi
+                echo "tbot-identity-wait: waiting for tbot identity secrets:$missing"
+                if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+                  echo "tbot-identity-wait: timeout after {{ .Values.transport.teleport.readinessGate.timeoutSeconds }}s; missing:$missing" >&2
+                  exit 1
+                fi
+                sleep {{ .Values.transport.teleport.readinessGate.pollIntervalSeconds }}
+              done
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: sa-token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/muster/templates/tbot-configmap.yaml
+++ b/helm/muster/templates/tbot-configmap.yaml
@@ -1,0 +1,45 @@
+{{/*
+tbot configuration ConfigMap (TB-4).
+
+Bot state is `storage.type: memory` — the kubernetes join method re-auths on
+every restart, so persistent storage would only add operational surface for
+no benefit (per PLAN §9 "tbot deployment topology").
+
+One outputs[] block per derived (cluster, role) pair. The list is rendered by
+the muster.tbot.outputs helper from .Values.transport.teleport.clusters[] with
+.Values.transport.teleport.apps[] applied as same-named overrides; duplicate
+names in apps[] are a templating-time error (see _helpers.tpl).
+
+The onboarding token name `muster-aggregator` is the contract with TB-3's
+provisioning script. proxy_server is a single value (one GS Teleport cluster
+fronts all MCs).
+*/}}
+{{- if .Values.transport.teleport.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "muster.tbot.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tbot
+data:
+  tbot.yaml: |
+    version: v2
+    proxy_server: {{ required "transport.teleport.proxyServer is required when transport.teleport.enabled" .Values.transport.teleport.proxyServer }}
+    onboarding:
+      join_method: kubernetes
+      # Bot ↔ tbot contract — must match the Teleport join-token name created by
+      # scripts/provision-teleport-bot.sh (TB-3).
+      token: muster-aggregator
+    storage:
+      type: memory
+    outputs:
+      {{- range (include "muster.tbot.outputs" . | fromYamlArray) }}
+      - type: application
+        app_name: {{ .appName | quote }}
+        destination:
+          type: kubernetes_secret
+          name: {{ .secretName | quote }}
+      {{- end }}
+{{- end }}

--- a/helm/muster/templates/tbot-configmap.yaml
+++ b/helm/muster/templates/tbot-configmap.yaml
@@ -5,10 +5,11 @@ Bot state is `storage.type: memory` — the kubernetes join method re-auths on
 every restart, so persistent storage would only add operational surface for
 no benefit (per PLAN §9 "tbot deployment topology").
 
-One outputs[] block per derived (cluster, role) pair. The list is rendered by
-the muster.tbot.outputs helper from .Values.transport.teleport.clusters[] with
-.Values.transport.teleport.apps[] applied as same-named overrides; duplicate
-names in apps[] are a templating-time error (see _helpers.tpl).
+One outputs[] block per .Values.transport.teleport.apps[] entry. The list is
+rendered by the muster.tbot.outputs helper from explicit (appName,
+identitySecret) pairs (PLAN §6 TB-0 revised 2026-04-29 + TB-4 follow-up); no
+naming-convention derivation. Duplicate appName values in apps[] are a
+templating-time error (see _helpers.tpl).
 
 The onboarding token name `muster-aggregator` is the contract with TB-3's
 provisioning script. proxy_server is a single value (one GS Teleport cluster

--- a/helm/muster/templates/tbot-deployment.yaml
+++ b/helm/muster/templates/tbot-deployment.yaml
@@ -1,0 +1,112 @@
+{{/*
+tbot Deployment (TB-4).
+
+Single-replica Deployment, separate from the muster Deployment per PLAN §6
+TB-4 and §9 ("Separate Deployment, matches teleport-operator pattern"). One
+bot is enough — restarting tbot only degrades remote-MC traffic, muster
+keeps serving Gazelle-local CRs.
+
+The Deployment is annotated with a checksum of the tbot ConfigMap so changes
+to clusters[]/apps[] roll the bot without manual intervention.
+
+No persistent storage — tbot uses storage.type: memory and re-auths via the
+kubernetes join method on each restart.
+*/}}
+{{- if .Values.transport.teleport.enabled -}}
+{{- $teleport := .Values.transport.teleport -}}
+{{- $audience := default (regexReplaceAll ":[0-9]+$" $teleport.proxyServer "") $teleport.clusterName -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "muster.tbot.deploymentName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tbot
+spec:
+  replicas: 1
+  strategy:
+    # Recreate: only one bot identity at a time; rolling a new pod alongside
+    # the old would race on the kubernetes_secret destination.
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "muster.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tbot
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/tbot-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "muster.labels" . | nindent 8 }}
+        app.kubernetes.io/component: tbot
+    spec:
+      serviceAccountName: {{ include "muster.tbot.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: tbot
+          image: "{{ $teleport.image.repository }}:{{ $teleport.image.tag | default "17.5.4" }}"
+          imagePullPolicy: {{ $teleport.image.pullPolicy }}
+          command:
+            - tbot
+          args:
+            - start
+            - -c
+            - /etc/tbot/tbot.yaml
+          env:
+            # POD_NAMESPACE is required for kubernetes_secret destinations.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # KUBERNETES_TOKEN_PATH points tbot at the audience-bound
+            # projected SA token used for the kubernetes join method.
+            - name: KUBERNETES_TOKEN_PATH
+              value: /var/run/secrets/tokens/join-sa-token
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml $teleport.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/tbot
+              readOnly: true
+            - name: join-sa-token
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "muster.tbot.configMapName" . }}
+        - name: join-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  # 600s is the kube minimum and the recommended tbot value.
+                  expirationSeconds: 600
+                  path: join-sa-token
+                  # Audience binds the JWT to the Teleport cluster — must match
+                  # the bot's join-token spec on the Teleport side.
+                  audience: {{ $audience | quote }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/muster/templates/tbot-rbac.yaml
+++ b/helm/muster/templates/tbot-rbac.yaml
@@ -1,0 +1,75 @@
+{{/*
+RBAC for the tbot Deployment (TB-4).
+
+The bot authenticates to Teleport via the kubernetes join method; the Teleport
+auth server validates this SA's projected JWT (audience-bound to the Teleport
+cluster) against the join token created in TB-3. No extra k8s permission is
+required for that — kubernetes recognises the projected token natively.
+
+In-cluster, tbot writes one Secret per output (destination type
+kubernetes_secret). RBAC is namespace-scoped (Role + RoleBinding, NOT
+ClusterRole) and constrained to the install namespace.
+
+Verbs: tbot needs to create/get/update/patch the Secret content as certs
+rotate. delete is included so the operator can later prune stale outputs by
+removing entries from clusters[]/apps[]. We constrain by resourceNames to the
+list derived by muster.tbot.outputs — `kubectl auth can-i delete secrets/foo`
+will deny anything outside that list.
+
+Trade-off note: the resourceNames constraint relies on the chart enumerating
+every Secret tbot will write. If a future maintainer adds a tbot output that
+isn't surfaced through clusters[]/apps[], they MUST extend muster.tbot.outputs
+to include it, or tbot will fail to write the Secret with a 403 — which is the
+desired loud signal.
+*/}}
+{{- if .Values.transport.teleport.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "muster.tbot.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tbot
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "muster.tbot.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tbot
+rules:
+  # tbot must be able to create the Secret on first run; once created, get/update/patch
+  # let it rotate cert material in place. delete enables operator-driven pruning when
+  # a cluster is removed from clusters[].
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # Constrain mutating verbs to exactly the Secrets derived by muster.tbot.outputs.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "update", "patch", "delete"]
+    resourceNames:
+      {{- range (include "muster.tbot.outputs" . | fromYamlArray) }}
+      - {{ .secretName | quote }}
+      {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "muster.tbot.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tbot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "muster.tbot.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "muster.tbot.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/muster/templates/tests/test-tbot-naming.yaml
+++ b/helm/muster/templates/tests/test-tbot-naming.yaml
@@ -1,9 +1,11 @@
 {{/*
-helm-test (TB-4) — verifies tbot identity Secrets exist post-deploy and that
-their names match the locked <role>-<cluster> convention TB-7's dispatcher
-relies on.
+helm-test (TB-4) — verifies tbot identity Secrets exist post-deploy. Names
+come verbatim from .Values.transport.teleport.apps[].identitySecret; no
+naming-convention check (PLAN §6 TB-0 revised 2026-04-29 dropped the
+<role>-<cluster> convention in favor of explicit values in both the chart
+and the MCPServer CR).
 
-Template-time duplicate detection in apps[] is handled in _helpers.tpl
+Template-time duplicate detection on apps[] is handled in _helpers.tpl
 (muster.tbot.outputs). This Pod adds the runtime existence check.
 */}}
 {{- if .Values.transport.teleport.enabled -}}
@@ -31,39 +33,18 @@ spec:
         - |
           set -eu
           fail=0
-          {{- range $cluster := (default (list) .Values.transport.teleport.clusters) }}
-          # Each clusters[] entry must produce these two Secrets with the locked names
-          # so muster's CR-driven dispatcher can resolve spec.transport.teleport.cluster
-          # to the correct identity material.
-          for s in tbot-identity-mcp-{{ $cluster.name }} tbot-identity-tx-{{ $cluster.name }}; do
-            if ! kubectl get secret "$s" -n "$POD_NAMESPACE" >/dev/null 2>&1; then
-              echo "MISSING: $s"
-              fail=1
-            else
-              echo "OK: $s"
-            fi
-          done
-          {{- end }}
           {{- range $a := (default (list) .Values.transport.teleport.apps) }}
-          for s in {{ $a.secretName | quote }}; do
+          # Each apps[] entry must have produced its identitySecret. Names are
+          # explicit (PLAN §6 TB-0 revised 2026-04-29) — no naming convention
+          # to assert beyond existence.
+          for s in {{ $a.identitySecret | quote }}; do
             if ! kubectl get secret "$s" -n "$POD_NAMESPACE" >/dev/null 2>&1; then
-              echo "MISSING (apps[] override): $s"
+              echo "MISSING: $s (appName={{ $a.appName }})"
               fail=1
             else
-              echo "OK (apps[] override): $s"
+              echo "OK: $s (appName={{ $a.appName }})"
             fi
           done
-          {{- end }}
-          # Convention assertion: every derived appName matches <role>-<cluster> exactly
-          # (locked in TB-1/TB-2 and consumed by TB-7's dispatcher).
-          {{- range (include "muster.tbot.outputs" . | fromYamlArray) }}
-          case {{ .appName | quote }} in
-            mcp-kubernetes-*|dex-*) ;;
-            *)
-              echo "CONVENTION VIOLATION: appName {{ .appName | quote }} does not match <role>-<cluster>"
-              fail=1
-              ;;
-          esac
           {{- end }}
           exit $fail
       env:

--- a/helm/muster/templates/tests/test-tbot-naming.yaml
+++ b/helm/muster/templates/tests/test-tbot-naming.yaml
@@ -1,0 +1,83 @@
+{{/*
+helm-test (TB-4) — verifies tbot identity Secrets exist post-deploy and that
+their names match the locked <role>-<cluster> convention TB-7's dispatcher
+relies on.
+
+Template-time duplicate detection in apps[] is handled in _helpers.tpl
+(muster.tbot.outputs). This Pod adds the runtime existence check.
+*/}}
+{{- if .Values.transport.teleport.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "muster.fullname" . }}-tbot-naming-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tbot-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  serviceAccountName: {{ include "muster.serviceAccountName" . }}
+  restartPolicy: Never
+  containers:
+    - name: assert-naming
+      image: "{{ .Values.transport.teleport.readinessGate.image.repository }}:{{ .Values.transport.teleport.readinessGate.image.tag }}"
+      imagePullPolicy: {{ .Values.transport.teleport.readinessGate.image.pullPolicy }}
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          fail=0
+          {{- range $cluster := (default (list) .Values.transport.teleport.clusters) }}
+          # Each clusters[] entry must produce these two Secrets with the locked names
+          # so muster's CR-driven dispatcher can resolve spec.transport.teleport.cluster
+          # to the correct identity material.
+          for s in tbot-identity-mcp-{{ $cluster.name }} tbot-identity-tx-{{ $cluster.name }}; do
+            if ! kubectl get secret "$s" -n "$POD_NAMESPACE" >/dev/null 2>&1; then
+              echo "MISSING: $s"
+              fail=1
+            else
+              echo "OK: $s"
+            fi
+          done
+          {{- end }}
+          {{- range $a := (default (list) .Values.transport.teleport.apps) }}
+          for s in {{ $a.secretName | quote }}; do
+            if ! kubectl get secret "$s" -n "$POD_NAMESPACE" >/dev/null 2>&1; then
+              echo "MISSING (apps[] override): $s"
+              fail=1
+            else
+              echo "OK (apps[] override): $s"
+            fi
+          done
+          {{- end }}
+          # Convention assertion: every derived appName matches <role>-<cluster> exactly
+          # (locked in TB-1/TB-2 and consumed by TB-7's dispatcher).
+          {{- range (include "muster.tbot.outputs" . | fromYamlArray) }}
+          case {{ .appName | quote }} in
+            mcp-kubernetes-*|dex-*) ;;
+            *)
+              echo "CONVENTION VIOLATION: appName {{ .appName | quote }} does not match <role>-<cluster>"
+              fail=1
+              ;;
+          esac
+          {{- end }}
+          exit $fail
+      env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+{{- end }}

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -404,6 +404,76 @@ muster:
       # SECURITY: only list client IDs you fully trust.
       trustedAudiences: []
 
+# Transport configuration (TB-4 — identity material only).
+#
+# When transport.teleport.enabled is true the chart provisions a separate
+# tbot Deployment that writes one Kubernetes Secret per (cluster, role) pair
+# derived from `clusters[]`. These Secrets carry the mTLS material muster's
+# CR-driven dispatcher (TB-7) loads at request time when an MCPServer CR has
+# `spec.transport.teleport.cluster: <name>` set. The chart does NOT render
+# any deployment-level routing — transport intent is per-CR.
+#
+# Customer Muster deployments (in-VPN) leave this off; the chart behaves
+# exactly as before.
+transport:
+  teleport:
+    # Enable tbot identity provisioning. Default off.
+    enabled: false
+    # The single GS Teleport proxy address — one cluster fronts all MCs.
+    proxyServer: teleport.giantswarm.io:443
+    # Optional explicit Teleport cluster name (used as the SA-token audience
+    # for the kubernetes join method). When empty, derived by stripping the
+    # port from proxyServer.
+    clusterName: ""
+    # tbot container image. Default tag pinned to the version shipped by
+    # giantswarm/teleport-kube-agent-app (Chart.yaml appVersion: 17.5.4).
+    image:
+      repository: public.ecr.aws/gravitational/teleport-distroless
+      # Empty tag falls back to the chart-side default (17.5.4) in
+      # tbot-deployment.yaml. Override per-environment as needed.
+      tag: ""
+      pullPolicy: IfNotPresent
+    # Provisioning hint — one entry per remote MC. The chart derives, for
+    # each entry:
+    #   appName=mcp-kubernetes-<name> -> Secret tbot-identity-mcp-<name>
+    #   appName=dex-<name>            -> Secret tbot-identity-tx-<name>
+    # Locked names; muster's dispatcher (TB-7) resolves both from the CR's
+    # spec.transport.teleport.cluster value.
+    clusters: []
+    # - name: glean
+    # - name: finch
+    #
+    # Escape hatch for non-conformant tbot output names. apps[] entries
+    # whose `name` matches a clusters[]-derived entry override that entry;
+    # apps[]-only names are appended. Duplicate names within apps[] are a
+    # template-time error.
+    apps: []
+    # - name: custom-mcp-glean
+    #   appName: custom-mcp-app-glean
+    #   secretName: tbot-identity-custom-glean
+    #
+    # tbot is light — small defaults are enough.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    # Init-container image used by muster's readiness gate (deployment.yaml)
+    # to verify all derived Secrets exist before muster goes Ready.
+    readinessGate:
+      image:
+        repository: bitnami/kubectl
+        tag: "1.30"
+        pullPolicy: IfNotPresent
+      # Per-iteration sleep in seconds. The init container loops until all
+      # Secrets exist; if a Secret is missing for >5 minutes it crashloops,
+      # which is the desired signal (see TB-4 readiness gate).
+      pollIntervalSeconds: 5
+      # Hard timeout (seconds). Container exits non-zero on timeout.
+      timeoutSeconds: 300
+
 # CRD installation
 crds:
   # Install Custom Resource Definitions

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -407,11 +407,16 @@ muster:
 # Transport configuration (TB-4 — identity material only).
 #
 # When transport.teleport.enabled is true the chart provisions a separate
-# tbot Deployment that writes one Kubernetes Secret per (cluster, role) pair
-# derived from `clusters[]`. These Secrets carry the mTLS material muster's
-# CR-driven dispatcher (TB-7) loads at request time when an MCPServer CR has
-# `spec.transport.teleport.cluster: <name>` set. The chart does NOT render
-# any deployment-level routing — transport intent is per-CR.
+# tbot Deployment that writes one Kubernetes Secret per `apps[]` entry.
+# These Secrets carry the mTLS material muster's CR-driven dispatcher
+# (TB-7) loads at request time when an MCPServer CR's `spec.transport.teleport`
+# names them via {mcp,dex}.identitySecretRef.
+#
+# After the TB-0 explicit-fields reshape (PLAN §6 TB-0 revised 2026-04-29)
+# the chart does NOT derive app or secret names from a cluster symbol —
+# every (appName, identitySecret) pair is stated explicitly. The CR carries
+# the same pair verbatim, so chart values and CRs grep against each other
+# directly.
 #
 # Customer Muster deployments (in-VPN) leave this off; the chart behaves
 # exactly as before.
@@ -433,24 +438,22 @@ transport:
       # tbot-deployment.yaml. Override per-environment as needed.
       tag: ""
       pullPolicy: IfNotPresent
-    # Provisioning hint — one entry per remote MC. The chart derives, for
-    # each entry:
-    #   appName=mcp-kubernetes-<name> -> Secret tbot-identity-mcp-<name>
-    #   appName=dex-<name>            -> Secret tbot-identity-tx-<name>
-    # Locked names; muster's dispatcher (TB-7) resolves both from the CR's
-    # spec.transport.teleport.cluster value.
-    clusters: []
-    # - name: glean
-    # - name: finch
+    # Explicit list of (Teleport application, Kubernetes Secret) pairs to
+    # provision. One entry per Teleport-routed endpoint (typically two per
+    # remote MC: an mcp-kubernetes app and a dex app). Each entry produces
+    # a tbot output and a Kubernetes Secret carrying the tbot-issued
+    # identity material.
     #
-    # Escape hatch for non-conformant tbot output names. apps[] entries
-    # whose `name` matches a clusters[]-derived entry override that entry;
-    # apps[]-only names are appended. Duplicate names within apps[] are a
-    # template-time error.
+    # Duplicate appName values within apps[] are a template-time error.
     apps: []
-    # - name: custom-mcp-glean
-    #   appName: custom-mcp-app-glean
-    #   secretName: tbot-identity-custom-glean
+    # - appName: mcp-kubernetes-glean
+    #   identitySecret: tbot-identity-mcp-glean
+    # - appName: dex-glean
+    #   identitySecret: tbot-identity-tx-glean
+    # - appName: mcp-kubernetes-finch
+    #   identitySecret: tbot-identity-mcp-finch
+    # - appName: dex-finch
+    #   identitySecret: tbot-identity-tx-finch
     #
     # tbot is light — small defaults are enough.
     resources:


### PR DESCRIPTION
## Summary

Adds tbot Deployment + ConfigMap + RBAC + readiness gate to the muster helm chart, gated by `transport.teleport.enabled` (default off — customer Muster is unaffected).

```yaml
transport:
  teleport:
    enabled: true
    proxyServer: teleport.giantswarm.io:443
    apps:
      - appName: mcp-kubernetes-glean
        identitySecret: tbot-identity-mcp-glean
      - appName: dex-glean
        identitySecret: tbot-identity-tx-glean
```

The chart provisions identity material **only**; per-CR transport routing comes from `MCPServer.spec.transport.teleport.{mcp,dex}.identitySecretRef` (TB-0). One tbot output + one Kubernetes Secret per \`apps[]\` entry. Template-time \`fail\` on duplicate appNames. Init-container readiness gate verifies all referenced Secrets exist before muster goes Ready.

## Dependencies / stacking

- **Depends functionally on:** [TB-0 / #601](https://github.com/giantswarm/muster/pull/601) (CRD shape) and **TB-3** (Teleport bot + token \`muster-aggregator\` referenced in tbot \`onboarding.token\`).
- **Branched off:** \`main\` (file-disjoint from TB-0; reviewers can read independently).
- **Blocks:** TB-7's dispatcher needs the Secrets at runtime; gate G-2 (TB-11 in PLAN) needs the chart deployed.

## Testing

- \`helm lint helm/muster\` clean
- \`helm template ... --set enabled=true --set apps[0].appName=...\` renders 4 secrets/outputs for a 2-cluster fixture
- Default render byte-identical to current \`main\`
- Duplicate-detection fails templating with a clear error

## Context

Part of [giantswarm/giantswarm#35456](https://github.com/giantswarm/giantswarm/issues/35456). PLAN §6 TB-4 (revised post-2026-04-29 to consume explicit-fields shape from TB-0).

---
🚧 **Draft / WIP**.