### PR TITLE
fix(broker): deterministic SessionIssuer when session has multiple issuers

### DIFF
--- a/internal/broker/manager.go
+++ b/internal/broker/manager.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -8,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
@@ -318,12 +320,27 @@ func (m *Manager) StoreToken(sessionID, userID, issuer string, token *pkgoauth.T
 var ErrSessionUnknown = errors.New("broker: session has no stored issuer")
 
 // SessionIssuer returns the IdP issuer URL bound to sessionID, or
-// [ErrSessionUnknown] if no stored token carries an ID token.
+// [ErrSessionUnknown] if no stored token carries an ID token. When the
+// session has tokens for multiple issuers, the lexicographically-smallest
+// (Issuer, Scope) key wins; iteration order is stable so concurrent
+// callers see the same answer.
 func (m *Manager) SessionIssuer(_ context.Context, sessionID string) (string, error) {
 	if m == nil || m.client == nil || m.client.tokenStore == nil {
 		return "", errors.New("broker: not initialized")
 	}
-	for _, token := range m.client.tokenStore.GetAllForSession(sessionID) {
+	tokens := m.client.tokenStore.GetAllForSession(sessionID)
+	keys := make([]TokenKey, 0, len(tokens))
+	for key := range tokens {
+		keys = append(keys, key)
+	}
+	slices.SortFunc(keys, func(a, b TokenKey) int {
+		if c := cmp.Compare(a.Issuer, b.Issuer); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Scope, b.Scope)
+	})
+	for _, key := range keys {
+		token := tokens[key]
 		if token != nil && token.IDToken != "" && token.Issuer != "" {
 			return token.Issuer, nil
 		}

--- a/internal/broker/manager_test.go
+++ b/internal/broker/manager_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
@@ -605,6 +606,67 @@ func TestManager_DeleteTokensByUser(t *testing.T) {
 		// Should not panic
 		manager.DeleteTokensByUser("user@example.com")
 	})
+}
+
+func TestManager_SessionIssuer_DeterministicAcrossMultipleIssuers(t *testing.T) {
+	cfg := config.OAuthMCPClientConfig{
+		Enabled:      true,
+		PublicURL:    "https://muster.example.com",
+		ClientID:     "client-id",
+		CallbackPath: "/oauth/proxy/callback",
+	}
+
+	manager := NewManager(cfg)
+	if manager == nil {
+		t.Fatal("Expected non-nil manager")
+	}
+	defer manager.Stop()
+
+	const sessionID = "session-multi-issuer"
+	// Store tokens for three issuers in non-sorted order; the function
+	// must return the lexicographically-smallest issuer every call.
+	for _, issuer := range []string{
+		"https://idp-c.example.com",
+		"https://idp-a.example.com",
+		"https://idp-b.example.com",
+	} {
+		manager.StoreToken(sessionID, "user", issuer, &pkgoauth.Token{
+			AccessToken: "access-" + issuer,
+			IDToken:     "id-" + issuer,
+			Issuer:      issuer,
+		})
+	}
+
+	const expected = "https://idp-a.example.com"
+	for range 10 {
+		got, err := manager.SessionIssuer(context.Background(), sessionID)
+		if err != nil {
+			t.Fatalf("SessionIssuer returned error: %v", err)
+		}
+		if got != expected {
+			t.Fatalf("SessionIssuer returned %q, expected stable %q (Go map iteration order leaked)", got, expected)
+		}
+	}
+}
+
+func TestManager_SessionIssuer_UnknownSession(t *testing.T) {
+	cfg := config.OAuthMCPClientConfig{
+		Enabled:      true,
+		PublicURL:    "https://muster.example.com",
+		ClientID:     "client-id",
+		CallbackPath: "/oauth/proxy/callback",
+	}
+
+	manager := NewManager(cfg)
+	if manager == nil {
+		t.Fatal("Expected non-nil manager")
+	}
+	defer manager.Stop()
+
+	_, err := manager.SessionIssuer(context.Background(), "no-such-session")
+	if !errors.Is(err, ErrSessionUnknown) {
+		t.Fatalf("expected ErrSessionUnknown, got %v", err)
+	}
 }
 
 func TestNewManager_SelfHostedCIMD(t *testing.T) {


### PR DESCRIPTION
Follow-up to #651/#669 (broker bounded-context refactor): closes the latent non-determinism in `Manager.SessionIssuer` flagged during the deep review.

## Problem

`Manager.SessionIssuer` iterated `tokenStore.GetAllForSession(sessionID)` — a Go `map[TokenKey]*Token`. When a session had stored tokens for more than one IdP (e.g. the user authenticated to muster via Dex AND has a token forwarded for a Teleport-backed cluster on a different issuer), the function returned a non-deterministic issuer.

Concurrent callers could observe different issuers for the same session. A downstream caller that compared the result across calls — or used it as a cache key — would see flapping.

The legacy `FindTokenWithIDToken` (now-deleted) had the same behaviour; this is a faithful-port latent bug, not a regression introduced by the refactor.

## Fix

Sort the keys by `(Issuer, Scope)` before scanning. The first match with a non-empty `IDToken` + `Issuer` wins deterministically; the lexicographically-smallest issuer is returned every time.

Single-issuer sessions are unaffected.

## Tests

- `TestManager_SessionIssuer_DeterministicAcrossMultipleIssuers` — three issuers stored in non-sorted insertion order; 10 calls all return the smallest (`https://idp-a.example.com`). Would fail intermittently on the pre-fix code under Go's map-iteration randomization.
- `TestManager_SessionIssuer_UnknownSession` — `ErrSessionUnknown` for sessions with no stored tokens.

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test -race ./internal/broker/...` green
- `golangci-lint run -E=gosec -E=goconst -E=govet` clean