### PR TITLE
docs: architecture-review plan and per-customer deployment runbook

### DIFF
--- a/docs/explanation/architecture-review-plan.md
+++ b/docs/explanation/architecture-review-plan.md
@@ -50,11 +50,13 @@ For these customers, individual MCs are upgraded from the default (backend-only)
 - **agentgateway is deployed wherever the full stack lives** — default: only on the central MC, sized for the customer's whole traffic. Per-MC variant: on each upgraded MC.
 - **`MCPServer.spec.auth.teleport`** is the default cross-MC transport. It exists in the schema today and works without Phase 7.
 - **`MCPServer.spec.auth.tokenExchange`** (Phase 7) is the upgrade transport, gated on customer demand for per-MC isolation. Trigger-driven, not critical path.
-- **Hub-vs-spoke** in the per-MC variant is config (which `MCPServer` CRDs each muster owns, which broker peers each Dex trusts). In the default shape there's no hub-vs-spoke — there's one muster per customer.
+- **Hub-vs-spoke** in the per-MC variant is config (which `MCPServer` CRDs each muster owns, which broker peers each Dex trusts) and applies **within a single customer** with multiple MCs of their own. It does NOT apply across customers — there is no GS-side hub federating into customer environments.
+- **GS-Central is its own customer-style stack, isolated.** GS runs one stack (agw + muster + broker + valkey + GS Dex) on a GS-managed MC for **GS-internal MCP work only** (dogfooding muster, GS-internal backends, validation of new MCP integrations). It does not federate into customer brokers; it does not contain MCPServer CRDs pointing at customer backends. The total agentgateway count in an installation is `1 (GS-Central) + N (one per customer)`, not "per MC".
+- **GS staff access customer MCs by direct connection to the customer's gateway.** When a GS engineer needs MCP-driven access to Acme, they configure Claude Code with `muster.acme-prod.<inst>.gigantic.io/mcp` as a separate entry, alongside their `muster.gs-central.../mcp` entry for GS-internal work. The customer's Dex configures GS Dex as a federated upstream OIDC connector (customer-opt-in, similar to how customer Teleport already trusts GS support roles); the GS engineer authenticates against the customer's Dex via the GS Dex connector; the customer's Dex issues a customer-audience JWT with `sub=<gs-engineer>`; the customer's agw and audit see the GS engineer's identity end-to-end. No broker federation, no cross-Dex JWKS sharing at the agw layer — just standard OIDC upstream federation at the identity layer.
 
 ## Where federation logic lives
 
-The broker handles federation entirely. muster's call sites are federation-agnostic.
+Federation in this plan means **a single customer's broker reaching that same customer's other MCs**, not GS-to-customer reach. The broker handles federation entirely. muster's call sites are federation-agnostic.
 
 ```
 muster operator             broker (in-process)              remote broker (peer)
@@ -91,24 +93,26 @@ The `TokenBroker` interface in `internal/aggregator/token_broker.go` (Phase 2) i
 
 ## Tool catalog and cluster attribution
 
-When a hub fans out across many MCs, tool name disambiguation is load-bearing. Convention: **`toolPrefix` on hub-side MCPServer CRDs encodes cluster identity**.
+This applies to **a customer with multiple MCs** who has upgraded to the per-MC variant — their central muster sees backends across their own MCs and needs to disambiguate. (It does not apply across customers — GS-Central does not aggregate customer backends.)
+
+Convention: **`toolPrefix` on the customer's hub-side MCPServer CRDs encodes the customer's cluster identity**.
 
 ```yaml
-# Hub-side MCPServer
+# Acme's hub muster on acme-prod, MCPServer pointing at acme-dev's backend
 spec:
-  toolPrefix: acme_prod_k8s
-  url: https://muster-agw.acme-prod.azuretest.gigantic.io/mcp/k8s
+  toolPrefix: acme_dev_k8s
+  url: https://muster-agw.acme-dev.azuretest.gigantic.io/mcp/k8s
   auth:
     tokenExchange: { ... }
 ```
 
-User and LLM see `x_acme_prod_k8s_list_pods` in the tool catalog; the cluster targeting is unambiguous. Spoke backends are unchanged — they receive the post-prefix-strip name (`list_pods`) just like in single-MC deployments.
+Acme's engineers see `x_acme_dev_k8s_list_pods` in their tool catalog; the cluster targeting is unambiguous. The spoke (acme-dev) MCPServers are unchanged — they receive the post-prefix-strip name (`list_pods`) just like in single-MC deployments.
 
-Tool catalog visibility is filtered per-user at the hub aggregator based on JWT claims (ADR-006 territory; the catalog filter stays at the hub aggregator because agw's `traffic.authorization` enforces individual calls, not catalog responses). Three enforcement layers in total:
+Tool catalog visibility is filtered per-user at the customer's hub aggregator based on JWT claims (ADR-006 territory; the catalog filter stays at the aggregator because agw's `traffic.authorization` enforces individual calls, not catalog responses). Three enforcement layers in total within the customer's stack:
 
-1. Hub aggregator filters `tools/list` by user identity (catalog visibility)
-2. Hub agw `traffic.authorization` enforces per-call access (Phase 6)
-3. Spoke agw + spoke broker JWKS validate the federated JWT (defense in depth)
+1. Customer's hub aggregator filters `tools/list` by user identity (catalog visibility)
+2. Customer's hub agw `traffic.authorization` enforces per-call access (Phase 6)
+3. Customer's spoke agw + spoke broker JWKS validate the federated JWT (defense in depth)
 
 ## Target architecture (end of Phase 8)
 
@@ -490,36 +494,40 @@ Deletes done for cluster mode must be careful not to remove code filesystem mode
 
 ---
 
-### Phase 7 — Cross-cluster broker federation (trigger-driven, opt-in per customer)
+### Phase 7 — Cross-MC broker federation (trigger-driven, opt-in per customer)
 
-*Schema is already designed (`MCPServer.spec.auth.tokenExchange`); this phase is broker plumbing. Not on the critical path — applies only to customers who upgrade specific MCs to the per-MC variant.*
+*Schema is already designed (`MCPServer.spec.auth.tokenExchange`) and the broker-side RFC 8693 exchange logic already exists in `mcp-oauth`. **Phase 7 is purely about a single customer's multi-MC fan-out** — Acme's central muster reaching backends on Acme's other MCs with full user identity preservation. It is **not** about GS staff accessing customer MCs (that's handled by per-customer Claude Code config + customer Dex's OIDC connector federation to GS Dex, no broker federation needed). Not on the critical path.*
 
 `pkg/apis/muster/v1alpha1/mcpserver_types.go` already has:
 
 ```go
-TokenExchange *TokenExchangeConfig  // RFC 8693 cross-cluster
+TokenExchange *TokenExchangeConfig  // RFC 8693 within a customer's MCs
 Teleport      *TeleportAuthConfig
 ```
 
-with documented semantics. What's missing is the broker runtime support for chained exchange across cluster Dexes.
+with documented semantics. The broker-side exchange code exists today; what's missing is the per-MC operational pattern that exercises it with spoke-side agw validation.
 
-**Work items (when triggered):**
-- Broker `exchange.go` learns to dispatch RFC 8693 against a remote Dex per `TokenExchangeConfig`
-- Cross-Dex JWKS fetch + cache for verifying tokens issued by a peer broker
-- agw on the remote cluster validates JWTs from local broker via remote broker JWKS
+**Work items (when triggered for a specific customer):**
+- Confirm/extend broker `exchange.go` to dispatch RFC 8693 against the customer's remote Dex (within the customer's trust domain) per `TokenExchangeConfig`
+- Cross-Dex JWKS fetch + cache for the customer's spoke broker to verify JWTs issued by the customer's hub broker
+- The customer's spoke agw validates JWTs from the customer's hub broker via the customer's spoke broker's JWKS — both inside the customer's trust domain
 - Translator (Phase 5) emits the right `AgentgatewayPolicy` based on whether `MCPServer.spec.auth.tokenExchange` or `auth.teleport` is set
 - Teleport-based MCPServers continue working alongside via the existing `auth.teleport` path
 
-**Topology after a Phase 7 upgrade for one customer MC:**
+**This is entirely within a single customer's trust domain.** GS-Central is not involved; no cross-customer broker peering. The federation graph is intra-customer (Acme's prod hub broker ↔ Acme's dev/staging brokers), not cross-customer.
+
+**Topology after a Phase 7 upgrade within a customer (Acme upgrades acme-dev to its own full stack):**
 
 ```
-Central MC: Claude Code → Envoy → muster + agw → cross-MC HTTPS → upgraded MC agw → upgraded MC backend
-                                       │ broker.GetToken(audience=upgraded-MC)        │
-                                       │ → RFC 8693 with upgraded MC's broker         │
-                                       │ → JWT (sub preserved, aud=upgraded-MC)       │
-                                       └─                                              ◄─ JWT validated
-                                                                                          against upgraded
-                                                                                          MC's broker JWKS
+Acme staff member → Acme central hub agw → Acme hub muster → cross-MC HTTPS → acme-dev agw → acme-dev backend
+                                                │ broker.GetToken(audience=acme-dev)              │
+                                                │ → RFC 8693 with acme-dev's broker               │
+                                                │ → JWT (sub preserved, aud=acme-dev)             │
+                                                └─                                                ◄─ JWT validated
+                                                                                                    against acme-dev
+                                                                                                    broker's JWKS
+
+All within Acme's trust domain. GS-Central is not involved.
 ```
 
 **Triggers (Phase 7 is undertaken when at least one applies for a specific customer):**
@@ -530,7 +538,9 @@ Central MC: Claude Code → Envoy → muster + agw → cross-MC HTTPS → upgrad
 - Scale on the central stack (throughput bottleneck)
 - Per-tenant operations within a customer (team isolation)
 
-Until at least one trigger applies, Teleport (`auth.teleport`) stays as the cross-MC transport — already supported, no Phase 7 work required.
+Until at least one trigger applies for a customer, Teleport (`auth.teleport`) stays as the cross-MC transport within that customer's stack — already supported, no Phase 7 work required.
+
+**Phase 7 has no GS-side scope.** GS staff cross-customer access is handled by per-customer Claude Code config + customer-side Dex OIDC federation to GS Dex — no broker federation primitive needed.
 
 **Effort:** 2 weeks of broker work plus per-customer cross-Dex trust setup (one-time per MC pair). **Risk:** medium (JWKS rotation timing, OIDC connector setup per cluster pair).
 
@@ -619,7 +629,7 @@ Steady state
 Trigger-driven (opt-in per customer, no fixed schedule):
    Phase 7 — broker federation (only for customers upgrading to per-MC variant)
    Broker pod extraction (compliance / scale / multi-tenancy)
-   MCPServerClass (when hub catalogs grow large)
+   MCPServerClass (when a customer's per-MC hub catalog grows large)
 ```
 
 **Effort to ship-to-customers (end of Phase 5)**: ~5-6 weeks once ServiceClass removal merges and Phase 2 reviews progress. Phase 2 dominates because of PR throughput; Phases 3 and 5 are smaller.
@@ -628,16 +638,29 @@ Trigger-driven (opt-in per customer, no fixed schedule):
 
 **Per-customer Phase 7 upgrade**: ~2 weeks when triggered, per customer who needs it.
 
-## Multi-cluster model
+## Deployment count per installation
 
-| Cluster type | Runs muster? | Runs agw? | Why |
-|---|---|---|---|
-| MC with platform/team agents | yes | yes | local agw handles muster ↔ same-cluster MCPs |
-| WC running its own MCP backends only (no muster) | no | optional | only needed if MC-side translator emits routes via WC's agw — Phase 7+ |
-| Remote MC with its own muster instance + MCPs | yes | yes | each MC's stack is symmetric; cross-MC calls go local-agw → remote-agw via broker federation |
-| Cluster that's a pure backend host (no muster, MCPs reached via Teleport from elsewhere) | no | no | Teleport tunnel terminates at the MCP service directly; agw isn't in this path |
+For an installation with `N` customers (where each customer may have 1+ MCs):
 
