### PR TITLE
ci: migrate to architect/push-to-registries multiarch path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,9 @@ workflows:
               only: /^v.*/
 
       # Branch builds: amd64 only for faster PR feedback
-      - architect/push-to-registries-multiarch:
+      - architect/push-to-registries:
           context: architect
+          multiarch: true
           name: push-to-registries
           platforms: "linux/amd64"
           requires:
@@ -28,8 +29,9 @@ workflows:
 
       # Tag builds: push multi-arch image to gsoci (primary registry).
       # Chart push depends on this completing successfully.
-      - architect/push-to-registries-multiarch:
+      - architect/push-to-registries:
           context: architect
+          multiarch: true
           name: push-to-gsoci-release
           registries-data: "public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true"
           requires:
@@ -43,8 +45,9 @@ workflows:
       # Tag builds: push multi-arch image to all registries (including China mirrors).
       # Runs in parallel, does NOT block the chart push. If a mirror is unreachable,
       # only mirror-dependent clusters are affected, not the primary delivery pipeline.
-      - architect/push-to-registries-multiarch:
+      - architect/push-to-registries:
           context: architect
+          multiarch: true
           name: push-to-all-registries-release
           requires:
             - go-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate image pushes from the deprecated `architect/push-to-registries-multiarch` job to `push-to-registries` with `multiarch: true`. Picks up the orb v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.
+
 ### Added
 
 - `muster.oauth.server.trustedPublicRegistrationRedirectURIs` — HTTPS redirect-URI allowlist for unauthenticated dynamic client registration, passed through to mcp-oauth (`Config.TrustedPublicRegistrationRedirectURIs`). Strict exact-match after RFC 3986 normalization. Default: `[]` (opt-in per URI).


### PR DESCRIPTION
## Summary

- Migrate all three image pushes (branch amd64, tag gsoci-release, tag all-registries-release) from the deprecated `architect/push-to-registries-multiarch` job to `architect/push-to-registries` with `multiarch: true`. The orb is already pinned to `8.1.0`.

## Why

`push-to-registries-multiarch` was deprecated in orb v7.0.0 and will be removed in the next major version. Switching also picks up v8.1.0's QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.

## Test plan

- [x] Branch CI exercises the new `push-to-registries` (`multiarch: true`, `platforms: linux/amd64`) on this PR.
- [ ] Auto-release tag after merge exercises the full multi-arch (amd64+arm64) tag-build path on both `push-to-gsoci-release` and `push-to-all-registries-release`.

Made with [Cursor](https://cursor.com)