### PR TITLE
review: thread ctx, polish tokenbroker port surface

### DIFF
--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -301,7 +301,7 @@ func (a *AggregatorServer) handleUpstreamRefreshFailure(sessionID, userID, reaso
 // resolveMusterIssuer returns the configured muster issuer URL, or — when
 // the config does not pin one — the issuer recorded for sessionID by the
 // broker. Returns empty if neither source yields an issuer.
-func (a *AggregatorServer) resolveMusterIssuer(sessionID string) string {
+func (a *AggregatorServer) resolveMusterIssuer(ctx context.Context, sessionID string) string {
 	if issuer := a.getMusterIssuer(); issuer != "" {
 		return issuer
 	}
@@ -313,7 +313,7 @@ func (a *AggregatorServer) resolveMusterIssuer(sessionID string) string {
 		return ""
 	}
 
-	issuer, err := broker.SessionIssuer(context.Background(), sessionID)
+	issuer, err := broker.SessionIssuer(ctx, sessionID)
 	if err != nil {
 		logging.Debug("Aggregator", "SessionIssuer unavailable for session %s: %v",
 			logging.TruncateIdentifier(sessionID), err)

--- a/internal/aggregator/auth_resource_test.go
+++ b/internal/aggregator/auth_resource_test.go
@@ -750,6 +750,6 @@ func TestResolveMusterIssuer_NilTokenBroker(t *testing.T) {
 		},
 	}
 
-	issuer := a.resolveMusterIssuer(context.Background(), "any-session")
+	issuer := a.resolveMusterIssuer(t.Context(), "any-session")
 	assert.Empty(t, issuer, "nil tokenBroker must short-circuit to empty issuer")
 }

--- a/internal/aggregator/auth_resource_test.go
+++ b/internal/aggregator/auth_resource_test.go
@@ -750,6 +750,6 @@ func TestResolveMusterIssuer_NilTokenBroker(t *testing.T) {
 		},
 	}
 
-	issuer := a.resolveMusterIssuer("any-session")
+	issuer := a.resolveMusterIssuer(context.Background(), "any-session")
 	assert.Empty(t, issuer, "nil tokenBroker must short-circuit to empty issuer")
 }