-Rule of thumb: **wherever muster runs, run agw**. Wherever muster only reaches via Teleport, agw is unnecessary.
+| Stack | Count | Location |
+|---|---|---|
+| **GS-Central stack** (agw + muster + broker + valkey + GS Dex client) | 1 | GS-managed MC, for GS-internal MCP work only |
+| **Customer stack** (agw + muster + broker + valkey + customer Dex client) | N | one on each customer's central MC |
+| **Customer secondary-MC stacks** (per-MC variant, opt-in) | 0 to many per customer | only when a customer's specific MC has been upgraded for compliance / isolation / latency / RBAC / scale / team-tenancy drivers |
+| **Backend-only MCs** (no muster, no agw — backend pods only) | many | customer MCs that host MCPs but have not been upgraded; reached from the customer's central muster via Teleport tunnel (or via the GS-built Teleport operator's URL once it lands) |
+
+**Total agw deployments**: `1 (GS-Central) + N (customers) + per-MC-upgrade-instances`. Each is a complete per-customer stack — not a fan-out of a single agw across MCs.
+
+GS-Central is **isolated**: it does not run MCPServer CRDs pointing at customer backends, does not federate into customer brokers, does not see or audit customer-side traffic. It exists for GS-internal use only.
+
+Cross-tenant access for GS staff (when needed): handled at the **identity layer**, not the broker layer. Per customer that has granted GS access:
+
+1. Customer's Dex configures GS Dex as a federated upstream OIDC connector (standard Dex config; one-time per customer; documented in the customer-onboarding template; analogous to GS Teleport role trust).
+2. GS engineer's Claude Code has a separate MCP server entry per customer they access: `muster.<customer>.<inst>.gigantic.io/mcp`.
+3. OAuth flow: Claude Code → customer's gateway → customer's Dex → GS Dex (via the federated connector) → GS corp SSO. Customer's Dex issues a customer-audience JWT with `sub=<gs-engineer>`. The customer's gateway and audit see the GS engineer's identity end-to-end.
+4. No broker federation. No cross-customer MCPServer CRDs at GS-Central. No GS-side aggregated catalog.
+
+Rule of thumb: **wherever muster runs, run agw**. Wherever muster only reaches via Teleport, agw is unnecessary. Cross-customer access is a customer-side trust decision exercised at the identity layer.
 
 ## Filesystem-mode behavior per phase
 

