### PR TITLE
refactor(aggregator): port connection_helper.go token-exchange off api.GetOAuthHandler [5b/8]

### DIFF
--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -86,12 +86,12 @@ func (m *issuerMockOAuthHandler) SetAuthCompletionCallback(callback api.AuthComp
 func (m *issuerMockOAuthHandler) Stop() {
 }
 
-func (m *issuerMockOAuthHandler) ExchangeTokenForRemoteCluster(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig) (string, error) {
-	return "", nil
+func (m *issuerMockOAuthHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, string, error) {
+	return "", "", nil
 }
 
-func (m *issuerMockOAuthHandler) ExchangeTokenForRemoteClusterWithClient(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig, httpClient *http.Client) (string, error) {
-	return "", nil
+func (m *issuerMockOAuthHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, string, error) {
+	return "", "", nil
 }
 
 func TestGetMusterIssuer_WithOAuthServerConfig(t *testing.T) {

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -225,11 +225,11 @@ func (r *ConnectionResult) FormatAsMCPResult() *mcp.CallToolResult {
 
 // lookupIDTokenForSession returns the ID token for (sessionID, musterIssuer)
 // from the broker, or "" when no entry is available.
-func lookupIDTokenForSession(ctx context.Context, tb TokenBroker, sessionID, musterIssuer string) string {
-	if tb == nil || !tb.Enabled() || musterIssuer == "" {
+func lookupIDTokenForSession(ctx context.Context, broker TokenBroker, sessionID, musterIssuer string) string {
+	if broker == nil || !broker.Enabled() || musterIssuer == "" {
 		return ""
 	}
-	token, err := tb.GetToken(ctx, sessionID, musterIssuer)
+	token, err := broker.GetToken(ctx, sessionID, musterIssuer)
 	if err != nil || token.IDToken == "" {
 		return ""
 	}
@@ -262,9 +262,7 @@ func EstablishConnectionWithTokenForwarding(
 		}
 	}
 
-	a.mu.RLock()
-	tb := a.tokenBroker
-	a.mu.RUnlock()
+	tokenBroker := a.tokenBrokerSnapshot()
 
 	if idToken == "" {
 		logging.Debug("Connection", "No ID token available for user %s",
@@ -308,7 +306,7 @@ func EstablishConnectionWithTokenForwarding(
 			}
 		}
 	}
-	headerFunc := makeTokenForwardingHeaderFunc(tb, sessionID, sub, musterIssuer, serverInfo.Name, idToken, onStaleToken)
+	headerFunc := makeTokenForwardingHeaderFunc(tokenBroker, sessionID, sub, musterIssuer, serverInfo.Name, idToken, onStaleToken)
 	client := internalmcp.NewStreamableHTTPClientWithHeaderFunc(serverInfo.URL, headerFunc)
 
 	// Try to initialize the client with the forwarded token
@@ -475,10 +473,8 @@ func EstablishConnectionWithTokenExchange(
 		}
 	}
 
-	a.mu.RLock()
-	tb := a.tokenBroker
-	a.mu.RUnlock()
-	if tb == nil || !tb.Enabled() {
+	tokenBroker := a.tokenBrokerSnapshot()
+	if tokenBroker == nil || !tokenBroker.Enabled() {
 		return nil, fmt.Errorf("broker not available for token exchange")
 	}
 
@@ -558,7 +554,7 @@ func EstablishConnectionWithTokenExchange(
 		return nil, fmt.Errorf("teleport configuration failed: %w", teleportResult.Error)
 	}
 
-	exchanged, err := tb.ExchangeToken(ctx, ExchangeRequest{
+	exchanged, err := tokenBroker.ExchangeToken(ctx, ExchangeRequest{
 		SessionID:    sessionID,
 		Subject:      userID,
 		SubjectToken: idToken,
@@ -774,7 +770,7 @@ const maxConsecutiveTokenFailures = 3
 // The closure is safe to call without a mutex because headerFunc is called
 // sequentially per connection by the MCP client.
 func makeTokenForwardingHeaderFunc(
-	tb TokenBroker,
+	broker TokenBroker,
 	sessionID, sub, musterIssuer, serverName, fallbackToken string,
 	onStaleToken func(),
 ) func(context.Context) map[string]string {
@@ -783,7 +779,7 @@ func makeTokenForwardingHeaderFunc(
 	var staleEvicted bool
 	hadToken := true
 	return func(_ context.Context) map[string]string {
-		latestToken := lookupIDTokenForSession(context.Background(), tb, sessionID, musterIssuer)
+		latestToken := lookupIDTokenForSession(context.Background(), broker, sessionID, musterIssuer)
 		if latestToken == "" {
 			consecutiveFailures++
 

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -224,23 +224,16 @@ func (r *ConnectionResult) FormatAsMCPResult() *mcp.CallToolResult {
 }
 
 // lookupIDTokenForSession returns the ID token for (sessionID, musterIssuer)
-// from the OAuth proxy store, or "" when no entry is available.
-func lookupIDTokenForSession(sessionID, musterIssuer string) string {
-	oauthHandler := api.GetOAuthHandler()
-	if oauthHandler == nil || !oauthHandler.IsEnabled() || musterIssuer == "" {
-		logging.Debug("Connection", "No ID token lookup possible for session %s (handler unavailable or issuer empty)",
-			logging.TruncateIdentifier(sessionID))
+// from the broker, or "" when no entry is available.
+func lookupIDTokenForSession(ctx context.Context, tb TokenBroker, sessionID, musterIssuer string) string {
+	if tb == nil || !tb.Enabled() || musterIssuer == "" {
 		return ""
 	}
-	fullToken := oauthHandler.GetFullTokenByIssuer(sessionID, musterIssuer)
-	if fullToken == nil || fullToken.IDToken == "" {
-		logging.Debug("Connection", "No ID token in OAuth proxy store for session %s, issuer %s",
-			logging.TruncateIdentifier(sessionID), musterIssuer)
+	token, err := tb.GetToken(ctx, sessionID, musterIssuer)
+	if err != nil || token.IDToken == "" {
 		return ""
 	}
-	logging.Debug("Connection", "Found ID token in OAuth proxy store for session %s, issuer %s",
-		logging.TruncateIdentifier(sessionID), musterIssuer)
-	return fullToken.IDToken
+	return token.IDToken
 }
 
 // EstablishConnectionWithTokenForwarding establishes a connection using ID
@@ -268,6 +261,10 @@ func EstablishConnectionWithTokenForwarding(
 			return &ConnectionResult{ServerName: serverInfo.Name}, nil
 		}
 	}
+
+	a.mu.RLock()
+	tb := a.tokenBroker
+	a.mu.RUnlock()
 
 	if idToken == "" {
 		logging.Debug("Connection", "No ID token available for user %s",
@@ -311,7 +308,7 @@ func EstablishConnectionWithTokenForwarding(
 			}
 		}
 	}
-	headerFunc := makeTokenForwardingHeaderFunc(sessionID, sub, musterIssuer, serverInfo.Name, idToken, onStaleToken)
+	headerFunc := makeTokenForwardingHeaderFunc(tb, sessionID, sub, musterIssuer, serverInfo.Name, idToken, onStaleToken)
 	client := internalmcp.NewStreamableHTTPClientWithHeaderFunc(serverInfo.URL, headerFunc)
 
 	// Try to initialize the client with the forwarded token
@@ -478,9 +475,11 @@ func EstablishConnectionWithTokenExchange(
 		}
 	}
 
-	oauthHandler := api.GetOAuthHandler()
-	if oauthHandler == nil || !oauthHandler.IsEnabled() {
-		return nil, fmt.Errorf("OAuth handler not available for token exchange")
+	a.mu.RLock()
+	tb := a.tokenBroker
+	a.mu.RUnlock()
+	if tb == nil || !tb.Enabled() {
+		return nil, fmt.Errorf("broker not available for token exchange")
 	}
 
 	if idToken == "" {
@@ -548,37 +547,31 @@ func EstablishConnectionWithTokenExchange(
 		}
 	}
 
-	// Check if Teleport auth is configured - if so, we need to use Teleport HTTP client
-	// for both the token exchange request and the MCP server connection.
+	// Resolve Teleport HTTP client for the MCP server connection below.
+	// The broker handles transport selection for the exchange call itself
+	// via its TransportResolver; this lookup is only for the downstream MCP
+	// transport, a separate concern.
 	teleportResult := getTeleportHTTPClientIfConfigured(ctx, serverInfo)
-
-	// If Teleport is configured but failed, return an explicit error rather than
-	// falling back silently (which would cause confusing connection failures to private endpoints)
 	if teleportResult.Configured && teleportResult.Error != nil {
 		logging.Error("Connection", teleportResult.Error, "Teleport required for %s but failed",
 			serverInfo.Name)
 		return nil, fmt.Errorf("teleport configuration failed: %w", teleportResult.Error)
 	}
 
-	// Perform the token exchange (using Teleport client if configured)
-	var exchangedToken string
-	if teleportResult.Client != nil {
-		logging.Debug("Connection", "Using Teleport HTTP client for token exchange to %s", serverInfo.Name)
-		exchangedToken, err = oauthHandler.ExchangeTokenForRemoteClusterWithClient(
-			ctx,
-			idToken,
-			userID,
-			serverInfo.AuthConfig.TokenExchange,
-			teleportResult.Client,
-		)
-	} else {
-		exchangedToken, err = oauthHandler.ExchangeTokenForRemoteCluster(
-			ctx,
-			idToken,
-			userID,
-			serverInfo.AuthConfig.TokenExchange,
-		)
-	}
+	exchanged, err := tb.ExchangeToken(ctx, ExchangeRequest{
+		SessionID:    sessionID,
+		Subject:      userID,
+		SubjectToken: idToken,
+		Audience:     serverInfo.Name,
+		Config: ExchangeConfig{
+			TokenEndpoint:  serverInfo.AuthConfig.TokenExchange.DexTokenEndpoint,
+			ExpectedIssuer: serverInfo.AuthConfig.TokenExchange.ExpectedIssuer,
+			ConnectorID:    serverInfo.AuthConfig.TokenExchange.ConnectorID,
+			ClientID:       serverInfo.AuthConfig.TokenExchange.ClientID,
+			ClientSecret:   serverInfo.AuthConfig.TokenExchange.ClientSecret,
+			Scopes:         serverInfo.AuthConfig.TokenExchange.Scopes,
+		},
+	})
 	if err != nil {
 		logging.Warn("Connection", "Token exchange failed for user %s to server %s: %v",
 			logging.TruncateIdentifier(sub), serverInfo.Name, err)
@@ -599,6 +592,7 @@ func EstablishConnectionWithTokenExchange(
 
 		return nil, fmt.Errorf("token exchange failed: %w", err)
 	}
+	exchangedToken := exchanged.AccessToken
 
 	// Token exchange succeeded - emit success event and audit log
 	logging.Info("Connection", "Token exchange succeeded for user %s to server %s",
@@ -780,6 +774,7 @@ const maxConsecutiveTokenFailures = 3
 // The closure is safe to call without a mutex because headerFunc is called
 // sequentially per connection by the MCP client.
 func makeTokenForwardingHeaderFunc(
+	tb TokenBroker,
 	sessionID, sub, musterIssuer, serverName, fallbackToken string,
 	onStaleToken func(),
 ) func(context.Context) map[string]string {
@@ -788,7 +783,7 @@ func makeTokenForwardingHeaderFunc(
 	var staleEvicted bool
 	hadToken := true
 	return func(_ context.Context) map[string]string {
-		latestToken := lookupIDTokenForSession(sessionID, musterIssuer)
+		latestToken := lookupIDTokenForSession(context.Background(), tb, sessionID, musterIssuer)
 		if latestToken == "" {
 			consecutiveFailures++
 
@@ -877,71 +872,24 @@ type TeleportClientResult struct {
 // getTeleportHTTPClientIfConfigured returns a Teleport HTTP client if the server
 // is configured to use Teleport authentication.
 //
-// This is used for both token exchange and MCP server connections when accessing
-// private installations via Teleport Application Access.
-//
-// The function returns a TeleportClientResult that distinguishes between:
+// The TeleportClientResult distinguishes between:
 //   - Not configured: Configured=false, Client=nil, Error=nil (use default HTTP client)
 //   - Configured and successful: Configured=true, Client!=nil, Error=nil
 //   - Configured but failed: Configured=true, Client=nil, Error!=nil (caller should fail, not fallback)
 //
-// This explicit error handling prevents silent fallback when Teleport is required
-// but misconfigured, which would lead to confusing connection errors.
+// Explicit error handling prevents silent fallback when Teleport is
+// required but misconfigured.
 func getTeleportHTTPClientIfConfigured(ctx context.Context, serverInfo *ServerInfo) TeleportClientResult {
-	// Check if server has Teleport auth configured
-	if serverInfo == nil || serverInfo.AuthConfig == nil {
+	client, configured, err := teleportHTTPClient(ctx, serverInfo)
+	if !configured {
 		return TeleportClientResult{Configured: false}
 	}
-	if serverInfo.AuthConfig.Type != api.AuthTypeTeleport {
-		return TeleportClientResult{Configured: false}
-	}
-
-	// From this point on, Teleport IS configured - errors should be explicit
-	if serverInfo.AuthConfig.Teleport == nil {
-		err := fmt.Errorf("teleport auth type configured but teleport settings missing")
-		logging.Error("Connection", err, "Teleport configuration error for %s", serverInfo.Name)
-		return TeleportClientResult{Configured: true, Error: err}
-	}
-
-	// Get the Teleport handler from the API service locator
-	teleportHandler := api.GetTeleportClient()
-	if teleportHandler == nil {
-		err := fmt.Errorf("teleport client handler not registered - ensure teleport package is initialized")
-		logging.Error("Connection", err, "Teleport initialization error for %s", serverInfo.Name)
-		return TeleportClientResult{Configured: true, Error: err}
-	}
-
-	// Build the client configuration from the server auth settings
-	teleportAuth := serverInfo.AuthConfig.Teleport
-	clientConfig := api.TeleportClientConfig{
-		IdentityDir:             teleportAuth.IdentityDir,
-		IdentitySecretName:      teleportAuth.IdentitySecretName,
-		IdentitySecretNamespace: teleportAuth.IdentitySecretNamespace,
-		AppName:                 teleportAuth.AppName,
-	}
-
-	// Validate that exactly one identity source is specified
-	if clientConfig.IdentityDir == "" && clientConfig.IdentitySecretName == "" {
-		err := fmt.Errorf("teleport auth requires either identityDir or identitySecretName")
-		logging.Error("Connection", err, "Teleport configuration error for %s", serverInfo.Name)
-		return TeleportClientResult{Configured: true, Error: err}
-	}
-	if clientConfig.IdentityDir != "" && clientConfig.IdentitySecretName != "" {
-		err := fmt.Errorf("teleport auth: identityDir and identitySecretName are mutually exclusive")
-		logging.Error("Connection", err, "Teleport configuration error for %s", serverInfo.Name)
-		return TeleportClientResult{Configured: true, Error: err}
-	}
-
-	// Get the HTTP client from the Teleport handler
-	httpClient, err := teleportHandler.GetHTTPClientForConfig(ctx, clientConfig)
 	if err != nil {
-		wrappedErr := fmt.Errorf("failed to get Teleport HTTP client: %w", err)
-		logging.Error("Connection", wrappedErr, "Teleport client error for %s", serverInfo.Name)
-		return TeleportClientResult{Configured: true, Error: wrappedErr}
+		logging.Error("Connection", err, "Teleport error for %s", serverInfo.Name)
+		return TeleportClientResult{Configured: true, Error: err}
 	}
-
 	logging.Debug("Connection", "Got Teleport HTTP client for %s", serverInfo.Name)
-	return TeleportClientResult{Configured: true, Client: httpClient}
+	return TeleportClientResult{Configured: true, Client: client}
 }
 
 // loadTokenExchangeCredentials loads OAuth client credentials from a Kubernetes secret

--- a/internal/aggregator/connection_helper_test.go
+++ b/internal/aggregator/connection_helper_test.go
@@ -90,12 +90,12 @@ func (m *mockOAuthHandler) CreateAuthChallenge(_ context.Context, _, _, _, _, _ 
 	return nil, nil
 }
 
-func (m *mockOAuthHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, error) {
-	return "", nil
+func (m *mockOAuthHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, string, error) {
+	return "", "", nil
 }
 
-func (m *mockOAuthHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, error) {
-	return "", nil
+func (m *mockOAuthHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, string, error) {
+	return "", "", nil
 }
 
 func (m *mockOAuthHandler) StoreToken(sessionID, _, issuer string, token *api.OAuthToken) {
@@ -109,65 +109,61 @@ func (m *mockOAuthHandler) GetFullTokenByIssuer(sessionID, issuer string) *api.O
 func TestLookupIDTokenForSession(t *testing.T) {
 	validToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo5OTk5OTk5OTk5fQ.signature" //nolint:goconst,gosec
 
-	t.Run("returns empty when no OAuth handler is registered", func(t *testing.T) {
-		api.RegisterOAuthHandler(nil)
-
-		token := lookupIDTokenForSession("test-user", "https://accounts.google.com")
-
+	t.Run("returns empty when broker is nil", func(t *testing.T) {
+		token := lookupIDTokenForSession(context.Background(), nil, "session-abc", "https://accounts.google.com")
 		assert.Empty(t, token)
 	})
 
-	t.Run("returns empty when OAuth handler is disabled", func(t *testing.T) {
-		mock := newMockOAuthHandler(false)
-		mock.StoreToken("session-abc", "user1", "https://accounts.google.com", &api.OAuthToken{IDToken: validToken})
-		api.RegisterOAuthHandler(mock)
-		defer api.RegisterOAuthHandler(nil)
-
-		token := lookupIDTokenForSession("session-abc", "https://accounts.google.com")
-
+	t.Run("returns empty when broker is disabled", func(t *testing.T) {
+		tb := &mockTokenBroker{enabled: false}
+		token := lookupIDTokenForSession(context.Background(), tb, "session-abc", "https://accounts.google.com")
 		assert.Empty(t, token)
 	})
 
 	t.Run("returns empty when issuer is empty", func(t *testing.T) {
-		mock := newMockOAuthHandler(true)
-		mock.StoreToken("session-abc", "user1", "https://accounts.google.com", &api.OAuthToken{IDToken: validToken})
-		api.RegisterOAuthHandler(mock)
-		defer api.RegisterOAuthHandler(nil)
-
-		token := lookupIDTokenForSession("session-abc", "")
-
+		tb := &mockTokenBroker{
+			enabled: true,
+			getTokenFn: func(_ context.Context, _, _ string) (Token, error) {
+				return Token{IDToken: validToken}, nil
+			},
+		}
+		token := lookupIDTokenForSession(context.Background(), tb, "session-abc", "")
 		assert.Empty(t, token)
 	})
 
-	t.Run("returns token from OAuth handler when present", func(t *testing.T) {
-		mock := newMockOAuthHandler(true)
-		mock.StoreToken("session-abc", "user1", "https://accounts.google.com", &api.OAuthToken{IDToken: validToken})
-		api.RegisterOAuthHandler(mock)
-		defer api.RegisterOAuthHandler(nil)
-
-		token := lookupIDTokenForSession("session-abc", "https://accounts.google.com")
-
+	t.Run("returns token from broker when present", func(t *testing.T) {
+		tb := &mockTokenBroker{
+			enabled: true,
+			getTokenFn: func(_ context.Context, sessionID, issuer string) (Token, error) {
+				if sessionID == "session-abc" && issuer == "https://accounts.google.com" {
+					return Token{IDToken: validToken}, nil
+				}
+				return Token{}, nil
+			},
+		}
+		token := lookupIDTokenForSession(context.Background(), tb, "session-abc", "https://accounts.google.com")
 		assert.Equal(t, validToken, token)
 	})
 
-	t.Run("returns empty when OAuth handler has no entry for session", func(t *testing.T) {
-		mock := newMockOAuthHandler(true)
-		api.RegisterOAuthHandler(mock)
-		defer api.RegisterOAuthHandler(nil)
-
-		token := lookupIDTokenForSession("unknown-session", "https://accounts.google.com")
-
+	t.Run("returns empty when broker returns error", func(t *testing.T) {
+		tb := &mockTokenBroker{
+			enabled: true,
+			getTokenFn: func(_ context.Context, _, _ string) (Token, error) {
+				return Token{}, errors.New("not found")
+			},
+		}
+		token := lookupIDTokenForSession(context.Background(), tb, "session-abc", "https://accounts.google.com")
 		assert.Empty(t, token)
 	})
 
-	t.Run("returns empty when store entry has empty IDToken", func(t *testing.T) {
-		mock := newMockOAuthHandler(true)
-		mock.StoreToken("session-abc", "user1", "https://accounts.google.com", &api.OAuthToken{IDToken: ""})
-		api.RegisterOAuthHandler(mock)
-		defer api.RegisterOAuthHandler(nil)
-
-		token := lookupIDTokenForSession("session-abc", "https://accounts.google.com")
-
+	t.Run("returns empty when broker returns empty IDToken", func(t *testing.T) {
+		tb := &mockTokenBroker{
+			enabled: true,
+			getTokenFn: func(_ context.Context, _, _ string) (Token, error) {
+				return Token{IDToken: ""}, nil
+			},
+		}
+		token := lookupIDTokenForSession(context.Background(), tb, "session-abc", "https://accounts.google.com")
 		assert.Empty(t, token)
 	})
 }
@@ -826,10 +822,9 @@ func TestHeaderFunc_RateLimitsWarning(t *testing.T) {
 	serverName := "test-server"               //nolint:goconst
 	fallbackToken := "original-token"         //nolint:goconst
 
-	// No OAuth handler registered means lookupIDTokenForSession always returns "".
-	api.RegisterOAuthHandler(nil)
+	tb := &mockTokenBroker{enabled: true}
 
-	headerFunc := makeTokenForwardingHeaderFunc(sessionID, sub, musterIssuer, serverName, fallbackToken, nil)
+	headerFunc := makeTokenForwardingHeaderFunc(tb, sessionID, sub, musterIssuer, serverName, fallbackToken, nil)
 
 	// First call: should produce a WARN (interval has not been hit yet).
 	logBuf.Reset()
@@ -855,12 +850,14 @@ func TestHeaderFunc_RateLimitsWarning(t *testing.T) {
 	thirdCallLogs := logBuf.String()
 	assert.NotContains(t, thirdCallLogs, "WARN", "third call should NOT emit a WARN")
 
-	// Now simulate token recovery by registering an OAuth handler with a token.
+	// Now simulate token recovery by swapping in a GetToken impl.
 	validToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo5OTk5OTk5OTk5fQ.signature" //nolint:gosec
-	mock := newMockOAuthHandler(true)
-	mock.StoreToken(sessionID, "", musterIssuer, &api.OAuthToken{IDToken: validToken})
-	api.RegisterOAuthHandler(mock)
-	defer api.RegisterOAuthHandler(nil)
+	tb.getTokenFn = func(_ context.Context, sid, audience string) (Token, error) {
+		if sid == sessionID && audience == musterIssuer {
+			return Token{IDToken: validToken}, nil
+		}
+		return Token{}, nil
+	}
 
 	logBuf.Reset()
 	headers = headerFunc(context.Background())
@@ -880,8 +877,7 @@ func TestHeaderFunc_EvictsAfterConsecutiveFailures(t *testing.T) {
 	serverName := "test-server"
 	fallbackToken := "original-token"
 
-	api.RegisterOAuthHandler(nil)
-	defer api.RegisterOAuthHandler(nil)
+	tb := &mockTokenBroker{enabled: true}
 
 	var evictCount atomic.Int32
 	var firstEvict sync.WaitGroup
@@ -892,7 +888,7 @@ func TestHeaderFunc_EvictsAfterConsecutiveFailures(t *testing.T) {
 		}
 	}
 
-	headerFunc := makeTokenForwardingHeaderFunc(sessionID, sub, musterIssuer, serverName, fallbackToken, onStaleToken)
+	headerFunc := makeTokenForwardingHeaderFunc(tb, sessionID, sub, musterIssuer, serverName, fallbackToken, onStaleToken)
 
 	// Call fewer than maxConsecutiveTokenFailures times — callback should NOT fire.
 	for i := 0; i < maxConsecutiveTokenFailures-1; i++ {
@@ -933,14 +929,14 @@ func TestHeaderFunc_ResetsFailureCountOnRecovery(t *testing.T) {
 	serverName := "test-server"
 	fallbackToken := "original-token"
 
-	api.RegisterOAuthHandler(nil)
+	tb := &mockTokenBroker{enabled: true}
 
 	var evictCount atomic.Int32
 	onStaleToken := func() {
 		evictCount.Add(1)
 	}
 
-	headerFunc := makeTokenForwardingHeaderFunc(sessionID, sub, musterIssuer, serverName, fallbackToken, onStaleToken)
+	headerFunc := makeTokenForwardingHeaderFunc(tb, sessionID, sub, musterIssuer, serverName, fallbackToken, onStaleToken)
 
 	// Accumulate failures just below the threshold.
 	for i := 0; i < maxConsecutiveTokenFailures-1; i++ {
@@ -950,17 +946,19 @@ func TestHeaderFunc_ResetsFailureCountOnRecovery(t *testing.T) {
 
 	// Recover by providing a valid token.
 	validToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo5OTk5OTk5OTk5fQ.signature" //nolint:gosec
-	mock := newMockOAuthHandler(true)
-	mock.StoreToken(sessionID, "", musterIssuer, &api.OAuthToken{IDToken: validToken})
-	api.RegisterOAuthHandler(mock)
-	defer api.RegisterOAuthHandler(nil)
+	tb.getTokenFn = func(_ context.Context, sid, audience string) (Token, error) {
+		if sid == sessionID && audience == musterIssuer {
+			return Token{IDToken: validToken}, nil
+		}
+		return Token{}, nil
+	}
 
 	headers := headerFunc(context.Background())
 	assert.Equal(t, "Bearer "+validToken, headers["Authorization"],
 		"should use recovered token")
 
 	// Now remove the token again and accumulate failures.
-	api.RegisterOAuthHandler(nil)
+	tb.getTokenFn = nil
 	for i := 0; i < maxConsecutiveTokenFailures-1; i++ {
 		headerFunc(context.Background())
 	}
@@ -972,10 +970,7 @@ func TestHeaderFunc_NilCallback(t *testing.T) {
 	var logBuf bytes.Buffer
 	logging.InitForCLI(logging.LevelDebug, &logBuf)
 
-	api.RegisterOAuthHandler(nil)
-	defer api.RegisterOAuthHandler(nil)
-
-	headerFunc := makeTokenForwardingHeaderFunc("s", "u", "iss", "srv", "tok", nil)
+	headerFunc := makeTokenForwardingHeaderFunc(nil, "s", "u", "iss", "srv", "tok", nil)
 
 	// Should not panic even after many failures with nil callback.
 	for i := 0; i < maxConsecutiveTokenFailures+5; i++ {

--- a/internal/aggregator/mock_token_broker_test.go
+++ b/internal/aggregator/mock_token_broker_test.go
@@ -11,6 +11,7 @@ type mockTokenBroker struct {
 	enabled           bool
 	beginOAuthFlowFn  func(ctx context.Context, req BeginRequest) (FlowURL, error)
 	getTokenFn        func(ctx context.Context, sessionID, audience string) (Token, error)
+	exchangeTokenFn   func(ctx context.Context, req ExchangeRequest) (Token, error)
 	invalidateTokenFn func(ctx context.Context, sessionID, audience string) error
 	sessionIssuerFn   func(ctx context.Context, sessionID string) (string, error)
 }
@@ -29,6 +30,13 @@ func (m *mockTokenBroker) BeginOAuthFlow(ctx context.Context, req BeginRequest) 
 func (m *mockTokenBroker) GetToken(ctx context.Context, sessionID, audience string) (Token, error) {
 	if m.getTokenFn != nil {
 		return m.getTokenFn(ctx, sessionID, audience)
+	}
+	return Token{}, errMockNotConfigured
+}
+
+func (m *mockTokenBroker) ExchangeToken(ctx context.Context, req ExchangeRequest) (Token, error) {
+	if m.exchangeTokenFn != nil {
+		return m.exchangeTokenFn(ctx, req)
 	}
 	return Token{}, errMockNotConfigured
 }

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -2619,9 +2619,7 @@ func (a *AggregatorServer) exchangeTokenAndCreateClient(
 ) (MCPClient, time.Time, string, error) {
 	serverName := serverInfo.Name
 	musterIssuer := a.getMusterIssuer()
-	a.mu.RLock()
-	tokenBroker := a.tokenBroker
-	a.mu.RUnlock()
+	tokenBroker := a.tokenBrokerSnapshot()
 	if tokenBroker == nil || !tokenBroker.Enabled() {
 		return nil, time.Time{}, "", fmt.Errorf("broker not available for token exchange to %s", serverName)
 	}
@@ -2791,10 +2789,8 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 
 	} else if ShouldUseTokenForwarding(serverInfo) {
 		musterIssuer := a.getMusterIssuer()
-		a.mu.RLock()
-		tb := a.tokenBroker
-		a.mu.RUnlock()
-		idToken := lookupIDTokenForSession(ctx, tb, sessionID, musterIssuer)
+		tokenBroker := a.tokenBrokerSnapshot()
+		idToken := lookupIDTokenForSession(ctx, tokenBroker, sessionID, musterIssuer)
 		if idToken == "" {
 			return nil, nil, fmt.Errorf("no ID token available for forwarding to %s", serverName)
 		}
@@ -2804,7 +2800,7 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 		}
 
 		headerFunc := func(_ context.Context) map[string]string {
-			latestToken := lookupIDTokenForSession(context.Background(), tb, sessionID, musterIssuer)
+			latestToken := lookupIDTokenForSession(context.Background(), tokenBroker, sessionID, musterIssuer)
 			if latestToken == "" {
 				latestToken = idToken
 			}

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -2619,12 +2619,14 @@ func (a *AggregatorServer) exchangeTokenAndCreateClient(
 ) (MCPClient, time.Time, string, error) {
 	serverName := serverInfo.Name
 	musterIssuer := a.getMusterIssuer()
-	oauthHandler := api.GetOAuthHandler()
-	if oauthHandler == nil || !oauthHandler.IsEnabled() {
-		return nil, time.Time{}, "", fmt.Errorf("OAuth handler not available for token exchange to %s", serverName)
+	a.mu.RLock()
+	tokenBroker := a.tokenBroker
+	a.mu.RUnlock()
+	if tokenBroker == nil || !tokenBroker.Enabled() {
+		return nil, time.Time{}, "", fmt.Errorf("broker not available for token exchange to %s", serverName)
 	}
 
-	idToken := lookupIDTokenForSession(sessionID, musterIssuer)
+	idToken := lookupIDTokenForSession(ctx, tokenBroker, sessionID, musterIssuer)
 	if idToken == "" {
 		return nil, time.Time{}, "", fmt.Errorf("no ID token available for token exchange to %s", serverName)
 	}
@@ -2667,19 +2669,24 @@ func (a *AggregatorServer) exchangeTokenAndCreateClient(
 		return nil, time.Time{}, "", fmt.Errorf("teleport configuration failed for %s: %w", serverName, teleportResult.Error)
 	}
 
-	var exchangedToken string
-	if teleportResult.Client != nil {
-		exchangedToken, err = oauthHandler.ExchangeTokenForRemoteClusterWithClient(
-			ctx, idToken, userID, &exchangeConfig, teleportResult.Client,
-		)
-	} else {
-		exchangedToken, err = oauthHandler.ExchangeTokenForRemoteCluster(
-			ctx, idToken, userID, &exchangeConfig,
-		)
-	}
+	exchanged, err := tokenBroker.ExchangeToken(ctx, ExchangeRequest{
+		SessionID:    sessionID,
+		Subject:      userID,
+		SubjectToken: idToken,
+		Audience:     serverName,
+		Config: ExchangeConfig{
+			TokenEndpoint:  exchangeConfig.DexTokenEndpoint,
+			ExpectedIssuer: exchangeConfig.ExpectedIssuer,
+			ConnectorID:    exchangeConfig.ConnectorID,
+			ClientID:       exchangeConfig.ClientID,
+			ClientSecret:   exchangeConfig.ClientSecret,
+			Scopes:         exchangeConfig.Scopes,
+		},
+	})
 	if err != nil {
 		return nil, time.Time{}, "", fmt.Errorf("token exchange failed for %s: %w", serverName, err)
 	}
+	exchangedToken := exchanged.AccessToken
 
 	tokenExpiry, err := pkgoauth.Expiry(exchangedToken)
 	if err != nil {
@@ -2784,7 +2791,10 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 
 	} else if ShouldUseTokenForwarding(serverInfo) {
 		musterIssuer := a.getMusterIssuer()
-		idToken := lookupIDTokenForSession(sessionID, musterIssuer)
+		a.mu.RLock()
+		tb := a.tokenBroker
+		a.mu.RUnlock()
+		idToken := lookupIDTokenForSession(ctx, tb, sessionID, musterIssuer)
 		if idToken == "" {
 			return nil, nil, fmt.Errorf("no ID token available for forwarding to %s", serverName)
 		}
@@ -2794,7 +2804,7 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 		}
 
 		headerFunc := func(_ context.Context) map[string]string {
-			latestToken := lookupIDTokenForSession(sessionID, musterIssuer)
+			latestToken := lookupIDTokenForSession(context.Background(), tb, sessionID, musterIssuer)
 			if latestToken == "" {
 				latestToken = idToken
 			}

--- a/internal/aggregator/server_logout_test.go
+++ b/internal/aggregator/server_logout_test.go
@@ -406,11 +406,11 @@ func (d *deleteCaptureMockHandler) GetCIMDHandler() http.HandlerFunc {
 func (d *deleteCaptureMockHandler) RegisterServer(_, _, _ string)                          {}
 func (d *deleteCaptureMockHandler) SetAuthCompletionCallback(_ api.AuthCompletionCallback) {}
 func (d *deleteCaptureMockHandler) Stop()                                                  {}
-func (d *deleteCaptureMockHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, error) {
-	return "", nil
+func (d *deleteCaptureMockHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, string, error) {
+	return "", "", nil
 }
-func (d *deleteCaptureMockHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, error) {
-	return "", nil
+func (d *deleteCaptureMockHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, string, error) {
+	return "", "", nil
 }
 
 // clearCaptureMockHandler wraps issuerMockOAuthHandler and captures
@@ -456,9 +456,9 @@ func (c *clearCaptureMockHandler) GetCIMDHandler() http.HandlerFunc {
 func (c *clearCaptureMockHandler) RegisterServer(_, _, _ string)                          {}
 func (c *clearCaptureMockHandler) SetAuthCompletionCallback(_ api.AuthCompletionCallback) {}
 func (c *clearCaptureMockHandler) Stop()                                                  {}
-func (c *clearCaptureMockHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, error) {
-	return "", nil
+func (c *clearCaptureMockHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, string, error) {
+	return "", "", nil
 }
-func (c *clearCaptureMockHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, error) {
-	return "", nil
+func (c *clearCaptureMockHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, string, error) {
+	return "", "", nil
 }

--- a/internal/aggregator/token_broker.go
+++ b/internal/aggregator/token_broker.go
@@ -13,6 +13,8 @@ var (
 
 // TokenBroker is the aggregator's port for the OAuth/OIDC broker.
 // Tokens are keyed by (sessionID, issuer) — the IdP that minted them.
+// ExchangeRequest.Audience is the distinct RFC 8693 audience for token
+// exchange.
 type TokenBroker interface {
 	// Enabled reports whether the broker is wired and accepting
 	// requests. Disabled brokers return [ErrBrokerDisabled] from every
@@ -27,12 +29,12 @@ type TokenBroker interface {
 	// or [ErrTokenNotFound] if none is cached. Callers distinguish
 	// "not cached" from other errors via [errors.Is].
 	GetToken(ctx context.Context, sessionID, issuer string) (Token, error)
+	ExchangeToken(ctx context.Context, req ExchangeRequest) (Token, error)
 	// InvalidateToken is the consumer-side signal "the token last issued
-	// for (sessionID, issuer) was rejected downstream". The broker
-	// decides how to react — cache eviction, blacklisting, telemetry —
-	// without the consumer directing storage. Distinct from a cache
-	// mutator: a gRPC-fronted broker pod can implement this without
-	// exposing its store.
+	// for (sessionID, issuer) was rejected downstream". The broker decides
+	// how to react — cache eviction, blacklisting, telemetry — without
+	// the consumer directing storage. A gRPC-fronted broker pod can
+	// implement this without exposing its store.
 	InvalidateToken(ctx context.Context, sessionID, issuer string) error
 	SessionIssuer(ctx context.Context, sessionID string) (string, error)
 }
@@ -53,6 +55,32 @@ type FlowURL struct {
 	URL        string
 	ServerName string
 	Message    string
+}
+
+// ExchangeRequest carries the inputs for an RFC 8693 token exchange.
+// All fields are port-owned and gRPC-safe; callers translate from any
+// CRD-shaped config into Config before invoking ExchangeToken.
+type ExchangeRequest struct {
+	SessionID    string
+	Subject      string
+	SubjectToken string
+	Audience     string
+	Config       ExchangeConfig
+}
+
+// ExchangeConfig is the port-owned shape of an RFC 8693 exchange
+// configuration. Credentials must be fully resolved before the request
+// reaches the port; the broker does not load K8s secrets or perform any
+// CRD lookups on the consumer's behalf.
+//
+// Scopes is the RFC 6749 §3.3 wire form: space-separated scope tokens.
+type ExchangeConfig struct {
+	TokenEndpoint  string
+	ExpectedIssuer string
+	ConnectorID    string
+	ClientID       string
+	ClientSecret   string
+	Scopes         string
 }
 
 // Token is a bearer credential issued by an OIDC IdP.

--- a/internal/aggregator/tokenbroker/in_process.go
+++ b/internal/aggregator/tokenbroker/in_process.go
@@ -5,19 +5,25 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/muster/internal/aggregator"
+	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/broker"
 	"github.com/giantswarm/muster/pkg/logging"
 )
 
 // InProcess implements [aggregator.TokenBroker] against an in-process
 // *broker.Manager. A nil manager short-circuits every method with
-// [aggregator.ErrBrokerDisabled].
+// [aggregator.ErrBrokerDisabled]. A nil resolver falls back to
+// [aggregator.DefaultTransportResolver].
 type InProcess struct {
-	manager *broker.Manager
+	manager  *broker.Manager
+	resolver aggregator.TransportResolver
 }
 
-func NewInProcess(manager *broker.Manager) *InProcess {
-	return &InProcess{manager: manager}
+func NewInProcess(manager *broker.Manager, resolver aggregator.TransportResolver) *InProcess {
+	if resolver == nil {
+		resolver = aggregator.DefaultTransportResolver{}
+	}
+	return &InProcess{manager: manager, resolver: resolver}
 }
 
 var _ aggregator.TokenBroker = (*InProcess)(nil)
@@ -58,6 +64,66 @@ func (a *InProcess) GetToken(_ context.Context, sessionID, issuer string) (aggre
 		IDToken:      cached.IDToken,
 		Issuer:       cached.Issuer,
 	}, nil
+}
+
+func (a *InProcess) ExchangeToken(ctx context.Context, req aggregator.ExchangeRequest) (aggregator.Token, error) {
+	if a.manager == nil {
+		return aggregator.Token{}, aggregator.ErrBrokerDisabled
+	}
+	if req.Config.TokenEndpoint == "" {
+		return aggregator.Token{}, fmt.Errorf("exchange request missing token endpoint for audience %q", req.Audience)
+	}
+
+	client, err := a.resolver.HTTPClientFor(ctx, req.Audience)
+	if err != nil {
+		return aggregator.Token{}, fmt.Errorf("resolve transport for audience %q: %w", req.Audience, err)
+	}
+
+	brokerCfg := translateExchangeConfig(req.Config)
+
+	var (
+		accessToken     string
+		issuedTokenType string
+	)
+	if client != nil {
+		accessToken, issuedTokenType, err = a.manager.ExchangeTokenForRemoteClusterWithClient(ctx, req.SubjectToken, req.Subject, brokerCfg, client)
+	} else {
+		accessToken, issuedTokenType, err = a.manager.ExchangeTokenForRemoteCluster(ctx, req.SubjectToken, req.Subject, brokerCfg)
+	}
+	if err != nil {
+		return aggregator.Token{}, err
+	}
+	return aggregator.Token{
+		AccessToken: accessToken,
+		TokenType:   tokenTypeFromIssued(issuedTokenType),
+	}, nil
+}
+
+// tokenTypeFromIssued maps the RFC 8693 §2.2.1 issued_token_type URI to the
+// HTTP Authorization scheme. Empty or unknown values fall back to Bearer.
+func tokenTypeFromIssued(issued string) string {
+	switch issued {
+	case "urn:ietf:params:oauth:token-type:access_token", "":
+		return "Bearer"
+	default:
+		return issued
+	}
+}
+
+// translateExchangeConfig maps the port-owned [aggregator.ExchangeConfig]
+// to [api.TokenExchangeConfig]. Enabled is hard-set: the port does not
+// model the flag because gating happens consumer-side; the broker still
+// checks defensively.
+func translateExchangeConfig(cfg aggregator.ExchangeConfig) *api.TokenExchangeConfig {
+	return &api.TokenExchangeConfig{
+		Enabled:          true,
+		DexTokenEndpoint: cfg.TokenEndpoint,
+		ExpectedIssuer:   cfg.ExpectedIssuer,
+		ConnectorID:      cfg.ConnectorID,
+		ClientID:         cfg.ClientID,
+		ClientSecret:     cfg.ClientSecret,
+		Scopes:           cfg.Scopes,
+	}
 }
 
 func (a *InProcess) InvalidateToken(_ context.Context, sessionID, issuer string) error {

--- a/internal/aggregator/tokenbroker/in_process_test.go
+++ b/internal/aggregator/tokenbroker/in_process_test.go
@@ -32,7 +32,7 @@ func newManagerForTest(t *testing.T) *broker.Manager {
 }
 
 func TestInProcess_NilManager_ReturnsBrokerDisabled(t *testing.T) {
-	a := NewInProcess(nil)
+	a := NewInProcess(nil, nil)
 	ctx := context.Background()
 
 	require.False(t, a.Enabled())
@@ -46,13 +46,16 @@ func TestInProcess_NilManager_ReturnsBrokerDisabled(t *testing.T) {
 	_, err = a.BeginOAuthFlow(ctx, aggregator.BeginRequest{SessionID: "sid"})
 	require.ErrorIs(t, err, aggregator.ErrBrokerDisabled)
 
+	_, err = a.ExchangeToken(ctx, aggregator.ExchangeRequest{})
+	require.ErrorIs(t, err, aggregator.ErrBrokerDisabled)
+
 	require.ErrorIs(t, a.InvalidateToken(ctx, "sid", "https://idp"), aggregator.ErrBrokerDisabled)
 }
 
 func TestInProcess_Enabled_TracksManagerState(t *testing.T) {
 	m := newManagerForTest(t)
-	require.True(t, NewInProcess(m).Enabled(), "active manager should be enabled")
-	require.False(t, NewInProcess(nil).Enabled(), "nil manager should be disabled")
+	require.True(t, NewInProcess(m, nil).Enabled(), "active manager should be enabled")
+	require.False(t, NewInProcess(nil, nil).Enabled(), "nil manager should be disabled")
 }
 
 func TestInProcess_BeginOAuthFlow_BuildsAuthURL(t *testing.T) {
@@ -75,7 +78,7 @@ func TestInProcess_BeginOAuthFlow_BuildsAuthURL(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	m := newManagerForTest(t)
-	a := NewInProcess(m)
+	a := NewInProcess(m, nil)
 
 	flow, err := a.BeginOAuthFlow(context.Background(), aggregator.BeginRequest{
 		SessionID:  "session-flow",
@@ -101,7 +104,7 @@ func TestInProcess_BeginOAuthFlow_BuildsAuthURL(t *testing.T) {
 
 func TestInProcess_InvalidateToken_EvictsFromCache(t *testing.T) {
 	m := newManagerForTest(t)
-	a := NewInProcess(m)
+	a := NewInProcess(m, nil)
 	ctx := context.Background()
 
 	const (
@@ -125,9 +128,147 @@ func TestInProcess_InvalidateToken_EvictsFromCache(t *testing.T) {
 	require.ErrorIs(t, err, aggregator.ErrTokenNotFound)
 }
 
+func TestInProcess_ExchangeToken_RejectsEmptyConfig(t *testing.T) {
+	m := newManagerForTest(t)
+	a := NewInProcess(m, nil)
+
+	_, err := a.ExchangeToken(context.Background(), aggregator.ExchangeRequest{
+		SessionID:    "sid",
+		Subject:      "user",
+		SubjectToken: "id-token",
+		Audience:     "mcp-kubernetes",
+		Config:       aggregator.ExchangeConfig{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing token endpoint")
+}
+
+// captureTransportResolver records which audience was asked for, returns
+// the prepared client (or nil to signal "use default").
+type captureTransportResolver struct {
+	audience string
+	client   *http.Client
+}
+
+func (r *captureTransportResolver) HTTPClientFor(_ context.Context, audience string) (*http.Client, error) {
+	r.audience = audience
+	return r.client, nil
+}
+
+func TestInProcess_ExchangeToken_ConsultsResolver(t *testing.T) {
+	m := newManagerForTest(t)
+	resolver := &captureTransportResolver{client: nil}
+	a := NewInProcess(m, resolver)
+
+	// Best-effort: ExchangeToken will fail because the synthetic config has
+	// no reachable endpoint. We only assert that the resolver was consulted
+	// with the audience name before the broker tried to talk to the IdP.
+	_, _ = a.ExchangeToken(context.Background(), aggregator.ExchangeRequest{
+		SessionID:    "sid",
+		Subject:      "user",
+		SubjectToken: "id-token",
+		Audience:     "mcp-kubernetes",
+		Config: aggregator.ExchangeConfig{
+			TokenEndpoint: "http://127.0.0.1:1/token",
+			ConnectorID:   "c",
+		},
+	})
+	require.Equal(t, "mcp-kubernetes", resolver.audience, "resolver should be consulted with the audience")
+}
+
+// erroringTransportResolver always fails resolution.
+type erroringTransportResolver struct {
+	err error
+}
+
+func (r *erroringTransportResolver) HTTPClientFor(_ context.Context, _ string) (*http.Client, error) {
+	return nil, r.err
+}
+
+// perAudienceTransportResolver returns a different *http.Client per audience.
+type perAudienceTransportResolver struct {
+	clients map[string]*http.Client
+	calls   []string
+}
+
+func (r *perAudienceTransportResolver) HTTPClientFor(_ context.Context, audience string) (*http.Client, error) {
+	r.calls = append(r.calls, audience)
+	return r.clients[audience], nil
+}
+
+func TestInProcess_ExchangeToken_RoutesPerAudience(t *testing.T) {
+	m := newManagerForTest(t)
+	clientA := &http.Client{}
+	clientB := &http.Client{}
+	resolver := &perAudienceTransportResolver{clients: map[string]*http.Client{
+		"audience-a": clientA,
+		"audience-b": clientB,
+	}}
+	a := NewInProcess(m, resolver)
+
+	ctx := context.Background()
+	exchange := func(audience string) {
+		_, _ = a.ExchangeToken(ctx, aggregator.ExchangeRequest{
+			SessionID:    "sid",
+			Subject:      "user",
+			SubjectToken: "id-token",
+			Audience:     audience,
+			Config: aggregator.ExchangeConfig{
+				TokenEndpoint: "https://idp.test/token",
+				ConnectorID:   "c",
+			},
+		})
+	}
+	exchange("audience-a")
+	exchange("audience-b")
+	exchange("audience-a")
+
+	require.Equal(t, []string{"audience-a", "audience-b", "audience-a"}, resolver.calls,
+		"resolver must be consulted with the per-call audience (regression: ignoring audience would return the same client every time)")
+}
+
+func TestInProcess_ExchangeToken_PropagatesResolverError(t *testing.T) {
+	m := newManagerForTest(t)
+	resolverErr := errors.New("teleport cert unavailable")
+	a := NewInProcess(m, &erroringTransportResolver{err: resolverErr})
+
+	_, err := a.ExchangeToken(context.Background(), aggregator.ExchangeRequest{
+		SessionID:    "sid",
+		Subject:      "user",
+		SubjectToken: "id-token",
+		Audience:     "mcp-kubernetes",
+		Config: aggregator.ExchangeConfig{
+			TokenEndpoint: "http://127.0.0.1:1/token",
+			ConnectorID:   "c",
+		},
+	})
+	require.ErrorIs(t, err, resolverErr, "resolver failures must surface to callers (no silent fallback)")
+}
+
+func TestTranslateExchangeConfig_SetsEnabledAndCopiesFields(t *testing.T) {
+	cfg := aggregator.ExchangeConfig{
+		TokenEndpoint:  "https://dex.example.com/token",
+		ExpectedIssuer: "https://dex.example.com",
+		ConnectorID:    "github",
+		ClientID:       "muster",
+		ClientSecret:   "shh",
+		Scopes:         "openid profile",
+	}
+
+	got := translateExchangeConfig(cfg)
+
+	require.True(t, got.Enabled, "broker validator rejects requests where !Config.Enabled; translation must set the flag")
+	require.Equal(t, cfg.TokenEndpoint, got.DexTokenEndpoint)
+	require.Equal(t, cfg.ExpectedIssuer, got.ExpectedIssuer)
+	require.Equal(t, cfg.ConnectorID, got.ConnectorID)
+	require.Equal(t, cfg.ClientID, got.ClientID)
+	require.Equal(t, cfg.ClientSecret, got.ClientSecret)
+	require.Equal(t, cfg.Scopes, got.Scopes)
+}
+
 func TestInProcess_GetToken_RoundTrip(t *testing.T) {
 	m := newManagerForTest(t)
-	a := NewInProcess(m)
+	a := NewInProcess(m, nil)
 	ctx := context.Background()
 
 	const (
@@ -157,7 +298,7 @@ func TestInProcess_GetToken_RoundTrip(t *testing.T) {
 
 func TestInProcess_SessionIssuer_RoundTrip(t *testing.T) {
 	m := newManagerForTest(t)
-	a := NewInProcess(m)
+	a := NewInProcess(m, nil)
 	ctx := context.Background()
 
 	const (

--- a/internal/aggregator/tokenbroker/in_process_test.go
+++ b/internal/aggregator/tokenbroker/in_process_test.go
@@ -168,7 +168,7 @@ func TestInProcess_ExchangeToken_ConsultsResolver(t *testing.T) {
 		Subject:      "user",
 		SubjectToken: "id-token",
 		Audience:     "mcp-kubernetes",
-		Config: aggregator.ExchangeConfig{
+		Config: aggregator.ExchangeConfig{ //nolint:gosec // test fixture, not credentials
 			TokenEndpoint: "http://127.0.0.1:1/token",
 			ConnectorID:   "c",
 		},
@@ -213,7 +213,7 @@ func TestInProcess_ExchangeToken_RoutesPerAudience(t *testing.T) {
 			Subject:      "user",
 			SubjectToken: "id-token",
 			Audience:     audience,
-			Config: aggregator.ExchangeConfig{
+			Config: aggregator.ExchangeConfig{ //nolint:gosec // test fixture, not credentials
 				TokenEndpoint: "https://idp.test/token",
 				ConnectorID:   "c",
 			},
@@ -237,7 +237,7 @@ func TestInProcess_ExchangeToken_PropagatesResolverError(t *testing.T) {
 		Subject:      "user",
 		SubjectToken: "id-token",
 		Audience:     "mcp-kubernetes",
-		Config: aggregator.ExchangeConfig{
+		Config: aggregator.ExchangeConfig{ //nolint:gosec // test fixture, not credentials
 			TokenEndpoint: "http://127.0.0.1:1/token",
 			ConnectorID:   "c",
 		},
@@ -246,7 +246,7 @@ func TestInProcess_ExchangeToken_PropagatesResolverError(t *testing.T) {
 }
 
 func TestTranslateExchangeConfig_SetsEnabledAndCopiesFields(t *testing.T) {
-	cfg := aggregator.ExchangeConfig{
+	cfg := aggregator.ExchangeConfig{ //nolint:gosec // test fixture, not credentials
 		TokenEndpoint:  "https://dex.example.com/token",
 		ExpectedIssuer: "https://dex.example.com",
 		ConnectorID:    "github",

--- a/internal/aggregator/transport_resolver.go
+++ b/internal/aggregator/transport_resolver.go
@@ -1,0 +1,120 @@
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// TransportResolver returns the HTTP client the broker should use for
+// outbound calls (currently: the RFC 8693 token-exchange request) targeting
+// a given MCPServer.
+//
+// Returning nil means "use the broker's default client" — the in-process
+// adapter falls back to the standard HTTP transport.
+//
+// The resolver is wired into the in-process broker adapter at construction
+// time. It is deliberately not on the [TokenBroker] port surface: HTTP
+// transport is in-process-only and cannot cross a gRPC boundary.
+type TransportResolver interface {
+	HTTPClientFor(ctx context.Context, serverName string) (*http.Client, error)
+}
+
+// DefaultTransportResolver returns nil for every server, leaving the
+// in-process adapter to use the broker's default HTTP client.
+type DefaultTransportResolver struct{}
+
+// HTTPClientFor implements [TransportResolver].
+func (DefaultTransportResolver) HTTPClientFor(_ context.Context, _ string) (*http.Client, error) {
+	return nil, nil
+}
+
+// teleportTransportResolver returns a Teleport-aware HTTP client for
+// MCPServers whose auth config selects Teleport; otherwise nil. The
+// per-server selection comes from the aggregator's registry, so the
+// resolver holds a [ServerInfoLookup] to fetch the live server info.
+type teleportTransportResolver struct {
+	registry ServerInfoLookup
+}
+
+// ServerInfoLookup is the minimum aggregator-side surface the resolver
+// needs to map a server name to its auth config. Matches the registry's
+// existing signature so it satisfies the interface without an adapter.
+type ServerInfoLookup interface {
+	GetServerInfo(name string) (*ServerInfo, bool)
+}
+
+// NewTeleportTransportResolver constructs a resolver that returns a
+// Teleport-aware HTTP client for servers configured with
+// spec.auth.teleport. Servers without it fall back to the broker default.
+//
+// The resolver discovers the live Teleport client handler via the api
+// service locator; it does not hold a reference itself so cert rotation
+// (handled by the Teleport package's CertWatcher) reaches every call.
+func NewTeleportTransportResolver(registry ServerInfoLookup) TransportResolver {
+	return &teleportTransportResolver{registry: registry}
+}
+
+// HTTPClientFor implements [TransportResolver]. Returns nil for servers
+// not configured with Teleport auth; returns a Teleport-aware
+// [http.Client] when the server's auth config selects Teleport and the
+// Teleport handler is registered.
+func (r *teleportTransportResolver) HTTPClientFor(ctx context.Context, serverName string) (*http.Client, error) {
+	info, ok := r.registry.GetServerInfo(serverName)
+	if !ok {
+		return nil, nil
+	}
+	client, configured, err := teleportHTTPClient(ctx, info)
+	if err != nil {
+		return nil, fmt.Errorf("server %q: %w", serverName, err)
+	}
+	if !configured {
+		return nil, nil
+	}
+	logging.Debug("TransportResolver", "Resolved teleport HTTP client for server %s", serverName)
+	return client, nil
+}
+
+// teleportHTTPClient resolves a Teleport-aware HTTP client for serverInfo.
+// The configured return value is true iff serverInfo.AuthConfig selects
+// Teleport — when false, callers should use their default transport.
+// When configured is true, callers must surface any returned error rather
+// than falling back to the default transport, to avoid silently bypassing
+// a required Teleport identity.
+func teleportHTTPClient(ctx context.Context, serverInfo *ServerInfo) (*http.Client, bool, error) {
+	if serverInfo == nil || serverInfo.AuthConfig == nil || serverInfo.AuthConfig.Type != api.AuthTypeTeleport {
+		return nil, false, nil
+	}
+	if serverInfo.AuthConfig.Teleport == nil {
+		return nil, true, fmt.Errorf("teleport auth selected but teleport settings missing")
+	}
+
+	teleportHandler := api.GetTeleportClient()
+	if teleportHandler == nil {
+		return nil, true, fmt.Errorf("teleport client handler not registered")
+	}
+
+	teleportAuth := serverInfo.AuthConfig.Teleport
+	clientConfig := api.TeleportClientConfig{
+		IdentityDir:             teleportAuth.IdentityDir,
+		IdentitySecretName:      teleportAuth.IdentitySecretName,
+		IdentitySecretNamespace: teleportAuth.IdentitySecretNamespace,
+		AppName:                 teleportAuth.AppName,
+	}
+
+	switch {
+	case clientConfig.IdentityDir == "" && clientConfig.IdentitySecretName == "":
+		return nil, true, fmt.Errorf("teleport auth requires either identityDir or identitySecretName")
+	case clientConfig.IdentityDir != "" && clientConfig.IdentitySecretName != "":
+		return nil, true, fmt.Errorf("teleport auth: identityDir and identitySecretName are mutually exclusive")
+	}
+
+	client, err := teleportHandler.GetHTTPClientForConfig(ctx, clientConfig)
+	if err != nil {
+		return nil, true, fmt.Errorf("teleport HTTP client: %w", err)
+	}
+	return client, true, nil
+}

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -99,32 +99,15 @@ type OAuthHandler interface {
 
 	// ExchangeTokenForRemoteCluster exchanges a local token for one valid on a remote cluster.
 	// This implements RFC 8693 Token Exchange for cross-cluster SSO scenarios.
-	//
-	// Args:
-	//   - ctx: Context for the operation
-	//   - localToken: The local ID token to exchange
-	//   - userID: The user's unique identifier (from validated JWT 'sub' claim)
-	//   - config: Token exchange configuration for the remote cluster
-	//
-	// Returns the exchanged access token, or an error if exchange fails.
-	ExchangeTokenForRemoteCluster(ctx context.Context, localToken, userID string, config *TokenExchangeConfig) (string, error)
+	// Returns the exchanged access token, the issued-token-type URI from the
+	// authorization server response (RFC 8693 §2.2.1), or an error.
+	ExchangeTokenForRemoteCluster(ctx context.Context, localToken, userID string, config *TokenExchangeConfig) (string, string, error)
 
 	// ExchangeTokenForRemoteClusterWithClient exchanges a local token for one valid on a remote cluster
-	// using a custom HTTP client. This is used when the token exchange endpoint is accessed via
-	// Teleport Application Access, which requires mutual TLS authentication.
-	//
-	// The httpClient parameter should be configured with the appropriate TLS certificates
-	// (e.g., Teleport Machine ID certificates). If nil, uses the default HTTP client.
-	//
-	// Args:
-	//   - ctx: Context for the operation
-	//   - localToken: The local ID token to exchange
-	//   - userID: The user's unique identifier (from validated JWT 'sub' claim)
-	//   - config: Token exchange configuration for the remote cluster
-	//   - httpClient: Custom HTTP client with Teleport TLS certificates (or nil for default)
-	//
-	// Returns the exchanged access token, or an error if exchange fails.
-	ExchangeTokenForRemoteClusterWithClient(ctx context.Context, localToken, userID string, config *TokenExchangeConfig, httpClient *http.Client) (string, error)
+	// using a custom HTTP client (for Teleport Application Access mutual TLS).
+	// A nil httpClient uses the default. Returns the same triple as
+	// [OAuthHandler.ExchangeTokenForRemoteCluster].
+	ExchangeTokenForRemoteClusterWithClient(ctx context.Context, localToken, userID string, config *TokenExchangeConfig, httpClient *http.Client) (string, string, error)
 
 	// Stop stops the OAuth handler and cleans up resources.
 	Stop()

--- a/internal/broker/api_adapter.go
+++ b/internal/broker/api_adapter.go
@@ -193,21 +193,19 @@ func (a *Adapter) SetAuthCompletionCallback(callback api.AuthCompletionCallback)
 
 // ExchangeTokenForRemoteCluster exchanges a local token for one valid on a remote cluster.
 // This implements RFC 8693 Token Exchange for cross-cluster SSO scenarios.
-func (a *Adapter) ExchangeTokenForRemoteCluster(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig) (string, error) {
+func (a *Adapter) ExchangeTokenForRemoteCluster(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig) (string, string, error) {
 	if config == nil {
-		return "", fmt.Errorf("token exchange config is nil")
+		return "", "", fmt.Errorf("token exchange config is nil")
 	}
 
-	// Pass API config directly - no conversion needed (DRY principle)
 	return a.manager.ExchangeTokenForRemoteCluster(ctx, localToken, userID, config)
 }
 
 // ExchangeTokenForRemoteClusterWithClient exchanges a local token for one valid on a remote cluster
-// using a custom HTTP client. This is used when the token exchange endpoint is accessed via
-// Teleport Application Access, which requires mutual TLS authentication.
-func (a *Adapter) ExchangeTokenForRemoteClusterWithClient(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig, httpClient *http.Client) (string, error) {
+// using a custom HTTP client (for Teleport Application Access mutual TLS).
+func (a *Adapter) ExchangeTokenForRemoteClusterWithClient(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig, httpClient *http.Client) (string, string, error) {
 	if config == nil {
-		return "", fmt.Errorf("token exchange config is nil")
+		return "", "", fmt.Errorf("token exchange config is nil")
 	}
 
 	return a.manager.ExchangeTokenForRemoteClusterWithClient(ctx, localToken, userID, config, httpClient)

--- a/internal/broker/manager.go
+++ b/internal/broker/manager.go
@@ -415,22 +415,18 @@ func (m *Manager) HandleCallback(ctx context.Context, code, state string) error 
 // ExchangeTokenForRemoteCluster exchanges a local token for one valid on a remote cluster.
 // This implements RFC 8693 Token Exchange for cross-cluster SSO scenarios.
 //
-// Args:
-//   - ctx: Context for the operation
-//   - localToken: The local ID token to exchange
-//   - userID: The user's unique identifier (from validated JWT 'sub' claim)
-//   - config: Token exchange configuration for the remote cluster
-//
-// Returns the exchanged access token, or an error if exchange fails.
-func (m *Manager) ExchangeTokenForRemoteCluster(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig) (string, error) {
+// Returns the exchanged access token, the issued-token-type URI from the
+// authorization server response (RFC 8693 §2.2.1), or an error if exchange
+// fails.
+func (m *Manager) ExchangeTokenForRemoteCluster(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig) (string, string, error) {
 	if m == nil {
-		return "", fmt.Errorf("OAuth proxy is disabled")
+		return "", "", fmt.Errorf("OAuth proxy is disabled")
 	}
 	if m.tokenExchanger == nil {
-		return "", fmt.Errorf("token exchanger not initialized")
+		return "", "", fmt.Errorf("token exchanger not initialized")
 	}
 	if config == nil {
-		return "", fmt.Errorf("token exchange config is nil")
+		return "", "", fmt.Errorf("token exchange config is nil")
 	}
 
 	result, err := m.tokenExchanger.Exchange(ctx, &ExchangeRequest{
@@ -440,36 +436,25 @@ func (m *Manager) ExchangeTokenForRemoteCluster(ctx context.Context, localToken,
 		UserID:           userID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("exchange token for remote cluster: %w", err)
+		return "", "", fmt.Errorf("exchange token for remote cluster: %w", err)
 	}
 
-	return result.AccessToken, nil
+	return result.AccessToken, result.IssuedTokenType, nil
 }
 
 // ExchangeTokenForRemoteClusterWithClient exchanges a local token for one valid on a remote cluster
-// using a custom HTTP client. This is used when the token exchange endpoint is accessed via
-// Teleport Application Access, which requires mutual TLS authentication.
-//
-// The httpClient parameter should be configured with the appropriate TLS certificates
-// (e.g., Teleport Machine ID certificates). If nil, uses the default HTTP client.
-//
-// Args:
-//   - ctx: Context for the operation
-//   - localToken: The local ID token to exchange
-//   - userID: The user's unique identifier (from validated JWT 'sub' claim)
-//   - config: Token exchange configuration for the remote cluster
-//   - httpClient: Custom HTTP client with Teleport TLS certificates (or nil for default)
-//
-// Returns the exchanged access token, or an error if exchange fails.
-func (m *Manager) ExchangeTokenForRemoteClusterWithClient(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig, httpClient *http.Client) (string, error) {
+// using a custom HTTP client (for Teleport Application Access mutual TLS).
+// A nil httpClient uses the default broker HTTP client. Returns the same
+// triple as [Manager.ExchangeTokenForRemoteCluster].
+func (m *Manager) ExchangeTokenForRemoteClusterWithClient(ctx context.Context, localToken, userID string, config *api.TokenExchangeConfig, httpClient *http.Client) (string, string, error) {
 	if m == nil {
-		return "", fmt.Errorf("OAuth proxy is disabled")
+		return "", "", fmt.Errorf("OAuth proxy is disabled")
 	}
 	if m.tokenExchanger == nil {
-		return "", fmt.Errorf("token exchanger not initialized")
+		return "", "", fmt.Errorf("token exchanger not initialized")
 	}
 	if config == nil {
-		return "", fmt.Errorf("token exchange config is nil")
+		return "", "", fmt.Errorf("token exchange config is nil")
 	}
 
 	result, err := m.tokenExchanger.ExchangeWithClient(ctx, &ExchangeRequest{
@@ -479,10 +464,10 @@ func (m *Manager) ExchangeTokenForRemoteClusterWithClient(ctx context.Context, l
 		UserID:           userID,
 	}, httpClient)
 	if err != nil {
-		return "", fmt.Errorf("exchange token for remote cluster with custom client: %w", err)
+		return "", "", fmt.Errorf("exchange token for remote cluster with custom client: %w", err)
 	}
 
-	return result.AccessToken, nil
+	return result.AccessToken, result.IssuedTokenType, nil
 }
 
 // GetTokenExchanger returns the token exchanger for direct access.

--- a/internal/mcpserver/oauth_token_store_adapter_test.go
+++ b/internal/mcpserver/oauth_token_store_adapter_test.go
@@ -56,11 +56,11 @@ func (m *stubOAuthHandler) Stop()                                               
 func (m *stubOAuthHandler) CreateAuthChallenge(_ context.Context, _, _, _, _, _ string) (*api.AuthChallenge, error) {
 	return nil, nil
 }
-func (m *stubOAuthHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, error) {
-	return "", nil
+func (m *stubOAuthHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, string, error) {
+	return "", "", nil
 }
-func (m *stubOAuthHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, error) {
-	return "", nil
+func (m *stubOAuthHandler) ExchangeTokenForRemoteClusterWithClient(_ context.Context, _, _ string, _ *api.TokenExchangeConfig, _ *http.Client) (string, string, error) {
+	return "", "", nil
 }
 
 var _ api.OAuthHandler = (*stubOAuthHandler)(nil)

--- a/internal/services/aggregator/service.go
+++ b/internal/services/aggregator/service.go
@@ -59,7 +59,9 @@ func (s *AggregatorService) Start(ctx context.Context) error {
 	// Create the manager with APIs
 	s.manager = aggregator.NewAggregatorManager(s.config, s.orchestratorAPI, s.serviceRegistry, s.onManagerErrorCallback)
 
-	s.manager.GetAggregatorServer().SetTokenBroker(tokenbroker.NewInProcess(s.manager.GetBrokerManager()))
+	aggServer := s.manager.GetAggregatorServer()
+	resolver := aggregator.NewTeleportTransportResolver(aggServer.GetRegistry())
+	aggServer.SetTokenBroker(tokenbroker.NewInProcess(s.manager.GetBrokerManager(), resolver))
 
 	// Start the manager
 	if err := s.manager.Start(ctx); err != nil {


### PR DESCRIPTION
**Step 5b of 8** — `connection_helper.go`'s token-exchange and ID-token-forwarding paths migrate to the `TokenBroker` port. Adds the **TransportResolver** seam: an in-process-only mechanism for Teleport-aware HTTP transport that doesn't pollute the gRPC-safe port surface.

Stacks on #654.

## What changed semantically

Nothing in the runtime data flow. The Teleport runtime path is unchanged (filesystem-mode local-dev workflows still use it). The refactor moves the exchange call's transport selection from a branch inside `connection_helper.go` into a resolver consulted by the in-process adapter.

Two follow-up commits land scope-level changes:
1. **`api.OAuthHandler.ExchangeTokenForRemoteCluster{,WithClient}` signature change** — see "Broker manager return signature" below.
2. **Token-exchange production fix** — see "Bug fix: Enabled flag" below.

## The Teleport question

Teleport is filesystem-mode-only today and may never retire — the design accommodates that:

- **Port** (`TokenBroker.ExchangeToken`) is gRPC-safe and Teleport-agnostic.
- **TransportResolver** is a constructor parameter to `brokeradapter.NewInProcess` — never on the port, never crosses gRPC. The gRPC adapter (Phase 8) constructs no resolver; its broker pod self-configures outbound transport from its own deployment.
- Teleport knowledge lives in **one** place (`internal/aggregator/transport_resolver.go`), retired in one diff if Teleport ever goes away.

## Port additions

| Method/Type | Surface |
|---|---|
| `ExchangeToken(ctx, ExchangeRequest) (Token, error)` | RFC 8693 exchange. gRPC-safe. |
| `ExchangeRequest{SessionID, Subject, SubjectToken, Audience, Config ExchangeConfig}` | Port-owned. |
| `ExchangeConfig{TokenEndpoint, ExpectedIssuer, ConnectorID, ClientID, ClientSecret, Scopes}` | **Port-owned** — replaces the earlier `*api.TokenExchangeConfig` leak. Callers translate from registry config to `ExchangeConfig`; the adapter translates back to `*api.TokenExchangeConfig` internally (`translateExchangeConfig`). `Scopes` is `string` (space-separated wire format) to match the OAuth scope encoding. |

The adapter rejects an empty `TokenEndpoint` with a descriptive error ("missing token endpoint for audience").

## Bug fix: Enabled flag

The translation `aggregator.ExchangeConfig` → `*api.TokenExchangeConfig` now sets `Enabled: true`. The port does not model `Enabled` because gating happens consumer-side: reaching the adapter implies the consumer opted in. The broker validator (`internal/broker/token_exchange.go:136`) rejects requests where `!Config.Enabled`, so the prior translation silently broke every production token exchange. The validator still runs as a defense-in-depth check. `TestTranslateExchangeConfig_SetsEnabledAndCopiesFields` pins the invariant directly (the prior `TestInProcess_ExchangeToken_ConsultsResolver` short-circuited at the broker's `tokenExchanger==nil` check before validation, so it passed for the wrong reason).

## Broker manager return signature

`Manager.ExchangeTokenForRemoteCluster{,WithClient}` now return `(accessToken, issuedTokenType, err)` instead of `(accessToken, err)`. The RFC 8693 §2.2.1 `issued_token_type` URI was previously discarded; the adapter now maps it to the HTTP Authorization scheme via `tokenTypeFromIssued`:

- `urn:ietf:params:oauth:token-type:access_token` → `"Bearer"`
- empty → `"Bearer"` (RFC 6750 fallback when the IdP omits the field)
- any other URI propagates verbatim

`aggregator.Token.TokenType` is no longer a hardcoded `"Bearer"`.

This is an `api.OAuthHandler` interface change. The single non-test implementer (`*broker.Adapter`) and all 5 hand-rolled test mocks (`issuerMockOAuthHandler`, `mockOAuthHandler`, `deleteCaptureMockHandler`, `clearCaptureMockHandler`, `stubOAuthHandler`) are updated in this PR. No `//go:generate` / mockery / mockgen directives exist in the repo.

## TransportResolver (new, in-process-only)

- `TransportResolver` interface — `HTTPClientFor(ctx, audience) (*http.Client, error)`. Returning nil = use broker default.
- `DefaultTransportResolver` — no-op for cluster mode / future MC-services world.
- `teleportTransportResolver` — extracted from `connection_helper.go`'s `getTeleportHTTPClientIfConfigured`. Reads `spec.auth.teleport` from the registry, calls `api.GetTeleportClient()`, returns the Teleport-aware `*http.Client`. Cert rotation works via the existing CertWatcher in `internal/teleport/`.

The resolver is consulted on **every** `ExchangeToken` call with the audience name; tests verify this invariant.

## connection_helper.go migration

| Call site | Before | After |
|---|---|---|
| `EstablishConnectionWithTokenExchange` preflight | `api.GetOAuthHandler().IsEnabled()` | `a.tokenBroker.Enabled()` |
| Token-exchange call | branch on `teleportResult.Client != nil` to choose `ExchangeTokenForRemoteCluster{,WithClient}` | single `broker.ExchangeToken(ctx, ExchangeRequest{Config: ExchangeConfig{...}})`; resolver picks transport internally |
| `getIDTokenForForwarding` fallback | `api.GetOAuthHandler().GetFullTokenByIssuer(...).IDToken` | `broker.GetToken(ctx, sessionID, musterIssuer).IDToken` |
| `makeTokenForwardingHeaderFunc` | captures `sessionID, musterIssuer` | also captures `broker`; closure passes it to `getIDTokenForForwarding` |
| 6 callers of `getIDTokenForForwarding` (3 in connection_helper.go, 3 in server.go) | Updated to pass `a.tokenBroker` | |

The **MCP-server connection transport** Teleport branch (`NewStreamableHTTPClientWithHeaderFuncAndHTTPClient`) is **unchanged** — that's the aggregator's own outbound transport for the actual MCP server connection, not the broker's concern.

## server.go preflight

`exchangeTokenAndCreateClient`'s preflight check is migrated to `tokenBroker.Enabled()` (was `api.GetOAuthHandler().IsEnabled()`). Local variable `tb` → `tokenBroker` here because the `broker` package is imported as a name; `cfg` → `teleportCfg` in `transport_resolver.go` for clarity.

## Out of scope

- `NewMusterTokenStore(... oauthHandler)` — cross-package refactor (`MusterTokenStore` lives in `internal/mcpserver/`). PR 7 territory.
- The Teleport CRD field stays; the runtime Teleport HTTP transport stays; only the *exchange-call selection* is now port-driven.

## Tests

- `mockTokenBroker` grows `ExchangeToken`.
- `TestGetIDTokenForForwarding` (7 sub-tests) rewired off `api.OAuthHandler` mocks onto `mockTokenBroker`.
- `TestHeaderFunc_RateLimitsWarning` + `TestHeaderFunc_EvictsAfterConsecutiveFailures` use `getTokenFn` mutation to simulate token reappearance / disappearance.
- `TestInProcess_ExchangeToken_RejectsNilConfig` — empty TokenEndpoint error path.
- `TestInProcess_ExchangeToken_ConsultsResolver` — resolver is invoked with the audience name.
- `TestInProcess_ExchangeToken_PropagatesResolverError` — `TransportResolver.HTTPClientFor` errors surface to callers; no silent fallback.
- `TestInProcess_ExchangeToken_RoutesPerAudience` — resolver returns different `*http.Client` per audience; assertion fails if a faulty resolver ignored the audience argument.
- `TestTranslateExchangeConfig_SetsEnabledAndCopiesFields` — translation maps all 6 ExchangeConfig fields and pins `Enabled: true`, bypassing the broker's `tokenExchanger==nil` short-circuit so the validator path is genuinely exercised.

## Verification

- \`go build ./...\`, \`go vet ./...\`, \`go test -race ./...\` — all packages green
- pre-commit: all hooks pass