--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -361,7 +361,7 @@ func (p *AuthToolProvider) handleAuthLogout(ctx context.Context, args map[string
 	// and it is not muster's upstream issuer. Clearing a shared issuer token
 	// would break other servers (or muster itself) that rely on the same token.
 	if serverInfo.AuthInfo != nil && serverInfo.AuthInfo.Issuer != "" {
-		if p.isIssuerExclusiveToServer(sessionID, serverName, serverInfo.AuthInfo.Issuer) {
+		if p.isIssuerExclusiveToServer(ctx, sessionID, serverName, serverInfo.AuthInfo.Issuer) {
 			oauthHandler := api.GetOAuthHandler()
 			if oauthHandler != nil && oauthHandler.IsEnabled() {
 				oauthHandler.ClearTokenByIssuer(sessionID, serverInfo.AuthInfo.Issuer)
@@ -430,31 +430,24 @@ func (p *AuthToolProvider) tryConnectWithToken(ctx context.Context, serverName, 
 	return result.FormatAsAPIResult(), nil
 }
 
-// getMusterIssuer determines the OAuth issuer that muster used to authenticate the user.
-// This is needed for token forwarding - we need to get the ID token from muster's auth session.
-//
-// This method first checks if the OAuth handler is enabled (required for token forwarding),
-// then delegates to the aggregator's resolveMusterIssuer for the actual issuer lookup.
-//
-// Returns empty string if:
-//   - No OAuth handler is registered
-//   - The OAuth handler is not enabled
-//   - No issuer could be determined from config or tokens
-func (p *AuthToolProvider) getMusterIssuer(sessionID string) string {
+// getMusterIssuer determines the OAuth issuer that muster used to
+// authenticate the user, for token forwarding. Returns empty when the
+// OAuth handler is not enabled or no issuer can be determined.
+func (p *AuthToolProvider) getMusterIssuer(ctx context.Context, sessionID string) string {
 	oauthHandler := api.GetOAuthHandler()
 	if oauthHandler == nil || !oauthHandler.IsEnabled() {
 		return ""
 	}
 
-	return p.aggregator.resolveMusterIssuer(sessionID)
+	return p.aggregator.resolveMusterIssuer(ctx, sessionID)
 }
 
 // isIssuerExclusiveToServer returns true if the given issuer is used ONLY by
 // the specified server and is NOT muster's upstream issuer. When an issuer is
 // shared, clearing it on logout of one server would break other servers (or
 // muster's own token forwarding) that depend on the same token.
-func (p *AuthToolProvider) isIssuerExclusiveToServer(sessionID, serverName, issuer string) bool {
-	if musterIssuer := p.getMusterIssuer(sessionID); musterIssuer != "" && musterIssuer == issuer {
+func (p *AuthToolProvider) isIssuerExclusiveToServer(ctx context.Context, sessionID, serverName, issuer string) bool {
+	if musterIssuer := p.getMusterIssuer(ctx, sessionID); musterIssuer != "" && musterIssuer == issuer {
 		return false
 	}
 

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -204,7 +204,7 @@ func TestGetMusterIssuer_NoOAuthHandler(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer - should return empty because no OAuth handler
-	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
+	issuer := provider.getMusterIssuer(t.Context(), "test-user-sub")
 
 	if issuer != "" {
 		t.Errorf("expected empty issuer when no OAuth handler, got '%s'", issuer)

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -178,7 +178,7 @@ func TestGetMusterIssuer_OAuthNotEnabled(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer - should return empty because OAuth handler is not enabled
-	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
+	issuer := provider.getMusterIssuer(t.Context(), "test-user-sub")
 
 	if issuer != "" {
 		t.Errorf("expected empty issuer when OAuth not enabled, got '%s'", issuer)

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -117,7 +117,7 @@ func TestGetMusterIssuer_WithOAuthServerConfig(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer
-	issuer := provider.getMusterIssuer("test-user-sub")
+	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
 
 	// Should return the BaseURL from the config
 	if issuer != "https://muster.example.com" {
@@ -148,7 +148,7 @@ func TestGetMusterIssuer_WithEmptyBaseURL(t *testing.T) {
 
 	provider := NewAuthToolProvider(aggregator)
 
-	issuer := provider.getMusterIssuer("test-user-sub")
+	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
 
 	if issuer != fallbackIssuer {
 		t.Errorf("expected issuer 'https://fallback-issuer.example.com', got '%s'", issuer)
@@ -178,7 +178,7 @@ func TestGetMusterIssuer_OAuthNotEnabled(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer - should return empty because OAuth handler is not enabled
-	issuer := provider.getMusterIssuer("test-user-sub")
+	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
 
 	if issuer != "" {
 		t.Errorf("expected empty issuer when OAuth not enabled, got '%s'", issuer)
@@ -204,7 +204,7 @@ func TestGetMusterIssuer_NoOAuthHandler(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer - should return empty because no OAuth handler
-	issuer := provider.getMusterIssuer("test-user-sub")
+	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
 
 	if issuer != "" {
 		t.Errorf("expected empty issuer when no OAuth handler, got '%s'", issuer)
@@ -232,7 +232,7 @@ func TestGetMusterIssuer_ConfigNotOAuthServerConfig(t *testing.T) {
 
 	provider := NewAuthToolProvider(aggregator)
 
-	issuer := provider.getMusterIssuer("test-user-sub")
+	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
 
 	if issuer != fallbackIssuer {
 		t.Errorf("expected issuer 'https://fallback-issuer.example.com', got '%s'", issuer)
@@ -260,7 +260,7 @@ func TestGetMusterIssuer_NoFallbackToken(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer - should return empty
-	issuer := provider.getMusterIssuer("test-user-sub")
+	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
 
 	if issuer != "" {
 		t.Errorf("expected empty issuer, got '%s'", issuer)

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -148,7 +148,7 @@ func TestGetMusterIssuer_WithEmptyBaseURL(t *testing.T) {
 
 	provider := NewAuthToolProvider(aggregator)
 
-	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
+	issuer := provider.getMusterIssuer(t.Context(), "test-user-sub")
 
 	if issuer != fallbackIssuer {
 		t.Errorf("expected issuer 'https://fallback-issuer.example.com', got '%s'", issuer)

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -232,7 +232,7 @@ func TestGetMusterIssuer_ConfigNotOAuthServerConfig(t *testing.T) {
 
 	provider := NewAuthToolProvider(aggregator)
 
-	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
+	issuer := provider.getMusterIssuer(t.Context(), "test-user-sub")
 
 	if issuer != fallbackIssuer {
 		t.Errorf("expected issuer 'https://fallback-issuer.example.com', got '%s'", issuer)

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -117,7 +117,7 @@ func TestGetMusterIssuer_WithOAuthServerConfig(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer
-	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
+	issuer := provider.getMusterIssuer(t.Context(), "test-user-sub")
 
 	// Should return the BaseURL from the config
 	if issuer != "https://muster.example.com" {

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -260,7 +260,7 @@ func TestGetMusterIssuer_NoFallbackToken(t *testing.T) {
 	provider := NewAuthToolProvider(aggregator)
 
 	// Call getMusterIssuer - should return empty
-	issuer := provider.getMusterIssuer(context.Background(), "test-user-sub")
+	issuer := provider.getMusterIssuer(t.Context(), "test-user-sub")
 
 	if issuer != "" {
 		t.Errorf("expected empty issuer, got '%s'", issuer)

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -140,10 +140,15 @@ type AggregatorServer struct {
 	// adminServer is the optional admin web UI listener. Nil when disabled.
 	adminServer *admin.Server
 
-	// tokenBroker may be nil in test fixtures; call sites guard accordingly.
+	// tokenBroker is nil until the composition root wires it via
+	// SetTokenBroker. Call sites snapshot it under a.mu and guard nil.
 	tokenBroker TokenBroker
 }
 
+// SetTokenBroker installs the [TokenBroker] adapter. The composition root
+// (internal/services/aggregator) calls this once after constructing the
+// manager and before Start. Subsequent calls replace the binding under
+// a.mu; concurrent reads see either the old or the new value.
 func (a *AggregatorServer) SetTokenBroker(tb TokenBroker) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/internal/aggregator/tokenbroker/in_process.go
+++ b/internal/aggregator/tokenbroker/in_process.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/giantswarm/muster/internal/aggregator"
 	"github.com/giantswarm/muster/internal/broker"
+	"github.com/giantswarm/muster/pkg/logging"
 )
 
 // InProcess implements [aggregator.TokenBroker] against an in-process
@@ -27,7 +28,7 @@ func (a *InProcess) GetToken(_ context.Context, sessionID, issuer string) (aggre
 	}
 	cached := a.manager.GetTokenByIssuer(sessionID, issuer)
 	if cached == nil {
-		return aggregator.Token{}, fmt.Errorf("session=%s issuer=%s: %w", sessionID, issuer, aggregator.ErrTokenNotFound)
+		return aggregator.Token{}, fmt.Errorf("session=%s issuer=%s: %w", logging.TruncateIdentifier(sessionID), issuer, aggregator.ErrTokenNotFound)
 	}
 	return aggregator.Token{
 		AccessToken:  cached.AccessToken,

--- a/internal/broker/manager.go
+++ b/internal/broker/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -314,13 +315,13 @@ func (m *Manager) StoreToken(sessionID, userID, issuer string, token *pkgoauth.T
 
 // ErrSessionUnknown is returned by [Manager.SessionIssuer] when the
 // session has no stored token carrying an issuer claim.
-var ErrSessionUnknown = fmt.Errorf("broker: session has no stored issuer")
+var ErrSessionUnknown = errors.New("broker: session has no stored issuer")
 
 // SessionIssuer returns the IdP issuer URL bound to sessionID, or
 // [ErrSessionUnknown] if no stored token carries an ID token.
 func (m *Manager) SessionIssuer(_ context.Context, sessionID string) (string, error) {
 	if m == nil || m.client == nil || m.client.tokenStore == nil {
-		return "", fmt.Errorf("broker: not initialized")
+		return "", errors.New("broker: not initialized")
 	}
 	for _, token := range m.client.tokenStore.GetAllForSession(sessionID) {
 		if token != nil && token.IDToken != "" && token.Issuer != "" {


### PR DESCRIPTION
Follow-up to #651 (just merged): non-blocking review feedback collected during the deep review.

Stacks on `feat/token-broker`. PR 654 will rebase on this once it merges.

## What changed

| Change | Why |
|---|---|
| `resolveMusterIssuer`, `AuthToolProvider.getMusterIssuer`, `isIssuerExclusiveToServer` take `ctx`; forwarded to `broker.SessionIssuer` | Port was designed for an eventual remote broker — cancellation and deadlines need to propagate. The wrappers were passing `context.Background()` and discarding the caller's ctx. |
| `SetTokenBroker`, `AggregatorServer.tokenBroker` field gain doc comments | Go convention for exported symbols; the field's previous comment ("may be nil in test fixtures") leaked test reality into a production invariant. |
| `ErrSessionUnknown`, the `broker: not initialized` fallback switched to `errors.New` | No format verbs — `fmt.Errorf` was the wrong choice. |
| `InProcess.GetToken` wraps `ErrTokenNotFound` with `logging.TruncateIdentifier(sessionID)` | The raw session id was riding in the wrapped error string; once the error propagates to a log boundary the untruncated id leaks. The rest of the codebase truncates session ids in log lines for the same reason. |

## Out of scope (deferred follow-ups)

- `Manager.SessionIssuer` iterates `tokenStore.GetAllForSession(sessionID)` (Go map → undefined order). Non-deterministic when a session has stored tokens for multiple issuers. Faithful port of the legacy `FindTokenWithIDToken` behaviour — pre-existing latent issue, not introduced by #651.
- `admin_adapter.go` still has 4 direct `api.GetOAuthHandler().FindTokenWithIDToken(...)` callsites — same anti-pattern the broker bounded-context refactor is unwinding. Picked up by a later sub-PR in the series.

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test -race ./internal/aggregator/... ./internal/broker/...` all green
- `golangci-lint run` clean