--- a/docs/explanation/architecture-review-plan.md
+++ b/docs/explanation/architecture-review-plan.md
@@ -1,0 +1,592 @@
+# Plan: gateway-first observability, token broker, slim cluster-mode muster
+
+## Constraints
+
+| Constraint | Notes |
+|---|---|
+| `MCPServer`, `Workflow`, `WorkflowRun` are the user-facing CRDs | stable contract |
+| Filesystem mode is a first-class deploy mode | preserved throughout (CTO call) |
+| Single Go module, single image, multiple commands | `muster operator`, `muster broker`, `muster agent`, `muster serve --filesystem-mode` |
+| Broker built on `giantswarm/mcp-oauth` library | only OSS impl with CIMD; we own the lib |
+| Workflow execution stays in muster | no equivalent in agentgateway |
+| Teleport remains cross-cluster transport as a fallback | broker federation (Phase 7) is on the critical path; Teleport stays as the transport for spokes that haven't adopted federation yet, mixed per-`MCPServer` |
+| Hexagonal: ports defined by the consumer, narrow per consumer | no shared `pkg/contracts/`, no shared `ports.go` |
+| Existing package names kept | `internal/aggregator/`, `internal/workflow/`, `internal/reconciler/` — rename is a separate concern |
+| Token validation is format-agnostic; issuance is format-toggled | mcp-oauth validates both opaque and JWT bearers regardless of mode; only issuance flips at deployment time |
+
+## Architectural invariant — one stack per customer (default), per-MC is opt-in
+
+**Default deployment shape: one stack per customer.**
+
+The customer's central MC runs the full muster stack — muster operator + agentgateway + broker (in-process) + valkey + Dex client. The customer's other MCs (if any) host backends only, with no local muster, no local agw, no local broker. Cross-MC backends are reached from the central muster via Teleport tunnel using `MCPServer.spec.auth.teleport`.
+
+```
+Per customer (default):
+  Central MC:    full stack (muster + agw + valkey + Dex client + all customer MCPServer CRDs)
+  Other MCs:     backend pods only (mcp-kubernetes, mcp-prometheus, etc.)
+                 reached via Teleport tunnel from the central muster
+```
+
+This is **what the glean deployment validated in Phase 1** and what most customers will run.
+
+**Opt-in deployment shape: one stack per MC.**
+
+Some customers will need per-MC isolation. Drivers include:
+
+- Regulatory per-environment isolation (prod and dev auth boundaries must be distinct)
+- Hard failure isolation (one MC's incident must not affect another MC's access)
+- Cross-MC latency (multi-region customers where local-to-local routing matters)
+- Per-MC RBAC variation (markedly different policies per environment)
+- Scale on central stack (large customers whose one-stack throughput becomes a bottleneck)
+- Per-tenant operations within a customer (team-A and team-B with strict isolation)
+
+For these customers, individual MCs are upgraded from the default (backend-only) to the full stack (muster + agw + valkey + Dex client). The upgrade is per-MC, per-customer, additive — same Helm chart, same translator, same agw config. Once a target MC runs the full stack, its `MCPServer` entry on the central muster swaps `auth.teleport` for `auth.tokenExchange`; the upgraded MC's Dex registers the central broker as a trusted peer; cross-MC calls flow via broker federation (Phase 7) preserving user identity at the spoke side.
+
+**Both shapes coexist within an installation.** Most customers stay on the default; specific customers upgrade specific MCs based on their drivers. The architecture supports both.
+
+### What this means for the building blocks
+
+- **muster the binary doesn't change between shapes.** Same image, same flags, same wiring. Only deployment topology differs.
+- **agentgateway is deployed wherever the full stack lives** — default: only on the central MC, sized for the customer's whole traffic. Per-MC variant: on each upgraded MC.
+- **`MCPServer.spec.auth.teleport`** is the default cross-MC transport. It exists in the schema today and works without Phase 7.
+- **`MCPServer.spec.auth.tokenExchange`** (Phase 7) is the upgrade transport, gated on customer demand for per-MC isolation. Trigger-driven, not critical path.
+- **Hub-vs-spoke** in the per-MC variant is config (which `MCPServer` CRDs each muster owns, which broker peers each Dex trusts). In the default shape there's no hub-vs-spoke — there's one muster per customer.
+
+## Where federation logic lives
+
+The broker handles federation entirely. muster's call sites are federation-agnostic.
+
+```
+muster operator             broker (in-process)              remote broker (peer)
+─────────────────           ─────────────────────           ───────────────────────
+reconcile MCPServer    ──▶  register(audience=X,
+  with auth.tokenExchange     peerConfig=<from CRD>)
+
+aggregator dispatch    ──▶  GetToken(sessionID, audience=X)
+                              │
+                              ├─ cache hit? return
+                              └─ exchange: POST /token       ──▶ accept exchange,
+                                          grant_type=8693          issue new JWT
+                                          audience=X             ◀── (aud=X, sub=user)
+                              cache result, return
+
+outbound HTTPS         ──▶  ⟨Bearer: exchanged JWT⟩
+to spoke agw URL              spoke agw validates against
+                              remote broker JWKS
+                              → routes to local backend
+```
+
+muster operator:
+- reconciles `MCPServer` CRDs; passes `auth.tokenExchange` config to broker
+- calls `broker.GetToken(sessionID, audience)` for each outbound MCP call
+- makes the HTTPS call to the URL in the MCPServer CRD, using the bearer broker returned
+
+Broker (`internal/broker/exchange.go`):
+- knows audience-to-peer-broker mapping (from MCPServer config)
+- performs RFC 8693 exchange against peer broker's token endpoint
+- caches exchanged tokens by `{sessionID, audience}`
+- maintains JWKS cache of peer brokers for inbound JWT validation
+
+The `TokenBroker` interface in `internal/aggregator/token_broker.go` (Phase 2) is federation-agnostic. Phase 7 is purely a broker-domain change: extends `internal/broker/exchange.go` to dispatch across peer brokers. muster aggregator code does not change.
+
+## Tool catalog and cluster attribution
+
+When a hub fans out across many MCs, tool name disambiguation is load-bearing. Convention: **`toolPrefix` on hub-side MCPServer CRDs encodes cluster identity**.
+
+```yaml
+# Hub-side MCPServer
+spec:
+  toolPrefix: acme_prod_k8s
+  url: https://muster-agw.acme-prod.azuretest.gigantic.io/mcp/k8s
+  auth:
+    tokenExchange: { ... }
+```
+
+User and LLM see `x_acme_prod_k8s_list_pods` in the tool catalog; the cluster targeting is unambiguous. Spoke backends are unchanged — they receive the post-prefix-strip name (`list_pods`) just like in single-MC deployments.
+
+Tool catalog visibility is filtered per-user at the hub aggregator based on JWT claims (ADR-006 territory; the catalog filter stays at the hub aggregator because agw's `traffic.authorization` enforces individual calls, not catalog responses). Three enforcement layers in total:
+
+1. Hub aggregator filters `tools/list` by user identity (catalog visibility)
+2. Hub agw `traffic.authorization` enforces per-call access (Phase 6)
+3. Spoke agw + spoke broker JWKS validate the federated JWT (defense in depth)
+
+## Target architecture (end of Phase 8)
+
+```
+Per-customer cluster
+─────────────────────────────────────────────────────────────
+Claude Code / Cursor      ──► agentgateway (edge data plane, MCP-aware)
+                                │ JWT or extAuth, RBAC, audit, tracing, metrics, rate limit
+                                │
+                                ├── /mcp/aggregator ──► muster operator
+                                │                       (CRD reconciler + translator + workflow runtime
+                                │                        + broker domain in-process)
+                                │
+                                ├── /mcp/<backend N> ──► backend MCP server (same cluster)
+                                │
+                                (HTTPRoute per backend, all emitted by translator)
+
+                            broker HTTP/gRPC endpoints exposed by muster operator
+                                │ OAuth 2.1 + CIMD + RFC 8693 + (opt-in) JWT issuance
+                                └── upstream IdP: Dex
+
+Local lab / BDD / demo
+─────────────────────────────────────────────────────────────
+muster serve --filesystem-mode --config-path ./.muster/
+  ├── reads YAML (MCPServer, Workflow)
+  ├── slim in-process MCP aggregator on :8090/mcp (preserved forever)
+  ├── (optional) embedded broker subprocess for full-stack lab
+  └── muster agent --local-dev → :8090/mcp
+```
+
+## Pre-Phase-1 — In flight
+
+ServiceClass removal is underway on `remove-sc-*` branches (4 commits ahead of `origin/main`). Once those merge, the plan starts from a clean main. Phase 2 work below assumes service-class removal is complete; if it isn't yet, the broker refactor still works — service-locator cleanup just inherits more dead code to delete.
+
+## Existing code map (verified against current branch)
+
+| Path | LOC (non-test) | Plan role |
+|---|---|---|
+| `internal/aggregator/` | ~10,310 | hosts auth glue + capability store; HTTP server bypassed in cluster mode by Phase 8 |
+| `internal/aggregator/auth_resource.go` | 476 | refactor through `TokenBroker` port — Phase 2 |
+| `internal/aggregator/auth_tools.go` | 469 | same |
+| `internal/aggregator/connection_helper.go` | 1153 | same |
+| `internal/aggregator/capability_store.go` + `_valkey.go` | ~280+ | replaced by agw `traffic.authorization` — Phase 6 |
+| `internal/oauth/` | ~3,050 | moves into `internal/broker/` — Phase 2 |
+| `internal/server/oauth_http.go` | 867 | moves into `internal/broker/http/` — Phase 2 |
+| `internal/orchestrator/` | ~860 | dropped from cluster-mode hot path — Phase 8; filesystem mode keeps it |
+| `internal/reconciler/` | — | hosts `mcpserver_reconciler.go`, `kubernetes_detector.go`, `filesystem_detector.go`; gains translator logic — Phase 5 |
+| `internal/api/` | ~1,500 | service-locator glue — replaced with constructor DI — Phase 2 |
+| `internal/services/{aggregator,mcpserver}/` | ~700 | wrapper packages — deleted in Phase 2 |
+| `internal/teleport/` | ~1,500 | stays until cross-cluster federation supersedes |
+| `internal/workflow/` | — | gains its own narrow `TokenBroker` port — Phase 2 |
+| `pkg/apis/muster/v1alpha1/mcpserver_types.go` | — | already has `Type`, `ForwardToken`, `RequiredAudiences`, `TokenExchange`, `Teleport` — schema is ready |
+
+## Package layout (target)
+
+```
+internal/aggregator/
+├── aggregator.go              existing domain
+├── token_broker.go            TokenBroker port (consumer-defined, narrow)
+├── entity_provider.go         EntityProvider port
+├── auth_resource.go           refactored to consume aggregator.TokenBroker
+├── auth_tools.go              same
+├── connection_helper.go       same
+└── broker/                    TokenBroker adapter (in-process now, gRPC client later if extracted)
+
+internal/workflow/
+├── executor.go                existing
+├── token_broker.go            workflow's narrower TokenBroker (GetToken / ExchangeToken)
+└── tool_caller.go             ToolCaller port
+
+internal/reconciler/
+├── mcpserver_reconciler.go    existing — extended in Phase 5 to emit AgentgatewayBackend + HTTPRoute
+├── kubernetes_detector.go     becomes the K8s EntityProvider implementation
+├── filesystem_detector.go     becomes the filesystem EntityProvider implementation
+└── workflow_reconciler.go     existing
+
+internal/broker/
+├── manager.go                 broker domain
+├── exchange.go                RFC 8693 routing logic
+├── session.go                 session lifecycle
+├── http/                      OAuth 2.1 endpoints (driving adapter, mounted in operator pod)
+└── grpc/                      gRPC server (driving adapter, dormant until pod extraction)
+
+cmd/muster/
+├── main.go                    cobra root
+├── operator.go                composition root for cluster mode (Phase 8 rename of serve.go)
+├── broker.go                  composition root for separate broker pod (when extracted)
+├── agent.go                   laptop CLI
+└── serve.go                   stays for filesystem mode until Phase 8 rename
+
+DELETED in Phase 2:
+- internal/api/             service-locator glue (replaced by constructor DI in cmd/)
+- internal/services/        wrapper packages around aggregator + mcpserver
+```
+
+Each consumer owns its own narrow `TokenBroker` interface. Both are satisfied structurally by the same broker implementation. No shared `pkg/contracts/`, no `ports.go` kitchen sinks. Ports live in single-purpose files.
+
+## Phases
+
+### Phase 1 — agw behind muster (per-backend observability)
+
+*Half-day YAML change. Reversible by URL revert.*
+
+**Goal:** every same-cluster MCP call gets audited, traced, and counted at agw, without disrupting auth or public routing.
+
+**Topology:**
+
+```
+Claude Code → Envoy → muster → muster-agw → backend MCPs
+                       └─→ OAuth/discovery on muster directly
+```
+
+**Work items:**
+
+- Apply `AgentgatewayBackend` + `HTTPRoute` per backend on `muster-agw`, matching `/mcp/<name>`
+- Revert the public `/mcp` split — Envoy goes back to a single rule pointing all of `muster.<cluster>.gigantic.io` to muster
+- Update each `MCPServer.spec.url` from `http://mcp-<name>.<ns>.svc:8080/mcp` to `https://muster-agw.muster.svc/mcp/<name>`
+- For `MCPServer.spec.auth.type=teleport`, leave the URL as the Teleport tunnel address — those backends bypass agw
+- Restart muster so the orchestrator picks up the new URLs
+
+**What you get:**
+
+| Concern | After Phase 1 |
+|---|---|
+| Per-backend Loki audit (`route=muster/mcp-k8s`) | ✓ |
+| Per-backend Mimir metrics (`agentgateway_requests_total{route=...}`) | ✓ |
+| Per-backend Tempo spans (muster → agw → backend) | ✓ |
+| Backend health-check via `AgentgatewayPolicy.backend.health` | ✓ |
+| Cross-cluster (Teleport-tunneled MCPs) | unchanged — bypasses agw, keeps muster-side audit |
+| User identity in agw audit log | ✗ (agw is internal-only here; muster's `security_audit` covers identity) |
+
+**Filesystem mode:** untouched — no agw in lab, muster's in-process aggregator handles routing locally.
+
+**Cross-cluster:** Teleport-tunneled MCPs continue exactly as today. agw doesn't see them. They get muster-side audit only. End-to-end cross-cluster identity is Phase 7's problem.
+
+**Effort:** half a day. **Risk:** low.
+
+---
+
+### Phase 2 — `TokenBroker` interface + broker bounded context (in-process), drop service locator
+
+*Critical path. Establishes the architectural seam. Refactor only — no behavior change.*
+
+```go
+// internal/aggregator/token_broker.go
+package aggregator
+
+type TokenBroker interface {
+    BeginOAuthFlow(ctx context.Context, req BeginRequest) (FlowURL, error)
+    CompleteOAuthFlow(ctx context.Context, code, state string) (Session, error)
+    GetToken(ctx context.Context, sessionID, audience string) (Token, error)
+    ExchangeToken(ctx context.Context, req ExchangeRequest) (Token, error)
+    RevokeSession(ctx context.Context, sessionID string) error
+    Introspect(ctx context.Context, bearer string) (Claims, error)  // accepts opaque or JWT
+    WatchAuthEvents(ctx context.Context) <-chan AuthEvent
+}
+```
+
+```go
+// internal/aggregator/entity_provider.go
+package aggregator
+
+type EntityProvider interface {
+    WatchMCPServers(ctx context.Context) <-chan EntityChange[MCPServer]
+    WatchWorkflows(ctx context.Context) <-chan EntityChange[Workflow]
+    UpdateStatus(ctx context.Context, kind, name string, status any) error
+}
+```
+
+```go
+// internal/workflow/token_broker.go
+package workflow
+
+type TokenBroker interface {
+    GetToken(ctx context.Context, sessionID, audience string) (Token, error)
+    ExchangeToken(ctx context.Context, req ExchangeRequest) (Token, error)
+}
+```
+
+`Introspect` takes any bearer because mcp-oauth validates both formats regardless of which the server is currently configured to issue. Callers don't need to know the format.
+
+**Work items:**
+
+- Define narrow `TokenBroker` interface in each consumer package (one interface per file, no `ports.go` kitchen sink)
+- Define `EntityProvider` interface in `internal/aggregator/` to seam K8s vs filesystem detector code paths
+- Create `internal/broker/` bounded context: domain (`manager.go`, `exchange.go`, `session.go`) + adapters (`http/`, `grpc/`) wrapping `mcp-oauth`
+- Mount `internal/broker/http/` HTTP endpoints inside the muster operator pod at `/oauth/*`
+- Create `internal/aggregator/broker/` adapter (in-process call into `internal/broker/`)
+- Refactor `internal/aggregator/auth_resource.go`, `auth_tools.go`, `connection_helper.go` to consume the local port instead of importing `internal/oauth/`
+- Migrate `internal/reconciler/{kubernetes,filesystem}_detector.go` behind the `EntityProvider` interface
+- **Delete `internal/api/` service locator + `internal/services/{aggregator,mcpserver}/` wrappers**; replace with constructor DI in `cmd/muster/`
+- `noOpBroker` adapter for filesystem `--no-auth`
+- Composition root in `cmd/serve.go` picks the adapter
+- Import-boundary CI rule: `internal/aggregator/` may not import `internal/broker/` directly — only via `internal/aggregator/broker/`
+
+Cluster mode: behavior unchanged. Filesystem mode: behavior unchanged.
+
+**Effort:** 2–3 weeks. **Risk:** low–medium (refactor of widely-imported `internal/api/`).
+
+**Parallel-runnable with Phase 1.**
+
+---
+
+### Phase 3 — OTel SDK in muster + backends
+
+*Parallel-safe.*
+
+- Wire OTel SDK into muster operator + workflow runtime
+- Honor inbound `traceparent`
+- Verify backends propagate `traceparent` (small upstream patch if absent)
+
+Cluster mode: rich tracing across all hops. After Phase 1, Tempo shows `client → Envoy → muster → muster-agw → backend MCP → real K8s API`. After Phase 4, identity attributes from JWT/extAuth get propagated into spans.
+Filesystem mode: optional via `--otel-endpoint=`; default no-op exporter.
+
+**Effort:** 1 week. **Risk:** low.
+
+**Can land any time after Phase 1.**
+
+---
+
+### Phase 4 — Edge auth (deployment-time format choice)
+
+*Critical path. The architectural break: agw becomes the user-facing auth boundary regardless of which token format the broker issues.*
+
+mcp-oauth gains an opt-in JWT issuance mode (separate PR in `giantswarm/mcp-oauth`). Validation in mcp-oauth already accepts both opaque (TokenStore lookup) and JWT (JWKS verify) bearers; the new mode adds a third validation branch for self-issued JWTs. Only issuance toggles per server instance.
+
+agw's edge-auth mechanism follows from the deployment-time issuance choice:
+
+| Broker issues | agw policy | Per-request behavior |
+|---|---|---|
+| JWT (recommended when agw is in front) | `traffic.jwtAuthentication` against broker JWKS | local signature verify; no broker round-trip |
+| Opaque (default; preserves encryption-at-rest) | `traffic.extAuth` → broker `/oauth/introspect` | broker validates and returns claims |
+
+Both produce identity as CEL vars at agw (`jwt.sub`/`jwt.email`/`jwt.groups` directly in JWT mode; `extAuth.response.headers["x-user-*"]` in opaque mode). Audit log, RBAC rules, rate limits work either way.
+
+**Topology change (when this lands):**
+
+```
+Phase 1 was:    Claude Code → Envoy → muster → muster-agw → backends
+Phase 4 becomes: Claude Code → Envoy → muster-agw → muster (or directly → backends)
+                                            ↘ /oauth, /.well-known on muster directly
+```
+
+agw moves to in front of muster. Public Envoy `HTTPRoute` splits again: `/mcp/*` to muster-agw, `/oauth/*` and `/.well-known/*` to muster. (This is the agw-in-front trial we already validated on glean — comes back at this phase.)
+
+**Work items:**
+- Land mcp-oauth JWT issuance PR (separate repo; prompt already drafted)
+- Broker exposes `/.well-known/jwks.json` (active in JWT mode, 404 in opaque) and keeps `/oauth/introspect` working for both formats
+- agw signs identity headers via httpsig (RFC 9421) before forwarding to muster, regardless of mode
+- muster operator + backends drop bearer validation; trust httpsig identity headers via small middleware
+- Translator (Phase 5) reads broker config and emits the matching agw policy
+
+Cluster mode: identity at agw, audit-log attribution, RBAC and rate-limit policies usable. muster operator no longer per-request-validates bearer tokens.
+Filesystem mode: unchanged when `--no-auth`. Full-stack lab broker subprocess can issue either format locally; the lab agw equivalent (or direct muster) validates accordingly.
+
+**Effort:** 2–2.5 weeks (excluding mcp-oauth PR review cycle). **Risk:** medium. The dual-mode support adds little risk because mcp-oauth's validator already handles both.
+
+**Depends on Phase 2 (broker boundary) for clean split between agw and muster.**
+
+---
+
+### Phase 5 — Translator MVP (extend `internal/reconciler/`)
+
+*Self-service inflection point. Single user-facing CRD; agw stack emitted underneath.*
+
+- Extend `internal/reconciler/mcpserver_reconciler.go` to emit, for each `MCPServer` in cluster mode:
+  - `AgentgatewayBackend` referencing user's Service from `MCPServer.spec.url`
+  - `HTTPRoute` matching `/mcp/<name>` on the platform `Gateway`
+  - `AgentgatewayPolicy` carrying audit configuration plus the matching auth mechanism — `traffic.jwtAuthentication` (broker JWKS) when broker issues JWTs, `traffic.extAuth` (broker `/oauth/introspect`) when broker issues opaque tokens. The translator reads broker config to decide.
+  - Owner references for GC
+- Status sync: translate `AgentgatewayBackend` conditions back into `MCPServer.status`
+- For `MCPServer.spec.auth.type=teleport`, translator emits a passthrough — no agw resources, muster handles it directly
+
+Cluster mode: app teams author one `MCPServer` CRD; routing + auth + audit emitted automatically.
+Filesystem mode: translator is no-op; reads YAML directly into in-process aggregator.
+
+**`MCPServerClass` for platform-team defaults is deferred to trigger-driven** (when there are >5 MCPServers per cluster and copy-pasted policy YAML becomes painful). Phase 5 hardcodes sensible defaults until then.
+
+**Effort:** 2 weeks. **Risk:** medium.
+
+**Depends on Phase 4 for knowing which auth mechanism to emit.**
+
+---
+
+### Phase 6 — ADR-006 → `traffic.authorization`
+
+- Per-session tool filter expressed as CEL on `mcp.method.name == "tools/call"` + `mcp.tool.name` + `jwt.groups`
+- Translator extended to emit `AgentgatewayPolicy` rules from `MCPServer.spec.tools` (or a new field) for per-tool RBAC
+- `internal/aggregator/capability_store.go` + `_valkey.go` unwired from cluster-mode hot path (file kept in tree for filesystem mode)
+
+Cluster mode: stateless, JWT-claim-based filtering at agw. ADR-006 outcome preserved, mechanism changed.
+Filesystem mode: keeps server-side capability store; optional `--simulate-groups=readonly` for tests.
+
+Deletes done for cluster mode must be careful not to remove code filesystem mode imports. The capability store file stays in the tree; only the cluster-mode composition root stops wiring it.
+
+**Effort:** 1.5 weeks. **Risk:** medium (capability store migration — write parity tests first).
+
+**Can run parallel with Phase 5; both depend on Phase 4 for JWT claims.**
+
+---
+
+### Phase 7 — Cross-cluster broker federation (trigger-driven, opt-in per customer)
+
+*Schema is already designed (`MCPServer.spec.auth.tokenExchange`); this phase is broker plumbing. Not on the critical path — applies only to customers who upgrade specific MCs to the per-MC variant.*
+
+`pkg/apis/muster/v1alpha1/mcpserver_types.go` already has:
+
+```go
+TokenExchange *TokenExchangeConfig  // RFC 8693 cross-cluster
+Teleport      *TeleportAuthConfig
+```
+
+with documented semantics. What's missing is the broker runtime support for chained exchange across cluster Dexes.
+
+**Work items (when triggered):**
+- Broker `exchange.go` learns to dispatch RFC 8693 against a remote Dex per `TokenExchangeConfig`
+- Cross-Dex JWKS fetch + cache for verifying tokens issued by a peer broker
+- agw on the remote cluster validates JWTs from local broker via remote broker JWKS
+- Translator (Phase 5) emits the right `AgentgatewayPolicy` based on whether `MCPServer.spec.auth.tokenExchange` or `auth.teleport` is set
+- Teleport-based MCPServers continue working alongside via the existing `auth.teleport` path
+
+**Topology after a Phase 7 upgrade for one customer MC:**
+
+```
+Central MC: Claude Code → Envoy → muster + agw → cross-MC HTTPS → upgraded MC agw → upgraded MC backend
+                                       │ broker.GetToken(audience=upgraded-MC)        │
+                                       │ → RFC 8693 with upgraded MC's broker         │
+                                       │ → JWT (sub preserved, aud=upgraded-MC)       │
+                                       └─                                              ◄─ JWT validated
+                                                                                          against upgraded
+                                                                                          MC's broker JWKS
+```
+
+**Triggers (Phase 7 is undertaken when at least one applies for a specific customer):**
+- Regulatory per-environment isolation requirements
+- Hard failure-isolation requirements ("prod must stay up if dev is broken")
+- Cross-MC latency that hurts AI workloads in practice
+- Per-MC RBAC variation (markedly different policies per environment)
+- Scale on the central stack (throughput bottleneck)
+- Per-tenant operations within a customer (team isolation)
+
+Until at least one trigger applies, Teleport (`auth.teleport`) stays as the cross-MC transport — already supported, no Phase 7 work required.
+
+**Effort:** 2 weeks of broker work plus per-customer cross-Dex trust setup (one-time per MC pair). **Risk:** medium (JWKS rotation timing, OIDC connector setup per cluster pair).
+
+---
+
+### Phase 8 — Bypass aggregator HTTP server in cluster mode
+
+*The cleanup that completes "muster operator is the operator, agw is the data plane".*
+
+After Phases 4–6, muster's in-process MCP HTTP server has no traffic in cluster mode. agw is the data plane both inbound (clients) and outbound (backends).
+
+**Work items:**
+
+- `cmd/muster/operator.go` no longer wires up `internal/aggregator/`'s in-process MCP HTTP server in cluster mode
+- Filesystem mode keeps the server (it IS the filesystem-mode data plane)
+- Rename `cmd/serve.go` → `cmd/operator.go` for cluster role; `serve` stays for filesystem mode
+- `internal/orchestrator/` only used by filesystem mode going forward — code stays in the binary, dormant in cluster
+
+**"Remove the aggregator" means *stop wiring it in cluster mode*, not delete the code.** The aggregator and orchestrator packages stay compiled in the binary because filesystem mode imports them. Cluster builds don't run them; the linker may strip dead code. No build tags needed unless binary size pressure justifies them later.
+
+Cluster mode end-state: muster operator pod runs CRD reconciler + translator + workflow runtime + broker domain. ~25–35k LOC active instead of ~75k.
+Filesystem mode end-state: unchanged from today.
+
+**Effort:** 1 week. **Risk:** low (mostly composition-root deletes once Phases 4–6 land).
+
+---
+
+## Trigger-driven (defer until needed)
+
+### Extract broker to its own pod
+
+Phase 2 already separates broker code (`internal/broker/`) and gives it a gRPC adapter. The broker just runs in the same pod as the operator until something forces extraction. Triggers:
+
+| Trigger | Action |
+|---|---|
+| Compliance or audit isolation requires broker secrets in a separate process boundary | New `cmd/muster/broker.go` entrypoint; switch operator's `aggregator/broker/` adapter from in-process to gRPC client; Helm chart adds broker deployment |
+| Independent scaling: broker RPS for token exchange dwarfs operator's CRD load | same |
+| Multi-tenant isolation: broker per tenant | same |
+
+Effort when triggered: ~1 week (Phase 2 makes this a deployment topology change, not architectural).
+
+### `MCPServerClass` for platform-team defaults
+
+A cluster-scoped CRD that lets the platform team declare default policies (auth, rate limits, audit sink, RBAC rule sets) applied to every `MCPServer` in a namespace — analogous to `IngressClass` / `GatewayClass`.
+
+Triggers:
+- More than ~5 `MCPServer`s per cluster, where copy-pasting policy YAML becomes painful
+- Per-namespace or per-tenant policy variation that platform team wants to enforce centrally
+- Customer demand for "all my team's MCPs get these guardrails by default"
+
+Until then, each `MCPServer` carries its own auth/RBAC fields (or the translator applies hard-coded sensible defaults). Effort when triggered: ~1.5–2 weeks.
+
+## Critical path
+
+```
+Phase 1 ─►─► Phase 5 ─►─► Phase 6 ─►─► Phase 8
+               ↑              ↑
+Phase 2 ──────┘              ┘
+Phase 4 ──────┘              ┘   ← Phase 5 emits Phase 4-aware policies; Phase 6 needs JWT claims
+Phase 3       (parallel anywhere from Phase 1 onward)
+
+Trigger-driven (opt-in per customer):
+  Phase 7 — broker federation (only for customers upgrading to per-MC variant)
+  Broker pod extraction (compliance / scale / multi-tenancy)
+  MCPServerClass (when hub catalogs grow large)
+```
+
+Critical-path total: ~10 weeks of focused engineering for one engineer. With Phases 2 and 4 running in parallel where dependencies allow, calendar time can compress to ~7–8 weeks. Phase 7 adds ~2 weeks per customer who upgrades.
+
+## Multi-cluster model
+
+| Cluster type | Runs muster? | Runs agw? | Why |
+|---|---|---|---|
+| MC with platform/team agents | yes | yes | local agw handles muster ↔ same-cluster MCPs |
+| WC running its own MCP backends only (no muster) | no | optional | only needed if MC-side translator emits routes via WC's agw — Phase 7+ |
+| Remote MC with its own muster instance + MCPs | yes | yes | each MC's stack is symmetric; cross-MC calls go local-agw → remote-agw via broker federation |
+| Cluster that's a pure backend host (no muster, MCPs reached via Teleport from elsewhere) | no | no | Teleport tunnel terminates at the MCP service directly; agw isn't in this path |
+
+Rule of thumb: **wherever muster runs, run agw**. Wherever muster only reaches via Teleport, agw is unnecessary.
+
+## Filesystem-mode behavior per phase
+
+| Phase | Filesystem mode |
+|---|---|
+| 1 | unchanged (no agw in lab) |
+| 2 | Ports added; default `noOpBroker` adapter for `--no-auth`, in-process broker for full-auth lab |
+| 3 | OTel optional via `--otel-endpoint=` flag |
+| 4 | JWT validation only if broker is wired in (full-auth lab); `--no-auth` lab unaffected |
+| 5 | Translator is no-op; YAML reads directly into in-process aggregator |
+| 6 | Keeps server-side capability store; optional `--simulate-groups` |
+| 7 | N/A (cross-cluster needs K8s + remote Dex) |
+| 8 | Untouched — aggregator HTTP server is filesystem mode's data plane |
+| Trigger-driven | Broker pod extraction, MCPServerClass: no filesystem-mode impact |
+
+## Preserved / replaced / lost
+
+| Today's behavior | After plan | Workaround |
+|---|---|---|
+| `MCPServer` / `Workflow` / `WorkflowRun` self-service | preserved | translator emits agw stack |
+| Filesystem mode for lab/dev/BDD | preserved | `EntityProvider` interface seam |
+| Workflow execution in muster | preserved | unchanged |
+| Cross-cluster MCP via Teleport | preserved indefinitely | broker federation as alternative when triggered (Phase 7) |
+| `auth.forwardToken: true` SSO | preserved | broker handles token exchange |
+| `auth.tokenExchange` (RFC 8693 cross-cluster) | preserved (already in schema) | wired in Phase 7 |
+| `localCommand` MCPServer type | filesystem mode only | drop in cluster mode |
+| Synthetic `auth_login_*` tool | replaced | agw RFC 9728 challenge → MCP client handles |
+| `toolPrefix` deterministic naming | preserved | translator emits per-backend HTTPRoute paths; tool-name rewrite via transformation policy if needed |
+| ADR-006 server-side capability store | replaced in cluster mode | stateless JWT-claim filter at agw; filesystem keeps server-side |
+| Opaque access tokens | preserved as a deployment choice (default); JWT mode added as opt-in | both modes coexist — mcp-oauth validates either; agw policy is conditional on broker config |
+| `internal/api/` service locator pattern | deleted in Phase 2 | constructor DI in `cmd/muster/` composition roots |
+| `internal/services/` wrapper packages | deleted in Phase 2 | direct adapter wiring |
+
+## Decision gates
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | `mcp-oauth` JWT mode | direct PR — we own the lib |
+| 2 | Webhook validation vs status-driven errors | webhook + status fallback (decide in Phase 5) |
+| 3 | Tool catalog visibility in `MCPServer.status` | yes |
+| 4 | Cross-cluster: keep Teleport, wire `tokenExchange` schema in Phase 7 when triggered | accept |
+| 5 | `localCommand` MCPServer type | filesystem-only post-Phase 8 |
+| 6 | Package rename `internal/aggregator/` → `internal/aggregation/` | defer; separate PR if desired |
+| 7 | Broker pod extraction | trigger-driven; not on critical path |
+| 8 | `MCPServerClass` | trigger-driven; not on critical path |
+| 9 | Drop opaque tokens entirely vs keep as deployment choice | keep both formats in both modes; broker config picks issuance, validators handle either |
+| 10 | Service-locator removal scope | folded into Phase 2 alongside broker refactor |
+| 11 | Per-client / per-resource issuance format selection | YAGNI; server-level toggle for now, additive override later if a consumer needs it |
+
+## Practical first move
+
+Tomorrow on glean:
+
+1. Apply the Phase 1 topology flip (half a day): revert public `/mcp` split, add per-backend `HTTPRoute`s on `muster-agw`, update `MCPServer.spec.url` to point at agw, restart muster.
+2. Verify Tempo shows muster→agw→backend chain for a tool call.
+3. Verify per-backend rows in Loki with `route=muster/mcp-k8s` etc.
+4. In parallel, draft the Phase 2 PR #1 (the `TokenBroker` interface skeleton in `internal/aggregator/token_broker.go`).
+5. In parallel, open the mcp-oauth JWT-mode RFC issue.
+
+Phase 1 completes that day. Phase 2 has its first reviewable PR within a few days. Phases 3–8 follow in sequence over ~10 weeks of focused engineering.

--- a/docs/explanation/architecture-review-plan.md
+++ b/docs/explanation/architecture-review-plan.md
@@ -244,13 +244,61 @@ Claude Code → Envoy → muster → muster-agw → backend MCPs
 
 **Cross-cluster:** Teleport-tunneled MCPs continue exactly as today. agw doesn't see them. They get muster-side audit only. End-to-end cross-cluster identity is Phase 7's problem.
 
-**Effort:** half a day. **Risk:** low.
+**Effort:** half a day. **Risk:** low. **Status: ✅ DONE on glean.**
+
+---
+
+## Current PR status (snapshot — 2026-05-11)
+
+The phases below are not all sequential; many are in flight in parallel. Real-time state of the in-flight work in `giantswarm/muster`:
+
+| Workstream | Open PRs | Status |
+|---|---|---|
+| **Pre-Phase-1 — ServiceClass removal** | #634, #635, #636 (steps 2/4, 3/4, 4/4) | in review; **merge to unblock everything else** |
+| **Phase 2 — Broker series** | #647 (ports), #648 (broker package rename), #649 (broker/http), #651 (adapter), #654 (auth_tools), #656 (connection_helper), #657 (session lifecycle) | 7 of ~8 PRs drafted; needs review throughput. Still to author: EntityProvider migration, internal/api/ delete, import-boundary CI |
+| **Phase 3 — Tracing + logging via mcp-toolkit** | #652 (tracing + metrics), #653 (logging + ctx-aware variants) | draft; review pending |
+| **ADR-012** | #613 | revised 2026-05-11; review pending |
+| **Architecture docs** | #650 | this document |
+| **Approved / mergeable** | #570 (lean list_tools), #629 (architectbot teams alignment) | merge buttons available |
+| **Stalled or needs review** | #496 (teemow — periodic capability polling, since March), #543 (TheoBrigitte — dedup tools, CHANGES_REQUESTED), #623 (workflow executor split), #627 (client dedup) | review or close-as-obsolete decisions needed |
+
+---
+
+## Reordered critical path — Phase 4 deferred to end
+
+After implementation experience and PR-throughput realities, Phase 4 (Edge auth — agw moves in front of muster) is reordered to the **end** of the critical path. Rationale:
+
+- **Lowest marginal observability value.** Phase 1 already delivers per-backend audit/traces/metrics. Phase 4's win is "identity column in agw audit log" — useful but additive; muster's `security_audit` logs already cover the identity story.
+- **Most public-facing churn.** Changing the Envoy → agw → muster routing (vs Envoy → muster directly) is a real customer-visible event; best done as a coordinated milestone, not interleaved with code refactors.
+- **External dependency on mcp-oauth JWT-mode PR.** That work has its own review cycle in `giantswarm/mcp-oauth`. Deferring Phase 4 gives the JWT PR time to land cleanly; otherwise Phase 4 ships in extAuth-only mode and Phase 4-revisit happens when JWT lands.
+- **Phase 5 (translator) doesn't depend on Phase 4.** Translator emits agw routes regardless of agw position; emitted `AgentgatewayPolicy` shape adjusts per the deployment-time auth choice.
+- **Phase 6 (ADR-006 → policy) doesn't strictly depend on Phase 4.** ADR-006 stays in muster's aggregator (works today). Cluster-mode migration to `traffic.authorization` is opt-in, not mandatory, and lands with Phase 4+8.
+- **Phase 4 + Phase 6 + Phase 8 land together.** Bypass aggregator HTTP (Phase 8) needs agw in front; ADR-006 → policy (Phase 6) needs JWT claims at agw; both follow Phase 4. Three phases, one coordinated milestone.
+
+```
+Pre-Phase-1: ServiceClass removal (#634/635/636)
+Phase 1:     agw behind muster (DONE on glean)
+Phase 2:     TokenBroker interface + broker bounded context (~7 of 8 PRs in flight)
+Phase 3:     OTel tracing + logging via mcp-toolkit (2 PRs in review)
+Phase 5:     Translator MVP (next critical-path work)
+             ─── SHIP TO CUSTOMERS HERE ───
+
+Phase 4 + 6 + 8: Final architectural transition (coordinated milestone, when mcp-oauth JWT
+                 lands AND a customer audit/RBAC requirement triggers it)
+
+Phase 7:     Cross-MC broker federation (trigger-driven per customer; opt-in upgrade
+             to per-MC variant)
+```
+
+**The platform is shippable at the end of Phase 5.** Customers can use the per-customer stack, get per-backend audit, MCPServer self-service, workflow CRDs, OTel tracing, OAuth via muster's broker, Teleport-tunneled cross-MC reach. The Phase 4 + 6 + 8 milestone polishes the architecture (identity at agw, RBAC at the edge, aggregator HTTP server bypassed in cluster mode) but is not required to be useful.
 
 ---
 
 ### Phase 2 — `TokenBroker` interface + broker bounded context (in-process), drop service locator
 
 *Critical path. Establishes the architectural seam. Refactor only — no behavior change.*
+
+**Status: 7 of ~8 PRs drafted, in review** — #647, #648, #649, #651, #654, #656, #657. Three remaining to author: EntityProvider migration for `internal/reconciler/{kubernetes,filesystem}_detector.go`, delete of `internal/api/` + `internal/services/{aggregator,mcpserver}/` + constructor DI in `cmd/`, import-boundary CI rule.
 
 ```go
 // internal/aggregator/token_broker.go
@@ -312,9 +360,9 @@ Cluster mode: behavior unchanged. Filesystem mode: behavior unchanged.
 
 ---
 
-### Phase 3 — OTel SDK in muster + backends
+### Phase 3 — OTel SDK in muster + backends via `mcp-toolkit`
 
-*Parallel-safe.*
+*Parallel-safe. **Status: 2 PRs drafted, in review** — #652 (tracing + metrics), #653 (logging + ctx-aware variants for trace correlation).*
 
 - Wire OTel SDK into muster operator + workflow runtime
 - Honor inbound `traceparent`
@@ -331,7 +379,7 @@ Filesystem mode: optional via `--otel-endpoint=`; default no-op exporter.
 
 ### Phase 4 — Edge auth (deployment-time format choice)
 
-*Critical path. The architectural break: agw becomes the user-facing auth boundary regardless of which token format the broker issues.*
+*Final architectural milestone. Lands together with Phase 6 (ADR-006 → policy) and Phase 8 (aggregator bypass) as a coordinated transition. **Not on the early critical path** — the platform is shippable at end of Phase 5; this milestone is the polish that follows when mcp-oauth JWT-mode is ready AND a customer audit/RBAC requirement triggers it.*
 
 mcp-oauth gains an opt-in JWT issuance mode (separate PR in `giantswarm/mcp-oauth`). Validation in mcp-oauth already accepts both opaque (TokenStore lookup) and JWT (JWKS verify) bearers; the new mode adds a third validation branch for self-issued JWTs. Only issuance toggles per server instance.
 
@@ -366,30 +414,62 @@ Filesystem mode: unchanged when `--no-auth`. Full-stack lab broker subprocess ca
 
 **Effort:** 2–2.5 weeks (excluding mcp-oauth PR review cycle). **Risk:** medium. The dual-mode support adds little risk because mcp-oauth's validator already handles both.
 
-**Depends on Phase 2 (broker boundary) for clean split between agw and muster.**
+**Depends on Phase 2 (broker boundary) for clean split between agw and muster. Lands with Phase 6 + Phase 8 as the final milestone.**
 
 ---
 
 ### Phase 5 — Translator MVP (extend `internal/reconciler/`)
 
-*Self-service inflection point. Single user-facing CRD; agw stack emitted underneath.*
+*Self-service inflection point. Single user-facing CRD; agw stack emitted underneath. **This is the last critical-path phase before the platform is shippable to customers.***
 
 - Extend `internal/reconciler/mcpserver_reconciler.go` to emit, for each `MCPServer` in cluster mode:
   - `AgentgatewayBackend` referencing user's Service from `MCPServer.spec.url`
   - `HTTPRoute` matching `/mcp/<name>` on the platform `Gateway`
-  - `AgentgatewayPolicy` carrying audit configuration plus the matching auth mechanism — `traffic.jwtAuthentication` (broker JWKS) when broker issues JWTs, `traffic.extAuth` (broker `/oauth/introspect`) when broker issues opaque tokens. The translator reads broker config to decide.
+  - `AgentgatewayPolicy` carrying audit configuration plus a placeholder auth posture (Phase-1-compatible: no edge JWT validation, no extAuth). When the Phase 4 + 6 + 8 milestone lands later, the translator is extended to emit the matching `traffic.jwtAuthentication` or `traffic.extAuth` block.
   - Owner references for GC
 - Status sync: translate `AgentgatewayBackend` conditions back into `MCPServer.status`
 - For `MCPServer.spec.auth.type=teleport`, translator emits a passthrough — no agw resources, muster handles it directly
 
-Cluster mode: app teams author one `MCPServer` CRD; routing + auth + audit emitted automatically.
+Cluster mode: app teams author one `MCPServer` CRD; routing + audit emitted automatically. Auth still validated by muster (as in Phase 1); identity not yet at agw.
 Filesystem mode: translator is no-op; reads YAML directly into in-process aggregator.
 
 **`MCPServerClass` for platform-team defaults is deferred to trigger-driven** (when there are >5 MCPServers per cluster and copy-pasted policy YAML becomes painful). Phase 5 hardcodes sensible defaults until then.
 
 **Effort:** 2 weeks. **Risk:** medium.
 
-**Depends on Phase 4 for knowing which auth mechanism to emit.**
+**Depends on Phase 2 (broker boundary) for clean DI.** Does NOT depend on Phase 4; Phase 5 ships before Phase 4 in the new order.
+
+---
+
+## Milestone — platform is shippable to customers
+
+At the end of Phase 5, the platform is fully usable:
+
+| Capability | Available end of Phase 5 |
+|---|---|
+| Per-customer stack deployment (Envoy → muster → muster-agw → backends) | ✓ |
+| Per-backend audit, traces, metrics at agw | ✓ |
+| Identity in muster's `security_audit` logs | ✓ |
+| OTel tracing through muster + backends | ✓ |
+| Self-service via `MCPServer` CRDs (translator emits agw resources) | ✓ |
+| Workflow CRD + execution | ✓ |
+| Cross-MC backends via Teleport tunnel (`auth.teleport`) | ✓ |
+| OAuth 2.1 + CIMD via mcp-oauth (opaque tokens, served by muster) | ✓ |
+| Per-MC stack upgrade option (`auth.tokenExchange`, opt-in per customer) | ✓ via Phase 7 when triggered |
+
+Capabilities deferred to the Phase 4 + 6 + 8 milestone (not required for the platform to be useful):
+
+| Capability | Deferred until Phase 4 + 6 + 8 |
+|---|---|
+| Identity column in agw access log rows | — |
+| Per-tool RBAC enforced at agw via CEL on `jwt.groups` | — |
+| Rate limit per identity at agw | — |
+| Cluster-mode aggregator bypass / muster as operator-only | — |
+
+Customers run on the Phase-5 shape indefinitely. The final-milestone work lands when there is a concrete trigger:
+- mcp-oauth JWT-mode PR merged (external dependency)
+- A customer audit/RBAC requirement that hardens the case
+- A planned coordinated release window
 
 ---
 
@@ -503,22 +583,50 @@ Triggers:
 
 Until then, each `MCPServer` carries its own auth/RBAC fields (or the translator applies hard-coded sensible defaults). Effort when triggered: ~1.5–2 weeks.
 
-## Critical path
+## Critical path (revised — Phase 4 deferred to final milestone)
 
 ```
-Phase 1 ─►─► Phase 5 ─►─► Phase 6 ─►─► Phase 8
-               ↑              ↑
-Phase 2 ──────┘              ┘
-Phase 4 ──────┘              ┘   ← Phase 5 emits Phase 4-aware policies; Phase 6 needs JWT claims
-Phase 3       (parallel anywhere from Phase 1 onward)
+Pre-Phase-1 — ServiceClass removal (PRs #634/635/636 in review)
+     │
+     ▼
+Phase 1 — agw behind muster (DONE on glean)
+     │
+     ▼
+Phase 2 — TokenBroker interface + broker bounded context (#647-#657, ~7 PRs in flight)
+     │
+     ▼
+Phase 3 — OTel tracing + logging via mcp-toolkit (#652, #653) ← parallel with Phase 2
+     │
+     ▼
+Phase 5 — Translator MVP
+     │
+     ▼
+─── SHIP TO CUSTOMERS ───
+The platform is fully usable here. Customers deploy per-customer stack;
+self-service via MCPServer CRDs; per-backend audit; OTel tracing;
+OAuth via muster's broker; Teleport for cross-MC.
+     │
+     ▼
+Final architectural milestone (coordinated; lands when mcp-oauth JWT PR ready
+AND a customer audit/RBAC trigger materializes):
+   - Phase 4: agw moves to user-facing edge, JWT-at-edge auth
+   - Phase 6: ADR-006 → traffic.authorization
+   - Phase 8: aggregator HTTP server bypassed in cluster mode
+     │
+     ▼
+Steady state
 
-Trigger-driven (opt-in per customer):
-  Phase 7 — broker federation (only for customers upgrading to per-MC variant)
-  Broker pod extraction (compliance / scale / multi-tenancy)
-  MCPServerClass (when hub catalogs grow large)
+Trigger-driven (opt-in per customer, no fixed schedule):
+   Phase 7 — broker federation (only for customers upgrading to per-MC variant)
+   Broker pod extraction (compliance / scale / multi-tenancy)
+   MCPServerClass (when hub catalogs grow large)
 ```
 
-Critical-path total: ~10 weeks of focused engineering for one engineer. With Phases 2 and 4 running in parallel where dependencies allow, calendar time can compress to ~7–8 weeks. Phase 7 adds ~2 weeks per customer who upgrades.
+**Effort to ship-to-customers (end of Phase 5)**: ~5-6 weeks once ServiceClass removal merges and Phase 2 reviews progress. Phase 2 dominates because of PR throughput; Phases 3 and 5 are smaller.
+
+**Final-milestone (Phase 4 + 6 + 8) effort**: ~3-4 weeks of focused work plus the external mcp-oauth JWT PR cycle (out of our hands; runs in parallel from now). Not blocked on shipping.
+
+**Per-customer Phase 7 upgrade**: ~2 weeks when triggered, per customer who needs it.
 
 ## Multi-cluster model
 

--- a/docs/runbooks/deploy-muster-with-agentgateway.md
+++ b/docs/runbooks/deploy-muster-with-agentgateway.md
@@ -1,0 +1,888 @@
+# Runbook — Deploy muster + agentgateway on a Giant Swarm cluster
+
+End-to-end runbook for the **per-customer bootstrap deployment** of muster + agentgateway. Validated on glean (azuretest installation, May 2026).
+
+This is the **default deployment shape**: one stack per customer, deployed on the customer's central MC. The customer's other MCs (if any) host MCP backend pods only — no local muster, no local agw — and are reached from the central muster via Teleport tunnel (see Phase D').
+
+For customers who need per-MC isolation (regulatory boundaries, hard failure isolation, cross-MC latency, etc.), the upgrade path is to deploy this same runbook on each non-central MC and swap `MCPServer.spec.auth` from `teleport` to `tokenExchange` (Phase 7 of the architecture-review plan, trigger-driven).
+
+Reproduces:
+
+- Bitnami Valkey for OAuth token storage
+- muster (with mcp-oauth, CIMD, Dex federation)
+- agentgateway data plane **behind muster** (Phase 1 topology — every same-cluster MCP call traverses agw for audit/metrics/traces)
+- Public Envoy HTTPRoute pointing all traffic at muster (no `/mcp` split)
+- Per-backend `AgentgatewayBackend` + `HTTPRoute` (`/mcp/k8s`, `/mcp/prom` for local backends; cross-MC backends via Teleport)
+- MCPServer CRDs whose `url` points at agw for local backends or at Teleport tunnel for remote backends
+- PodMonitor scraping `agentgateway_*` metrics
+- AgentgatewayPolicy for tracing (OTLP gRPC → Tempo with multi-tenant `X-Scope-OrgID`)
+
+## Topology
+
+```
+Claude Code / Cursor → Envoy(giantswarm-default) → muster pod (OAuth + aggregator)
+                                                      │
+                                                      ↓ per backend, http://muster-agw.muster.svc/mcp/<name>
+                                                   muster-agw pod (agentgateway)
+                                                      │
+                                                      ├─► mcp-kubernetes.mcp-kubernetes.svc:8080
+                                                      ├─► mcp-prometheus.mcp-prometheus.svc:8080
+                                                      └─► (any future MCPServer pointed at agw)
+
+                                     Backends reached via Teleport tunnel keep their direct path
+                                     and bypass agw — `MCPServer.spec.auth.type=teleport`
+```
+
+Cluster used as reference: `<CLUSTER>` = `glean`, `<INSTALLATION>` = `azuretest`. Substitute for your target cluster.
+
+## Prerequisites
+
+| Component | Why | Verify |
+|---|---|---|
+| `dex` running, reachable at `https://dex.<CLUSTER>.<INSTALLATION>.gigantic.io` | upstream IdP for muster | `curl -s https://dex.<CLUSTER>.<INSTALLATION>.gigantic.io/.well-known/openid-configuration` returns JSON |
+| `dex-k8s-authenticator` static client in dex | downstream audience for SSO to mcp-kubernetes / mcp-prometheus | `kubectl -n giantswarm get secret dex -o jsonpath='{.data.config\.yaml}' \| base64 -d \| grep dex-k8s-authenticator` |
+| `dex-k8s-authenticator` has `muster-token-exchange-<CLUSTER>` as a trusted peer | enables RFC 8693 token exchange | check `trustedPeers` list under `dex-k8s-authenticator` static client |
+| `mcp-kubernetes` deployment in `mcp-kubernetes` namespace, Service on port 8080 | downstream MCP backend | `kubectl -n mcp-kubernetes get svc,deploy` |
+| `mcp-prometheus` deployment in `mcp-prometheus` namespace, Service on port 8080 | downstream MCP backend | same |
+| `giantswarm-default` Gateway (Envoy Gateway) accepting `*.<CLUSTER>.<INSTALLATION>.gigantic.io` | public TLS termination | `kubectl -n envoy-gateway-system get gateway giantswarm-default` |
+| `tempo-distributor` Service in `tempo` namespace, port 4317 | OTLP gRPC endpoint for traces | `kubectl -n tempo get svc tempo-distributor` |
+| Tempo tenant ID for trace ingestion (multi-tenant Tempo on GS) | required `X-Scope-OrgID` header on OTLP writes | usually `giantswarm` — confirm with your platform team |
+| Prometheus operator CRDs (`PodMonitor`, `ServiceMonitor`) | metrics scraping | `kubectl get crd podmonitors.monitoring.coreos.com` |
+| Loki + alloy/promtail scraping pod logs in `muster` namespace | audit log pipeline | `kubectl get app -A \| grep loki` |
+| Kyverno PSS policies (if enforced) | all manifests below are PSS-restricted-compliant | `kubectl get clusterpolicy \| grep pod-security` |
+
+## Phase A — Pre-deployment
+
+### A.1 Register the muster OAuth2 client in dex
+
+Edit dex's static config (typically managed via the GS config-controller or a Flux-managed Secret). Add under `staticClients`:
+
+```yaml
+- id: muster-<CLUSTER>
+  name: muster-<CLUSTER>
+  redirectURIs:
+    - https://muster.<CLUSTER>.<INSTALLATION>.gigantic.io/oauth/callback
+  secret: <GENERATE-RANDOM-32-BYTES-BASE64>
+```
+
+> NOTE: the redirect URI **must** be `/oauth/callback`, not `/oauth/proxy/callback`.
+> `/oauth/proxy/callback` is muster's outbound RP callback (muster → downstream MCPs);
+> the dex-to-muster server callback path is `/oauth/callback`.
+
+Rolling out depends on how dex is managed in the target cluster:
+- If dex config is in a Flux-managed Secret: edit the source repo, push, wait for reconcile.
+- If managed via `dex-operator` `OAuth2Client` CRD: `kubectl apply` the CR.
+- If hand-managed: `kubectl -n giantswarm edit secret dex` and trigger pod restart.
+
+### A.2 Generate the OAuth credentials secret
+
+```bash
+DEX_CLIENT_SECRET=$(openssl rand -base64 32)            # match what you put in dex
+ENCRYPTION_KEY=$(openssl rand -base64 32)               # AES-256-GCM key for token store
+VALKEY_PASSWORD=$(openssl rand -base64 32)              # Valkey AUTH
+
+kubectl --context=teleport.giantswarm.io-<CLUSTER> create namespace muster
+
+kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster create secret generic muster-oauth-credentials \
+  --from-literal=dex-client-secret="${DEX_CLIENT_SECRET}" \
+  --from-literal=encryption-key="${ENCRYPTION_KEY}" \
+  --from-literal=valkey-password="${VALKEY_PASSWORD}"
+```
+
+The secret keys are referenced by both Valkey and muster Helm values below — keep names identical.
+
+## Phase B — Helm installs
+
+### B.1 Bitnami Valkey
+
+`valkey-values.yaml`:
+
+```yaml
+architecture: standalone
+
+auth:
+  existingSecret: muster-oauth-credentials
+  existingSecretPasswordKey: valkey-password
+
+primary:
+  persistence:
+    enabled: false
+  podSecurityContext:
+    enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
+    fsGroup: 1001
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    privileged: false
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+metrics:
+  enabled: false
+
+networkPolicy:
+  enabled: false
+```
+
+Install:
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+
+helm --kube-context=teleport.giantswarm.io-<CLUSTER> -n muster upgrade --install muster-valkey bitnami/valkey \
+  -f valkey-values.yaml \
+  --version 9.0.3
+```
+
+### B.2 agentgateway CRDs + controller
+
+```bash
+helm --kube-context=teleport.giantswarm.io-<CLUSTER> -n agentgateway-system upgrade --install \
+  agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds \
+  --version v1.1.0 --create-namespace
+
+helm --kube-context=teleport.giantswarm.io-<CLUSTER> -n agentgateway-system upgrade --install \
+  agentgateway oci://cr.agentgateway.dev/charts/agentgateway \
+  --version v1.1.0
+```
+
+Verify the GatewayClass:
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> get gatewayclass agentgateway
+# CONTROLLER agentgateway.dev/agentgateway   ACCEPTED True
+```
+
+### B.3 muster
+
+`muster-values.yaml`:
+
+```yaml
+replicaCount: 1
+
+crds:
+  install: false   # CRDs must be applied separately or via a different mechanism
+
+image:
+  pullPolicy: IfNotPresent
+  tag: "0.1.139"   # PIN — chart's appVersion default is 0.1.0 which is way too old
+
+# PSS-compliant pod + container security context (required if Kyverno PSS is enforced)
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# No public exposure from the chart — Envoy fronts muster directly via HTTPRoute below
+ingress:
+  enabled: false
+
+gatewayAPI:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+muster:
+  aggregator:
+    port: 8090
+    transport: streamable-http
+
+  events: false
+  debug: true
+
+  oauth:
+    mcpClient:
+      enabled: true
+      publicUrl: https://muster.<CLUSTER>.<INSTALLATION>.gigantic.io
+      callbackPath: /oauth/proxy/callback     # muster as RP to downstream MCPs
+      cimd:
+        path: /.well-known/oauth-client.json
+
+    server:
+      enabled: true
+      baseUrl: https://muster.<CLUSTER>.<INSTALLATION>.gigantic.io
+      provider: dex
+      dex:
+        issuerUrl: https://dex.<CLUSTER>.<INSTALLATION>.gigantic.io
+        clientId: muster-<CLUSTER>            # matches the dex static client id from Phase A.1
+
+      existingSecret: muster-oauth-credentials
+
+      storage:
+        type: valkey
+        valkey:
+          url: muster-valkey-primary.muster.svc:6379
+          existingSecret: muster-oauth-credentials
+          secretKeyPassword: valkey-password
+
+      encryptionKey: true
+      allowPublicClientRegistration: false
+```
+
+Install (use the in-tree Helm chart from the muster repo):
+
+```bash
+helm --kube-context=teleport.giantswarm.io-<CLUSTER> -n muster upgrade --install muster \
+  /path/to/muster-repo/helm/muster \
+  -f muster-values.yaml
+```
+
+Apply CRDs separately:
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> apply -f /path/to/muster-repo/helm/muster/crds/
+```
+
+## Phase C — agw resources (Phase 1 topology: agw behind muster)
+
+### C.1 AgentgatewayParameters + Gateway
+
+`agentgateway-<CLUSTER>.yaml`:
+
+```yaml
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayParameters
+metadata:
+  name: muster-trial
+  namespace: muster
+spec:
+  logging:
+    format: json
+    level: info
+  env:
+    # Required when Tempo is multi-tenant (GS observability stack default).
+    # The OTel SDK in agw reads this env var and adds the header to OTLP exports.
+    - name: OTEL_EXPORTER_OTLP_TRACES_HEADERS
+      value: X-Scope-OrgID=<TEMPO_TENANT_ID>     # typically "giantswarm"
+  service:
+    spec:
+      type: ClusterIP
+  deployment:
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: agentgateway
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: muster-agw
+  namespace: muster
+spec:
+  gatewayClassName: agentgateway
+  infrastructure:
+    parametersRef:
+      group: agentgateway.dev
+      kind: AgentgatewayParameters
+      name: muster-trial
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+```
+
+### C.2 Per-backend `AgentgatewayBackend` + `HTTPRoute`
+
+> NOTE: `AgentgatewayBackend.spec.mcp.targets[].static.backendRef` does not accept a `namespace` field — cross-namespace references aren't supported via `backendRef`. Use `static.host` with the FQDN of the target service instead.
+
+`agw-per-backend-<CLUSTER>.yaml`:
+
+```yaml
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: muster-mcp-k8s
+  namespace: muster
+spec:
+  mcp:
+    targets:
+      - name: kubernetes
+        static:
+          host: mcp-kubernetes.mcp-kubernetes.svc.cluster.local
+          port: 8080
+          protocol: StreamableHTTP
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: muster-mcp-prom
+  namespace: muster
+spec:
+  mcp:
+    targets:
+      - name: prometheus
+        static:
+          host: mcp-prometheus.mcp-prometheus.svc.cluster.local
+          port: 8080
+          protocol: StreamableHTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: muster-mcp-k8s
+  namespace: muster
+spec:
+  parentRefs:
+    - name: muster-agw
+      namespace: muster
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp/k8s
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: muster-mcp-k8s
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: muster-mcp-prom
+  namespace: muster
+spec:
+  parentRefs:
+    - name: muster-agw
+      namespace: muster
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp/prom
+      backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: muster-mcp-prom
+```
+
+### C.3 Public HTTPRoute on Envoy + BackendTrafficPolicy
+
+In Phase 1 topology, agw is **internal-only**. The public route is a single rule pointing all traffic at muster (which then calls agw outbound for backends).
+
+The `BackendTrafficPolicy` is needed only if your platform `Gateway` has a gateway-level error-pages policy that intercepts upstream errors with a 14k HTML 401 page (default on GS Envoy gateways) — its mere existence per-route overrides that.
+
+`public-route-<CLUSTER>.yaml`:
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: muster-public
+  namespace: muster
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: giantswarm-default
+      namespace: envoy-gateway-system
+  hostnames:
+    - muster.<CLUSTER>.<INSTALLATION>.gigantic.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: muster
+          port: 8090
+          weight: 1
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: muster-public
+  namespace: muster
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: muster-public
+  # Empty otherwise — its existence overrides the gateway-level error-pages policy
+```
+
+Apply all three files:
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> apply \
+  -f agentgateway-<CLUSTER>.yaml \
+  -f agw-per-backend-<CLUSTER>.yaml \
+  -f public-route-<CLUSTER>.yaml
+```
+
+## Phase D — MCPServer CRDs
+
+In Phase 1 topology, `MCPServer.spec.url` points at the **gateway URL for that backend**, not at the backend service directly. Same-cluster backends only.
+
+For backends reached via Teleport (`auth.type: teleport`), leave `spec.url` as the Teleport tunnel address — those bypass agw entirely.
+
+`mcpservers-<CLUSTER>.yaml`:
+
+```yaml
+---
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: mcp-kubernetes
+  namespace: muster
+spec:
+  type: streamable-http
+  url: http://muster-agw.muster.svc/mcp/k8s
+  autoStart: true
+  toolPrefix: k8s
+  description: Kubernetes MCP server (via agw)
+  auth:
+    forwardToken: true
+    requiredAudiences:
+      - dex-k8s-authenticator
+---
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: mcp-prometheus
+  namespace: muster
+spec:
+  type: streamable-http
+  url: http://muster-agw.muster.svc/mcp/prom
+  autoStart: true
+  toolPrefix: prom
+  description: Prometheus/Mimir MCP server (via agw)
+  auth:
+    forwardToken: true
+    requiredAudiences:
+      - dex-k8s-authenticator
+```
+
+Apply:
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> apply -f mcpservers-<CLUSTER>.yaml
+```
+
+> NOTE: muster's orchestrator only registers MCPServer services at startup today. After applying new MCPServer CRs, restart the muster pod so they get registered:
+>
+> ```bash
+> kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster rollout restart deploy/muster
+> ```
+>
+> Expected steady state: `STATUS: Auth Required` for both — they're waiting for a per-session SSO token from a connecting user.
+
+## Phase D' — Cross-MC backends reached via Teleport (when applicable)
+
+If the customer has multiple MCs and the central muster (deployed in Phase B.3 above) needs to reach backends on the customer's other MCs, those remote backends are reached via Teleport tunnel. **The remote MCs themselves do not run muster, agw, or valkey** — only the backend MCP pods plus a Teleport app registration.
+
+### D'.1 Teleport identity on the central muster pod
+
+The central muster pod needs a Teleport machine-ID credential scoped to the customer's MCs. Two common patterns:
+
+| Pattern | When |
+|---|---|
+| **tbot sidecar** | Identity is rotated by tbot inside the muster pod. Same model GS uses for other in-pod Teleport access. |
+| **Mounted identity Secret** | An external operator rotates the identity Secret; muster pod mounts it. Simpler if you already have a rotator. |
+
+Either way, the muster pod is started with `MUSTER_TELEPORT_IDENTITY_PATH` (or equivalent) pointing at the credential. The Helm chart supports both patterns; pick one and configure it in `muster-values.yaml`.
+
+### D'.2 Teleport app registration on the remote MC
+
+On each remote MC hosting backends the central muster needs to reach, register the backend services as Teleport applications. Standard GS pattern via the `teleport-applications` App CR or `Application` resource:
+
+```yaml
+apiVersion: app.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: mcp-k8s-app
+  namespace: teleport
+spec:
+  ...
+  # registers mcp-kubernetes.<remote-MC-namespace>.svc as a Teleport-accessible app
+  # reachable as https://mcp-k8s-<remote-MC>.<TELEPORT_PROXY_DOMAIN>/mcp
+```
+
+(Exact CR shape depends on the customer's existing Teleport setup; see the customer's existing Teleport app definitions for analogous services as reference.)
+
+### D'.3 Teleport role grants on the central muster's identity
+
+Grant the muster pod's Teleport identity access to the Teleport apps registered in D'.2. Role scoped to the customer's MCs:
+
+```yaml
+kind: role
+metadata:
+  name: muster-<CUSTOMER>-mcp-access
+spec:
+  allow:
+    app_labels:
+      customer: <CUSTOMER>
+      service: mcp-*
+```
+
+### D'.4 `MCPServer` CRD for the remote backend
+
+On the central MC (same `muster` namespace as the local MCPServer CRDs from Phase D), add one MCPServer entry per remote backend:
+
+```yaml
+---
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: mcp-k8s-<REMOTE-MC>
+  namespace: muster
+spec:
+  type: streamable-http
+  url: https://mcp-k8s-<REMOTE-MC>.<TELEPORT_PROXY_DOMAIN>/mcp
+  autoStart: true
+  toolPrefix: <REMOTE_MC_SHORTNAME>_k8s     # disambiguates tools in the catalog
+  description: Kubernetes MCP server on <REMOTE-MC> (reached via Teleport)
+  auth:
+    type: teleport
+    teleport:
+      appName: mcp-k8s-<REMOTE-MC>
+      identitySecretName: muster-teleport-identity
+      identitySecretNamespace: muster
+```
+
+After applying, restart the muster pod (same caveat as Phase D — orchestrator registers on startup).
+
+### D'.5 Verify
+
+```bash
+# MCPServer should appear with auth.type=teleport
+kubectl --context=teleport.giantswarm.io-<CENTRAL-CLUSTER> -n muster get mcpserver mcp-k8s-<REMOTE-MC>
+
+# muster pod logs should show Teleport tunnel established (lazy: first tool call triggers it)
+kubectl --context=teleport.giantswarm.io-<CENTRAL-CLUSTER> -n muster logs deploy/muster | grep -i teleport
+
+# From a Claude Code session connected to the customer's central muster, list tools and
+# look for the toolPrefix from D'.4 (e.g., x_<REMOTE_MC_SHORTNAME>_k8s_list_pods).
+# Calling the tool should succeed and the call should appear in the central muster-agw's
+# audit log with route=muster/muster-mcp-<REMOTE-MC>.
+```
+
+### When to upgrade a remote MC to its own full stack (per-MC variant)
+
+If the customer hits any of the following, run this entire runbook on the remote MC as well (treating it as a new central MC for its own users), then swap the central muster's MCPServer entry for that backend from `auth.teleport` to `auth.tokenExchange` (Phase 7 of the architecture-review plan):
+
+- Regulatory requirement for per-MC auth boundary
+- Hard requirement for failure isolation (central muster outage must not affect remote MC's local users or workloads)
+- Cross-MC latency that hurts AI workloads
+- Markedly different RBAC requirements per MC
+
+Phase 7 is trigger-driven; the default `auth.teleport` pattern keeps working for as long as the customer doesn't need the upgrade.
+
+## Phase E — Observability
+
+### E.1 PodMonitor for agentgateway metrics
+
+`agw-podmonitor.yaml`:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: muster-agw
+  namespace: muster
+  labels:
+    application.giantswarm.io/team: bumblebee   # adjust to your team
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: muster-agw
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+```
+
+agentgateway exposes Prometheus metrics on port 15020 named `metrics`, path `/metrics`. Metric names are prefixed `agentgateway_*` (request counters, MCP method counts, latency histograms, byte counts, xDS messages, tokio runtime stats).
+
+### E.2 AgentgatewayPolicy — tracing
+
+agw natively logs MCP-aware fields in its access log when `AgentgatewayParameters.spec.logging.format=json` is set, including `mcp.method.name`, `mcp.target` (backend name from `AgentgatewayBackend.spec.mcp.targets[].name`), `mcp.tool.name` (a structured object with `target`/`name`/`arguments`/`result`), `mcp.session.id`, `trace.id`, and `span.id`. No CEL extension is required for the access log itself — Loki's JSON parser flattens the structured field into queryable labels (`mcp_tool_name_name`, `mcp_tool_name_target`, etc.).
+
+For tracing, the policy points at Tempo and adds a couple of CEL-derived span attributes that make trace search by tool name useful.
+
+`agw-frontend-policy.yaml`:
+
+```yaml
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: muster-agw-frontend
+  namespace: muster
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: muster-agw
+  frontend:
+    accessLog: {}
+    tracing:
+      protocol: GRPC
+      randomSampling: "1.0"        # 100% in trial; drop to 0.1 in prod
+      backendRef:
+        kind: Service
+        name: tempo-distributor
+        namespace: tempo
+        port: 4317
+      resources:
+        - name: service.name
+          expression: '"muster-agw"'
+        - name: deployment.environment
+          expression: '"<CLUSTER>"'
+      attributes:
+        add:
+          - name: mcp.tool
+            expression: 'has(mcp.tool) ? mcp.tool.name : ""'
+          - name: mcp.target
+            expression: 'has(mcp.target) ? mcp.target : ""'
+```
+
+> NOTE: the `tracing` block in the CRD does not expose a way to add request headers to the OTLP export. Multi-tenant Tempo (GS default) requires `X-Scope-OrgID`. We set this via the `OTEL_EXPORTER_OTLP_TRACES_HEADERS` env var in `AgentgatewayParameters.spec.env` (Phase C.1) — the OTel Rust SDK reads this env var and applies the header automatically. Without it, agw spans are silently rejected by Tempo with `BatchSpanProcessor.ExportError "no org id"`.
+
+Apply both:
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> apply -f agw-podmonitor.yaml -f agw-frontend-policy.yaml
+```
+
+After applying, restart agw to pick up params/policy changes:
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster rollout restart deploy/muster-agw
+```
+
+> NOTE: restarting agw invalidates muster's existing MCP sessions to backends. After agw restart, also restart muster:
+>
+> ```bash
+> kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster rollout restart deploy/muster
+> ```
+
+## Verification
+
+### Public OAuth + MCP endpoints
+
+```bash
+# Public PRM endpoint (used by MCP clients during auth bootstrap)
+curl -s https://muster.<CLUSTER>.<INSTALLATION>.gigantic.io/.well-known/oauth-protected-resource | jq
+
+# Discovery
+curl -s https://muster.<CLUSTER>.<INSTALLATION>.gigantic.io/.well-known/oauth-authorization-server | jq
+
+# /mcp returns 401 with WWW-Authenticate (correct — bearer required, browser flow follows)
+curl -s -o /dev/null -w "%{http_code}\n" -X POST https://muster.<CLUSTER>.<INSTALLATION>.gigantic.io/mcp \
+  -H 'Accept: application/json,text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}'
+# expect: 401
+```
+
+### Pod state
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster get pods
+# Expect: muster, muster-agw, muster-valkey-primary all Running 1/1
+
+kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster get mcpservers
+# Expect: STATUS=Auth Required for both, url=http://muster-agw.muster.svc/mcp/...
+
+kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster get agentgatewaybackends
+# Expect: muster-mcp-k8s, muster-mcp-prom both ACCEPTED=True
+
+kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster get agentgatewaypolicy muster-agw-frontend
+# Expect: ACCEPTED=True, ATTACHED=True
+```
+
+### Add to Claude Code and run a tool
+
+```bash
+claude mcp add --transport http muster-<CLUSTER> https://muster.<CLUSTER>.<INSTALLATION>.gigantic.io/mcp
+# OAuth flow runs in browser. After it completes, run any K8s tool, e.g. list pods.
+```
+
+### Audit log (Grafana → Loki)
+
+URL: `https://grafana.<CLUSTER>.<INSTALLATION>.gigantic.io` → Explore → Loki
+
+```logql
+# Per-backend MCP tool calls — the Phase 1 audit story
+{namespace="muster", pod=~"muster-agw-.*"}
+  | json
+  | __error__ = ""
+  | mcp_method_name = "tools/call"
+  | line_format "{{.time}} {{.route}} {{.mcp_target}}/{{.mcp_tool_name_name}} status={{.http_status}} dur={{.duration}} trace={{.trace_id}}"
+
+# muster security audit — token issuance and SSO events with user identity
+{namespace="muster", pod=~"muster-.*", container="muster"}
+  | json
+  | msg = "security_audit"
+  | line_format "{{.time}} event={{.event_type}} user={{.user_id_hash}} client={{.client_id}}"
+```
+
+### Metrics (Grafana → Mimir)
+
+```promql
+# Per-backend request rate
+sum by (route) (rate(agentgateway_requests_total{namespace="muster"}[1m]))
+
+# MCP method breakdown per backend
+sum by (route, method) (agentgateway_mcp_requests_total{namespace="muster"})
+
+# P95 latency per backend
+histogram_quantile(0.95,
+  sum by (le, route) (rate(agentgateway_request_duration_seconds_bucket{namespace="muster", route=~"muster/muster-mcp-.*"}[5m])))
+
+# Bytes returned per backend
+sum by (route) (agentgateway_response_bytes_total{namespace="muster", route=~"muster/muster-mcp-.*"})
+
+# Inventory of agw metrics (18 total)
+{__name__=~"agentgateway_.*"}
+```
+
+### Traces (Grafana → Tempo)
+
+Service Name: `muster-agw`. Filter span attributes by `mcp.tool=<name>` or `mcp.target=kubernetes|prometheus`. Click any `trace.id` from the Loki access-log row to drill in.
+
+If Tempo shows no spans, check agw logs for `BatchSpanProcessor.ExportError`:
+
+```bash
+kubectl --context=teleport.giantswarm.io-<CLUSTER> -n muster logs deploy/muster-agw \
+  | grep -E "ExportError|opentelemetry_sdk"
+```
+
+The most common cause is the missing `X-Scope-OrgID` header — Phase C.1 env var must be set.
+
+## Cleanup
+
+Reverse order of installation. Cluster-only resources first; cross-cluster references (dex client) last.
+
+```bash
+CTX=teleport.giantswarm.io-<CLUSTER>
+
+# E. Observability
+kubectl --context=$CTX -n muster delete agentgatewaypolicy muster-agw-frontend
+kubectl --context=$CTX -n muster delete podmonitor muster-agw
+
+# D. MCPServer CRs
+kubectl --context=$CTX -n muster delete mcpserver mcp-kubernetes mcp-prometheus
+
+# C. Routes / Gateway / Backend / Parameters
+kubectl --context=$CTX -n muster delete backendtrafficpolicy muster-public
+kubectl --context=$CTX -n muster delete httproute muster-public muster-mcp-k8s muster-mcp-prom
+kubectl --context=$CTX -n muster delete agentgatewaybackend muster-mcp-k8s muster-mcp-prom
+kubectl --context=$CTX -n muster delete gateway muster-agw
+kubectl --context=$CTX -n muster delete agentgatewayparameters muster-trial
+
+# B. Helm releases
+helm --kube-context=$CTX -n muster uninstall muster
+helm --kube-context=$CTX -n muster uninstall muster-valkey
+
+# B. agentgateway controller (only if no other workloads in the cluster use it)
+helm --kube-context=$CTX -n agentgateway-system uninstall agentgateway
+helm --kube-context=$CTX -n agentgateway-system uninstall agentgateway-crds
+kubectl --context=$CTX delete namespace agentgateway-system
+
+# muster CRDs (CAUTION — only if no other workloads use these CRDs)
+kubectl --context=$CTX delete crd \
+  mcpservers.muster.giantswarm.io \
+  workflows.muster.giantswarm.io \
+  workflowruns.muster.giantswarm.io 2>/dev/null
+
+# A. Secrets, namespace
+kubectl --context=$CTX -n muster delete secret muster-oauth-credentials
+kubectl --context=$CTX delete namespace muster
+
+# A. Dex static client (manual revert in dex source-of-truth)
+# - Remove the muster-<CLUSTER> entry from dex's staticClients config
+# - Push to gitops repo / re-apply the OAuth2Client CRD / re-edit the source secret
+# - Restart dex pods to pick up the change
+```
+
+## Known issues / caveats
+
+| Issue | Workaround |
+|---|---|
+| Chart `appVersion: "0.1.0"` in `helm/muster/Chart.yaml` is stale; default image tag would be `0.1.0` (much older than current binary) | always set `image.tag` explicitly in values |
+| Old muster image (≤ 0.1.0) lacks `mcp-oauth` v0.2.117's RFC 8252 port-agnostic loopback redirect URI matching → Claude Code OAuth fails with `redirect URI not registered for client` | use `image.tag: 0.1.139` or later |
+| New `MCPServer` CRs created post-startup show `Disconnected` because muster's orchestrator only registers at boot | restart the muster pod after `kubectl apply` |
+| Restarting `muster-agw` invalidates muster's MCP sessions to backends; tools/call returns 422 "session header is required" until muster reconnects | restart muster after every agw restart |
+| `Auth Required` is the steady state for `forwardToken: true` MCPServers, not an error | a per-session SSO flow activates them when a user connects |
+| `AgentgatewayBackend.spec.mcp.targets[].static.backendRef` rejects a `namespace` field (cross-namespace not supported via `backendRef`) | use `static.host` with the full DNS name of the target Service |
+| Multi-tenant Tempo silently rejects spans with `BatchSpanProcessor.ExportError "no org id"` if `X-Scope-OrgID` header is absent | set `OTEL_EXPORTER_OTLP_TRACES_HEADERS` env var on agw via `AgentgatewayParameters.spec.env` |
+| `MCPServer.spec.url` for backends in *other clusters* must use Teleport (`auth.teleport`); cluster-local agw routing only works for same-cluster backends | cross-cluster broker federation is a later phase of the architecture-review plan |
+| agw audit log shows the **post-prefix-strip** tool name (e.g. `capi_list_clusters`, not `x_k8s_capi_list_clusters`) — toolPrefix is added by muster's aggregator and stripped before forwarding | combine `mcp_target` + `mcp_tool_name_name` for unambiguous identification; the user-visible (prefixed) name lives in muster's logs |
+| Gateway-level `BackendTrafficPolicy` on `giantswarm-default` injects a 14k HTML 401 error page that masks muster's JSON OAuth errors | per-route `BackendTrafficPolicy` (even empty) overrides — see C.3 |
+
+## File inventory (apply order)
+
+```
+muster-oauth-credentials secret  (kubectl create secret, Phase A.2)
+valkey-values.yaml               (helm install, Phase B.1)
+agentgateway-crds chart          (helm install, Phase B.2)
+agentgateway chart               (helm install, Phase B.2)
+muster-values.yaml               (helm install, Phase B.3)
+muster CRDs                      (kubectl apply, Phase B.3)
+agentgateway-<CLUSTER>.yaml      (kubectl apply, Phase C.1)
+agw-per-backend-<CLUSTER>.yaml   (kubectl apply, Phase C.2)
+public-route-<CLUSTER>.yaml      (kubectl apply, Phase C.3)
+mcpservers-<CLUSTER>.yaml        (kubectl apply, Phase D)
+agw-podmonitor.yaml              (kubectl apply, Phase E.1)
+agw-frontend-policy.yaml         (kubectl apply, Phase E.2)
+```
+
+Restart points (after which a pod must roll):
+- `muster` after applying new MCPServer CRs
+- `muster-agw` after changing AgentgatewayParameters or AgentgatewayPolicy
+- `muster` after `muster-agw` restart (to re-establish backend MCP sessions)
+
+Approximate end-to-end deploy time: 30–45 minutes including verification (excluding waiting for dex config rollout, which depends on the GS gitops loop).


### PR DESCRIPTION
## Summary

Adds two documentation files that pair with [ADR-012](https://github.com/giantswarm/muster/pull/613):

1. **`docs/explanation/architecture-review-plan.md`** — detailed phase plan from today's glean deployment to the end state. Eight phases plus trigger-driven items. Covers the per-customer default deployment shape and the opt-in per-MC variant. References `mcp-toolkit/tracing` extraction and the `mcp-oauth` JWT-mode PR as parallel tracks.

2. **`docs/runbooks/deploy-muster-with-agentgateway.md`** — concrete per-customer deployment runbook, validated end-to-end on glean (Phase 1 topology: agentgateway behind muster). Covers prerequisites, Helm installs, MCPServer CRDs, observability wiring (PodMonitor, AgentgatewayPolicy with Tempo OTLP), Teleport-tunneled remote backends, verification, cleanup, and the agentgateway v1.1.0 CRD limitations encountered during implementation.

Both documents reflect findings from the Phase 1 trial on glean and from ADR-012 review discussions. They are the implementation companions to ADR-012 (which captures the architectural decision); this PR adds the implementation guidance and step-by-step deployment process.