### PR TITLE
feat(musterstdio): stdio→MCP-over-StreamableHTTP shim binary (PR 5/10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ logs
 stress-test-results/
 .klaus/
 muster-v-*
+musterstdio

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,3 +14,18 @@ linters:
       - path: _test\.go
         linters: [gosec]
         text: G101
+      # musterstdio is by design a generic stdio→HTTP shim: its --child-command
+      # / --child-arg flags carry user-controlled values straight to os/exec.
+      # G204's heuristic flags every exec.Command call in these files. Only the
+      # specific files that actually need to launch the configured child (or,
+      # in the test helpers, the built shim binary / re-exec'd fake child) are
+      # exempt — the rest of cmd/musterstdio is still scanned.
+      - path: cmd/musterstdio/bridge\.go
+        linters: [gosec]
+        text: G204
+      - path: cmd/musterstdio/main_test\.go
+        linters: [gosec]
+        text: G204
+      - path: cmd/musterstdio/testhelpers_test\.go
+        linters: [gosec]
+        text: G204

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,9 +50,28 @@ builds:
       - >-
         -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
         -X main.date={{.Date}}
+  - id: musterstdio
+    main: ./cmd/musterstdio
+    binary: musterstdio
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - >-
+        -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
+        -X main.date={{.Date}}
 
 archives:
   - id: default
+    builds:
+      - muster
     # Default formats for all platforms (can be overridden per OS)
     formats: [tar.gz]
     name_template: >-
@@ -74,6 +93,18 @@ archives:
     files:
       - LICENSE
       - README.md
+  - id: musterstdio
+    builds:
+      - musterstdio
+    formats: [tar.gz]
+    name_template: >-
+      musterstdio_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    wrap_in_directory: true
+    files:
+      - LICENSE
 
 checksum:
   # Algorithm to use. Valid options are sha256, sha512, sha1, crc32, md5, etc.
@@ -126,6 +157,10 @@ release:
       name_template: muster_windows_amd64.exe
     - glob: ./dist/muster_windows_arm64*/muster.exe
       name_template: muster_windows_arm64.exe
+    - glob: ./dist/musterstdio_linux_amd64*/musterstdio
+      name_template: musterstdio_linux_amd64
+    - glob: ./dist/musterstdio_linux_arm64*/musterstdio
+      name_template: musterstdio_linux_arm64
 
 brews:
   - name: muster

--- a/Dockerfile.musterstdio
+++ b/Dockerfile.musterstdio
@@ -1,0 +1,33 @@
+# Stage 1: Build the musterstdio binary (cross-compiles for target).
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags "-w -extldflags '-static' \
+    -X 'main.version=${VERSION}' \
+    -X 'main.commit=${COMMIT}' \
+    -X 'main.date=${DATE}'" \
+    -o musterstdio ./cmd/musterstdio
+
+# Stage 2: distroless runtime.
+FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm AS certs
+FROM scratch
+
+COPY --from=certs /etc/passwd /etc/passwd
+COPY --from=certs /etc/group /etc/group
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY --from=builder /app/musterstdio /musterstdio
+USER giantswarm
+
+EXPOSE 8080
+ENTRYPOINT ["/musterstdio"]

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -7,6 +7,20 @@
 release-dry-run: ## Test the release process without publishing (all platforms)
 	goreleaser release --snapshot --clean --skip=announce,publish,validate
 
+.PHONY: musterstdio-image
+musterstdio-image: ## Build the musterstdio container image for the current platform
+	docker build -f Dockerfile.musterstdio -t musterstdio:$(VERSION) .
+
+.PHONY: musterstdio-image-multiarch
+musterstdio-image-multiarch: ## Build and push the musterstdio image for linux/amd64 + linux/arm64 (requires buildx)
+	docker buildx build -f Dockerfile.musterstdio \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT=$(GITSHA1) \
+		--build-arg DATE=$(BUILDTIMESTAMP) \
+		-t musterstdio:$(VERSION) \
+		--push .
+
 .PHONY: release-dry-run-fast
 release-dry-run-fast: ## Fast release dry-run for CI (linux/amd64 only, ~6min faster)
 	goreleaser release --config .goreleaser.ci.yaml --snapshot --clean --skip=announce,publish,validate

--- a/cmd/musterstdio/bridge.go
+++ b/cmd/musterstdio/bridge.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// errInvalidFrame is returned when a request body cannot be parsed as JSON-RPC.
+var errInvalidFrame = errors.New("invalid JSON-RPC frame")
+
+// errBridgeUnavailable is returned when Send is called on a stopped or never-
+// started Bridge.
+var errBridgeUnavailable = errors.New("bridge unavailable")
+
+// BridgeOptions configures a Bridge.
+type BridgeOptions struct {
+	// Command is the child process command (path or PATH-resolvable name).
+	Command string
+	// Args are the child process arguments.
+	Args []string
+	// Env is appended to the parent environment when launching the child.
+	Env map[string]string
+	// Logger receives structured diagnostics. Required.
+	Logger *slog.Logger
+}
+
+// Bridge owns the stdio MCP child process and demultiplexes JSON-RPC
+// responses back to the Send calls that registered the matching id.
+type Bridge struct {
+	opts   BridgeOptions
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+
+	writeMu sync.Mutex
+
+	pendingMu sync.Mutex
+	pending   map[string]chan []byte
+
+	procDone chan struct{}
+	procErr  error
+
+	readDone chan struct{}
+
+	state struct {
+		mu      sync.Mutex
+		started bool
+		stopped bool
+		readErr error
+	}
+}
+
+// NewBridge constructs a Bridge with the given options. Start must be called
+// before Send.
+func NewBridge(opts BridgeOptions) *Bridge {
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	return &Bridge{
+		opts:     opts,
+		pending:  make(map[string]chan []byte),
+		procDone: make(chan struct{}),
+		readDone: make(chan struct{}),
+	}
+}
+
+// Start launches the child process and starts the stdout reader goroutine.
+// It returns an error if the process cannot be started; runtime failures
+// surface through Send and IsHealthy.
+func (b *Bridge) Start(_ context.Context) error {
+	b.state.mu.Lock()
+	if b.state.started {
+		b.state.mu.Unlock()
+		return errors.New("bridge already started")
+	}
+	b.state.started = true
+	b.state.mu.Unlock()
+
+	cmd := exec.Command(b.opts.Command, b.opts.Args...)
+	cmd.Env = append(cmd.Environ(), envSliceFromMap(b.opts.Env)...)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("create child stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return fmt.Errorf("create child stdout pipe: %w", err)
+	}
+	cmd.Stderr = stderrLogger{logger: b.opts.Logger}
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return fmt.Errorf("start child %q: %w", b.opts.Command, err)
+	}
+
+	b.cmd = cmd
+	b.stdin = stdin
+	b.stdout = stdout
+	go b.readLoop()
+	go func() {
+		b.procErr = cmd.Wait()
+		close(b.procDone)
+	}()
+	return nil
+}
+
+// Send writes the frame to the child's stdin and, if the frame carries a
+// JSON-RPC id, waits for the matching response. For notifications (no id),
+// Send returns nil, nil after the frame has been written.
+func (b *Bridge) Send(ctx context.Context, frame []byte) ([]byte, error) {
+	if !b.IsHealthy() {
+		return nil, errBridgeUnavailable
+	}
+
+	id, hasID, err := extractID(frame)
+	if err != nil {
+		return nil, err
+	}
+
+	var respCh chan []byte
+	var key string
+	if hasID {
+		key = string(id)
+		respCh = make(chan []byte, 1)
+		b.pendingMu.Lock()
+		if _, dup := b.pending[key]; dup {
+			b.pendingMu.Unlock()
+			return nil, fmt.Errorf("duplicate in-flight id %s", key)
+		}
+		b.pending[key] = respCh
+		b.pendingMu.Unlock()
+	}
+
+	if err := b.writeFrame(frame); err != nil {
+		b.unregister(key)
+		return nil, fmt.Errorf("write frame to child: %w", err)
+	}
+	if !hasID {
+		return nil, nil
+	}
+
+	select {
+	case resp, ok := <-respCh:
+		if !ok {
+			return nil, fmt.Errorf("child stream closed before response for id %s: %w", key, errBridgeUnavailable)
+		}
+		return resp, nil
+	case <-ctx.Done():
+		b.unregister(key)
+		return nil, ctx.Err()
+	}
+}
+
+// IsHealthy reports whether the child is running and its stdout has not
+// errored out.
+func (b *Bridge) IsHealthy() bool {
+	select {
+	case <-b.procDone:
+		return false
+	default:
+	}
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+	if !b.state.started || b.state.stopped {
+		return false
+	}
+	return b.state.readErr == nil
+}
+
+// Stop closes the child's stdin, sends SIGTERM, waits up to timeout for the
+// process to exit, and falls back to SIGKILL on expiry.
+func (b *Bridge) Stop(timeout time.Duration) error {
+	b.state.mu.Lock()
+	if b.state.stopped {
+		b.state.mu.Unlock()
+		return nil
+	}
+	b.state.stopped = true
+	cmd := b.cmd
+	stdin := b.stdin
+	b.state.mu.Unlock()
+
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	if stdin != nil {
+		_ = stdin.Close()
+	}
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+
+	select {
+	case <-b.procDone:
+	case <-time.After(timeout):
+		_ = cmd.Process.Kill()
+		<-b.procDone
+	}
+
+	b.failPending(fmt.Errorf("child exited: %w", errBridgeUnavailable))
+	<-b.readDone
+	return nil
+}
+
+// Wait blocks until the child exits and returns its exit error, if any.
+func (b *Bridge) Wait() error {
+	<-b.procDone
+	return b.procErr
+}
+
+// pendingCountForTest exposes the in-flight registration count to tests.
+func (b *Bridge) pendingCountForTest() int {
+	b.pendingMu.Lock()
+	defer b.pendingMu.Unlock()
+	return len(b.pending)
+}
+
+func (b *Bridge) writeFrame(frame []byte) error {
+	b.writeMu.Lock()
+	defer b.writeMu.Unlock()
+	if _, err := b.stdin.Write(frame); err != nil {
+		return err
+	}
+	_, err := b.stdin.Write([]byte{'\n'})
+	return err
+}
+
+func (b *Bridge) readLoop() {
+	defer close(b.readDone)
+	r := bufio.NewReaderSize(b.stdout, 1<<20)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			if delivered := b.deliver(line); !delivered {
+				b.opts.Logger.Debug("bridge: dropped unmatched frame", "len", len(line))
+			}
+		}
+		if err != nil {
+			b.state.mu.Lock()
+			if !errors.Is(err, io.EOF) {
+				b.state.readErr = err
+			}
+			b.state.mu.Unlock()
+			b.failPending(fmt.Errorf("child stdout closed: %w", errBridgeUnavailable))
+			return
+		}
+	}
+}
+
+func (b *Bridge) deliver(line []byte) bool {
+	id, hasID, err := extractID(line)
+	if err != nil || !hasID {
+		return false
+	}
+	key := string(id)
+	b.pendingMu.Lock()
+	ch, ok := b.pending[key]
+	if ok {
+		delete(b.pending, key)
+	}
+	b.pendingMu.Unlock()
+	if !ok {
+		return false
+	}
+	if n := len(line); n > 0 && line[n-1] == '\n' {
+		line = line[:n-1]
+	}
+	ch <- line
+	close(ch)
+	return true
+}
+
+func (b *Bridge) unregister(key string) {
+	if key == "" {
+		return
+	}
+	b.pendingMu.Lock()
+	delete(b.pending, key)
+	b.pendingMu.Unlock()
+}
+
+func (b *Bridge) failPending(_ error) {
+	b.pendingMu.Lock()
+	for k, ch := range b.pending {
+		close(ch)
+		delete(b.pending, k)
+	}
+	b.pendingMu.Unlock()
+}
+
+// extractID returns the raw bytes of the JSON-RPC id field, or hasID=false if
+// the frame has no id (i.e., it is a notification).
+func extractID(frame []byte) ([]byte, bool, error) {
+	var probe struct {
+		ID *json.RawMessage `json:"id,omitempty"`
+	}
+	if err := json.Unmarshal(frame, &probe); err != nil {
+		return nil, false, fmt.Errorf("parse JSON-RPC frame: %w: %w", errInvalidFrame, err)
+	}
+	if probe.ID == nil {
+		return nil, false, nil
+	}
+	return []byte(*probe.ID), true, nil
+}
+
+func envSliceFromMap(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+// stderrLogger forwards the child's stderr line-by-line through slog.
+type stderrLogger struct{ logger *slog.Logger }
+
+func (s stderrLogger) Write(p []byte) (int, error) {
+	s.logger.Info("child stderr", "msg", string(p))
+	return len(p), nil
+}

--- a/cmd/musterstdio/bridge_test.go
+++ b/cmd/musterstdio/bridge_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBridge_RequestResponse verifies a single JSON-RPC request is routed to
+// the child's stdin and the matching response surfaces on Send.
+func TestBridge_RequestResponse(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	cmd, args, env := runChildArgs("echo")
+	b := newBridgeForTest(t, cmd, args, env)
+	require.NoError(t, b.Start(ctx))
+	t.Cleanup(func() { _ = b.Stop(time.Second) })
+
+	resp, err := b.Send(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	require.EqualValues(t, 1, parsed["id"])
+}
+
+// TestBridge_Notification_NoResponse verifies a JSON-RPC notification (no id)
+// returns immediately with a nil response.
+func TestBridge_Notification_NoResponse(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	cmd, args, env := runChildArgs("echo")
+	b := newBridgeForTest(t, cmd, args, env)
+	require.NoError(t, b.Start(ctx))
+	t.Cleanup(func() { _ = b.Stop(time.Second) })
+
+	resp, err := b.Send(ctx, []byte(`{"jsonrpc":"2.0","method":"ping"}`))
+	require.NoError(t, err)
+	require.Nil(t, resp)
+}
+
+// TestBridge_ConcurrentRequests_OutOfOrder verifies the response mux delivers
+// each Send the response with the matching id, even when the child writes
+// responses out of order.
+func TestBridge_ConcurrentRequests_OutOfOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	cmd, args, env := runChildArgs("out_of_order")
+	b := newBridgeForTest(t, cmd, args, env)
+	require.NoError(t, b.Start(ctx))
+	t.Cleanup(func() { _ = b.Stop(time.Second) })
+
+	type result struct {
+		id  int
+		raw []byte
+		err error
+	}
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for _, id := range []int{1, 2} {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			req := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"x"}`, id))
+			r, err := b.Send(ctx, req)
+			results <- result{id: id, raw: r, err: err}
+		}(id)
+	}
+	wg.Wait()
+	close(results)
+
+	got := map[int][]byte{}
+	for r := range results {
+		require.NoError(t, r.err)
+		got[r.id] = r.raw
+	}
+	require.Len(t, got, 2)
+	for id, raw := range got {
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(raw, &parsed))
+		require.EqualValues(t, id, parsed["id"], "mux must deliver the response for id %d to the Send for id %d", id, id)
+	}
+}
+
+// TestBridge_ContextCancel_UnregistersPending verifies a canceled Send does
+// not leak its response channel registration.
+func TestBridge_ContextCancel_UnregistersPending(t *testing.T) {
+	t.Parallel()
+
+	parentCtx, cancelParent := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelParent()
+
+	cmd, args, env := runChildArgs("slow")
+	b := newBridgeForTest(t, cmd, args, env)
+	require.NoError(t, b.Start(parentCtx))
+	t.Cleanup(func() { _ = b.Stop(time.Second) })
+
+	sendCtx, cancelSend := context.WithCancel(parentCtx)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancelSend()
+	}()
+	_, err := b.Send(sendCtx, []byte(`{"jsonrpc":"2.0","id":42,"method":"slow"}`))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, b.pendingCountForTest(), "canceled Send must remove its pending entry")
+}
+
+// TestBridge_ChildExits_FailsInFlight verifies that when the child exits, the
+// in-flight Send returns a wrapped error and IsHealthy flips to false.
+func TestBridge_ChildExits_FailsInFlight(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	cmd, args, env := runChildArgs("echo")
+	b := newBridgeForTest(t, cmd, args, env)
+	require.NoError(t, b.Start(ctx))
+	t.Cleanup(func() { _ = b.Stop(time.Second) })
+
+	require.True(t, b.IsHealthy())
+	require.NoError(t, b.Stop(500*time.Millisecond))
+	require.False(t, b.IsHealthy(), "after Stop, bridge must be unhealthy")
+
+	_, err := b.Send(ctx, []byte(`{"jsonrpc":"2.0","id":99,"method":"after-stop"}`))
+	require.Error(t, err)
+}
+
+// TestBridge_Stop_SIGKILL_Fallback verifies that a child ignoring SIGTERM is
+// killed after the configured timeout.
+func TestBridge_Stop_SIGKILL_Fallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	cmd, args, env := runChildArgs("ignore_term")
+	b := newBridgeForTest(t, cmd, args, env)
+	require.NoError(t, b.Start(ctx))
+
+	start := time.Now()
+	err := b.Stop(150 * time.Millisecond)
+	elapsed := time.Since(start)
+	require.NoError(t, err, "Stop must succeed even when SIGTERM is ignored")
+	require.Less(t, elapsed, 3*time.Second, "Stop must not block past the SIGKILL fallback")
+}
+
+// TestBridge_Send_InvalidJSON_Errors checks that a body the parser cannot
+// extract an id from surfaces an error rather than blocking forever.
+func TestBridge_Send_InvalidJSON_Errors(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	cmd, args, env := runChildArgs("echo")
+	b := newBridgeForTest(t, cmd, args, env)
+	require.NoError(t, b.Start(ctx))
+	t.Cleanup(func() { _ = b.Stop(time.Second) })
+
+	_, err := b.Send(ctx, []byte(`not-json`))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errInvalidFrame) || err != nil)
+}
+
+// newBridgeForTest returns a Bridge with no logger noise and reasonable
+// defaults so tests stay readable.
+func newBridgeForTest(t *testing.T, cmd string, args []string, env []string) *Bridge {
+	t.Helper()
+	return NewBridge(BridgeOptions{
+		Command: cmd,
+		Args:    args,
+		Env:     parseEnv(env),
+		Logger:  testLogger(t),
+	})
+}

--- a/cmd/musterstdio/doc.go
+++ b/cmd/musterstdio/doc.go
@@ -1,0 +1,6 @@
+// Package main implements musterstdio, a standalone shim that wraps an
+// stdio MCP server child process and exposes it over MCP-over-StreamableHTTP.
+// It is the shim image referenced by the translator stack for stdio
+// MCPServer specs: filesystem mode runs it as a local subprocess; cluster
+// mode runs it as a Deployment.
+package main

--- a/cmd/musterstdio/main.go
+++ b/cmd/musterstdio/main.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// version is overridden by build-time ldflags so the shim reports the muster
+// release it was built from.
+var version = "dev"
+
+// Options aggregates the CLI flag values for the shim. Each field has a
+// dedicated flag bound in Run.
+type Options struct {
+	// ChildCommand is the executable to spawn (path or PATH-resolvable name).
+	ChildCommand string
+	// ChildArgs are arguments passed to the child, in order.
+	ChildArgs sliceFlag
+	// ChildEnv contains KEY=VALUE pairs prepended to the child's environment.
+	ChildEnv sliceFlag
+	// ListenPort is the TCP port for the main HTTP listener.
+	ListenPort int
+	// HealthPort, when non-zero and different from ListenPort, exposes
+	// /healthz on its own listener. Zero means "serve on the main port".
+	HealthPort int
+	// ShutdownTimeout bounds how long Run waits for in-flight requests and
+	// the child to drain after a shutdown signal.
+	ShutdownTimeout time.Duration
+	// StartupTimeout bounds how long Run waits for the child to come up and
+	// the HTTP listener to bind before declaring failure.
+	StartupTimeout time.Duration
+	// MaxRequestBytes caps the POST /mcp request body size.
+	MaxRequestBytes int64
+	// PrintVersion makes the binary print the version string and exit.
+	PrintVersion bool
+}
+
+// Run is the testable entry point: it parses flags, spawns the child, starts
+// the HTTP server, and blocks until ctx is canceled or a fatal error occurs.
+func Run(ctx context.Context, args []string, stderr io.Writer, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(stderr, nil))
+	}
+	opts, err := parseFlags(args, stderr)
+	if err != nil {
+		return err
+	}
+	if opts.PrintVersion {
+		_, _ = fmt.Fprintln(stderr, "musterstdio "+version)
+		return nil
+	}
+	if opts.ChildCommand == "" {
+		return errors.New("flag --child-command is required")
+	}
+
+	bridge := NewBridge(BridgeOptions{
+		Command: opts.ChildCommand,
+		Args:    opts.ChildArgs,
+		Env:     parseEnvPairs(opts.ChildEnv),
+		Logger:  logger,
+	})
+	startCtx, cancelStart := context.WithTimeout(ctx, opts.StartupTimeout)
+	if err := bridge.Start(startCtx); err != nil {
+		cancelStart()
+		return fmt.Errorf("start child: %w", err)
+	}
+	cancelStart()
+
+	srv, err := NewServer(Config{
+		Bridge:          bridge,
+		ListenAddr:      fmt.Sprintf("0.0.0.0:%d", opts.ListenPort),
+		HealthAddr:      healthAddr(opts),
+		MaxRequestBytes: opts.MaxRequestBytes,
+		Logger:          logger,
+	})
+	if err != nil {
+		_ = bridge.Stop(opts.ShutdownTimeout)
+		return fmt.Errorf("construct server: %w", err)
+	}
+	if err := srv.Start(ctx); err != nil {
+		_ = bridge.Stop(opts.ShutdownTimeout)
+		return fmt.Errorf("start server: %w", err)
+	}
+
+	readyArgs := []any{
+		"version", version,
+		"listen_addr", srv.Addr().String(),
+		"child", opts.ChildCommand,
+	}
+	if hAddr := srv.HealthAddr(); hAddr != nil {
+		readyArgs = append(readyArgs, "health_addr", hAddr.String())
+	}
+	logger.Info("musterstdio ready", readyArgs...)
+
+	childExited := make(chan error, 1)
+	go func() { childExited <- bridge.Wait() }()
+
+	var shutdownErr error
+	select {
+	case <-ctx.Done():
+		logger.Info("shutdown signal received; draining")
+	case err := <-childExited:
+		logger.Error("child exited unexpectedly", "err", err)
+		shutdownErr = fmt.Errorf("child exited before shutdown: %w", err)
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), opts.ShutdownTimeout)
+	defer cancelShutdown()
+	if err := srv.Shutdown(shutdownCtx); err != nil && shutdownErr == nil {
+		shutdownErr = fmt.Errorf("shutdown server: %w", err)
+	}
+	if err := bridge.Stop(opts.ShutdownTimeout); err != nil && shutdownErr == nil {
+		shutdownErr = fmt.Errorf("stop child: %w", err)
+	}
+	return shutdownErr
+}
+
+func parseFlags(args []string, stderr io.Writer) (Options, error) {
+	var opts Options
+	opts.ListenPort = 8080
+	opts.ShutdownTimeout = 30 * time.Second
+	opts.StartupTimeout = 10 * time.Second
+	opts.MaxRequestBytes = 1 << 20
+
+	fs := flag.NewFlagSet("musterstdio", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&opts.ChildCommand, "child-command", "", "executable to spawn as the stdio MCP child")
+	fs.Var(&opts.ChildArgs, "child-arg", "argument passed to the child (repeatable, in order)")
+	fs.Var(&opts.ChildEnv, "child-env", "KEY=VALUE environment entry prepended to the child (repeatable)")
+	fs.IntVar(&opts.ListenPort, "listen-port", opts.ListenPort, "TCP port for the main HTTP listener")
+	fs.IntVar(&opts.HealthPort, "health-port", 0, "TCP port for the optional separate /healthz listener (0 = serve on listen-port)")
+	fs.DurationVar(&opts.ShutdownTimeout, "shutdown-timeout", opts.ShutdownTimeout, "maximum time to wait for in-flight requests and the child to drain")
+	fs.DurationVar(&opts.StartupTimeout, "startup-timeout", opts.StartupTimeout, "maximum time to wait for the child to come up")
+	fs.Int64Var(&opts.MaxRequestBytes, "max-request-bytes", opts.MaxRequestBytes, "maximum POST /mcp request body size")
+	fs.BoolVar(&opts.PrintVersion, "version", false, "print version and exit")
+
+	if err := fs.Parse(args); err != nil {
+		return Options{}, fmt.Errorf("parse flags: %w", err)
+	}
+	if fs.NArg() > 0 {
+		return Options{}, fmt.Errorf("unexpected positional arguments: %v", fs.Args())
+	}
+	if opts.ListenPort < 0 || opts.ListenPort > 65535 {
+		return Options{}, fmt.Errorf("invalid --listen-port %d", opts.ListenPort)
+	}
+	if opts.HealthPort < 0 || opts.HealthPort > 65535 {
+		return Options{}, fmt.Errorf("invalid --health-port %d", opts.HealthPort)
+	}
+	return opts, nil
+}
+
+func healthAddr(opts Options) string {
+	if opts.HealthPort == 0 || opts.HealthPort == opts.ListenPort {
+		return ""
+	}
+	return "0.0.0.0:" + strconv.Itoa(opts.HealthPort)
+}
+
+func parseEnvPairs(pairs []string) map[string]string {
+	out := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		k, v, ok := strings.Cut(p, "=")
+		if !ok {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// sliceFlag implements flag.Value for repeatable string flags.
+type sliceFlag []string
+
+func (s *sliceFlag) String() string {
+	if s == nil {
+		return ""
+	}
+	return strings.Join(*s, ",")
+}
+
+func (s *sliceFlag) Set(v string) error { *s = append(*s, v); return nil }
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := Run(ctx, os.Args[1:], os.Stderr, logger); err != nil {
+		logger.Error("musterstdio exited with error", "err", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/musterstdio/main_test.go
+++ b/cmd/musterstdio/main_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// TestEndToEnd_PostRoundTrip wires a real Bridge to a real Server (no Run)
+// against an in-process fake child, and verifies POST /mcp round-trips.
+func TestEndToEnd_PostRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cmd, args, env := runChildArgs("echo")
+	bridge := NewBridge(BridgeOptions{
+		Command: cmd,
+		Args:    args,
+		Env:     parseEnv(env),
+		Logger:  testLogger(t),
+	})
+	require.NoError(t, bridge.Start(t.Context()))
+	t.Cleanup(func() { _ = bridge.Stop(time.Second) })
+
+	srv, err := NewServer(Config{
+		Bridge:     bridge,
+		ListenAddr: loopbackEphemeral,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, srv.Start(t.Context()))
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	body := []byte(`{"jsonrpc":"2.0","id":7,"method":"tools/list","params":{"x":1}}`)
+	resp, raw := httpPostJSON(t, t.Context(), "http://"+srv.Addr().String()+"/mcp", body)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	require.EqualValues(t, 7, parsed["id"])
+}
+
+// TestSigterm_GracefulShutdown launches the compiled shim binary as a real
+// subprocess, fires a SIGTERM, and asserts a clean exit code. The binary is
+// invoked with --listen-port 0 and its bound address is recovered from
+// stderr.
+func TestSigterm_GracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	bin := buildShimBinary(t)
+	cmd, args, env := runChildArgs("echo")
+	shimArgs := []string{
+		flagChildCommand, cmd,
+		flagListenPort, "0",
+	}
+	for _, a := range args {
+		shimArgs = append(shimArgs, flagChildArg, a)
+	}
+	for _, e := range env {
+		shimArgs = append(shimArgs, flagChildEnv, e)
+	}
+
+	cmdProc := exec.Command(bin, shimArgs...)
+	cmdProc.Env = append(os.Environ(), env...)
+	stderrPipe, err := cmdProc.StderrPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmdProc.Start())
+	t.Cleanup(func() { _ = cmdProc.Process.Kill() })
+
+	addr := readListenAddr(t, stderrPipe, 5*time.Second)
+	waitForHealth(t, "http://"+addr+"/healthz", 3*time.Second)
+
+	require.NoError(t, cmdProc.Process.Signal(syscall.SIGTERM))
+	done := make(chan error, 1)
+	go func() { done <- cmdProc.Wait() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "shim must exit 0 on SIGTERM")
+	case <-time.After(10 * time.Second):
+		t.Fatal("shim did not exit after SIGTERM")
+	}
+}
+
+// TestChildCrash_NonZeroExit verifies that a child crashing at startup makes
+// the shim exit non-zero with a diagnostic message.
+func TestChildCrash_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	bin := buildShimBinary(t)
+	cmd, args, env := runChildArgs("crash")
+	shimArgs := []string{
+		flagChildCommand, cmd,
+		flagListenPort, "0",
+	}
+	for _, a := range args {
+		shimArgs = append(shimArgs, flagChildArg, a)
+	}
+	for _, e := range env {
+		shimArgs = append(shimArgs, flagChildEnv, e)
+	}
+
+	cmdProc := exec.Command(bin, shimArgs...)
+	cmdProc.Env = append(os.Environ(), env...)
+	stderr := &captured{}
+	cmdProc.Stderr = stderr
+	require.NoError(t, cmdProc.Start())
+
+	done := make(chan error, 1)
+	go func() { done <- cmdProc.Wait() }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "shim must exit non-zero when child crashes")
+		require.Contains(t, strings.ToLower(stderr.String()), "child")
+	case <-time.After(10 * time.Second):
+		_ = cmdProc.Process.Kill()
+		t.Fatal("shim did not exit after child crash; stderr=" + stderr.String())
+	}
+}
+
+// TestInvalidFlags_ReturnsUsageError verifies that missing --child-command
+// produces a clear error and a non-zero exit, not a panic.
+func TestInvalidFlags_ReturnsUsageError(t *testing.T) {
+	t.Parallel()
+
+	stderr := &captured{}
+	err := Run(t.Context(), []string{"--listen-port", "0"}, stderr, slog.New(slog.NewTextHandler(stderr, nil)))
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()+stderr.String()), "child-command")
+}
+
+// TestParseFlags_RejectsPositionalArgs covers the "trailing args" branch.
+func TestParseFlags_RejectsPositionalArgs(t *testing.T) {
+	t.Parallel()
+
+	stderr := &captured{}
+	_, err := parseFlags([]string{flagChildCommand, "echo", "extra"}, stderr)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected positional arguments")
+}
+
+// TestParseFlags_RejectsInvalidPort covers the port-range branch.
+func TestParseFlags_RejectsInvalidPort(t *testing.T) {
+	t.Parallel()
+
+	stderr := &captured{}
+	_, err := parseFlags([]string{flagListenPort, "70000"}, stderr)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --listen-port")
+
+	_, err = parseFlags([]string{"--health-port", "-1"}, stderr)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --health-port")
+}
+
+// TestStderrLogger_Forwards covers the child stderr forwarder.
+func TestStderrLogger_Forwards(t *testing.T) {
+	t.Parallel()
+
+	buf := &captured{}
+	log := slog.New(slog.NewTextHandler(buf, nil))
+	n, err := stderrLogger{logger: log}.Write([]byte("hello world"))
+	require.NoError(t, err)
+	require.Equal(t, len("hello world"), n)
+	require.Contains(t, buf.String(), "hello world")
+}
+
+// TestRun_PrintVersion exercises the --version short-circuit.
+func TestRun_PrintVersion(t *testing.T) {
+	t.Parallel()
+
+	stderr := &captured{}
+	err := Run(t.Context(), []string{"--version"}, stderr, slog.New(slog.NewTextHandler(stderr, nil)))
+	require.NoError(t, err)
+	require.Contains(t, stderr.String(), "musterstdio")
+}
+
+// TestRun_ContextCancel_GracefulReturn launches Run in-process and asserts
+// that canceling the parent context drives a clean shutdown.
+func TestRun_ContextCancel_GracefulReturn(t *testing.T) {
+	t.Parallel()
+
+	stderrBuf := &captured{}
+	runCtx, cancel := context.WithCancel(t.Context())
+
+	flags := childFlagsFor(t, "echo", 0)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- Run(runCtx, flags, stderrBuf, slog.New(slog.NewTextHandler(stderrBuf, nil)))
+	}()
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(stderrBuf.String(), "listen_addr=")
+	}, 5*time.Second, 10*time.Millisecond, "Run never logged readiness; stderr=%s", stderrBuf.String())
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancel; stderr=" + stderrBuf.String())
+	}
+}
+
+// TestNoGoroutineLeaks runs Bridge+Server in-process, exercises POST /mcp,
+// shuts down, and asserts no extra goroutines remain.
+func TestNoGoroutineLeaks(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+		goleak.IgnoreAnyFunction("net/http.(*Server).Serve"),
+		goleak.IgnoreCurrent(),
+	)
+
+	cmd, args, env := runChildArgs("echo")
+	bridge := NewBridge(BridgeOptions{
+		Command: cmd,
+		Args:    args,
+		Env:     parseEnv(env),
+		Logger:  testLogger(t),
+	})
+	require.NoError(t, bridge.Start(t.Context()))
+
+	srv, err := NewServer(Config{
+		Bridge:     bridge,
+		ListenAddr: loopbackEphemeral,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, srv.Start(t.Context()))
+
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	resp, _ := httpPostJSON(t, t.Context(), "http://"+srv.Addr().String()+"/mcp", body)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, srv.Shutdown(context.Background()))
+	require.NoError(t, bridge.Stop(2*time.Second))
+}
+
+// readListenAddr scans a stderr stream for the slog-formatted listen_addr
+// attribute and returns the host:port. Used by subprocess tests to find the
+// shim's ephemeral port without a fixed-port race.
+func readListenAddr(t *testing.T, r io.Reader, deadline time.Duration) string {
+	t.Helper()
+	addrRe := regexp.MustCompile(`listen_addr=([^\s]+)`)
+	found := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 64*1024), 1<<20)
+		for scanner.Scan() {
+			line := scanner.Text()
+			t.Logf("shim stderr: %s", line)
+			if m := addrRe.FindStringSubmatch(line); m != nil {
+				found <- m[1]
+				continue
+			}
+		}
+	}()
+	select {
+	case addr := <-found:
+		return addr
+	case <-time.After(deadline):
+		t.Fatal("shim never printed listen_addr")
+		return ""
+	}
+}

--- a/cmd/musterstdio/scenarios_test.go
+++ b/cmd/musterstdio/scenarios_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// scenarios_test.go captures end-to-end behaviour in BDD form. Each subtest
+// runs the shim Bridge + Server against the in-process fake stdio child and
+// asserts a discrete user-facing behaviour. Wider system-level scenarios
+// (CRD-driven, exercising the shim through MCPServer) live under
+// internal/testing/scenarios once the reconciler wires this binary in
+// (PR 6 of the translator series).
+
+// TestScenario_StdioChild_ExposesMCPOverStreamableHTTP documents the core
+// behaviour: given an stdio MCP child, the shim translates HTTP requests into
+// stdio frames and routes responses back.
+func TestScenario_StdioChild_ExposesMCPOverStreamableHTTP(t *testing.T) {
+	t.Parallel()
+
+	// Given an stdio MCP child reachable through the shim
+	srv, _ := scenarioBootstrap(t, "echo")
+
+	// When a JSON-RPC request is POSTed to /mcp
+	body := []byte(`{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"x"}}`)
+	resp, raw := httpPostJSON(t, t.Context(), "http://"+srv.Addr().String()+"/mcp", body)
+
+	// Then the matching response surfaces with the request id preserved
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	require.EqualValues(t, 42, parsed["id"])
+	require.Contains(t, parsed, "result")
+}
+
+// TestScenario_Notification_NoResponseBody documents that JSON-RPC
+// notifications (no id) do not yield a response body and the shim signals 202.
+func TestScenario_Notification_NoResponseBody(t *testing.T) {
+	t.Parallel()
+
+	// Given a shim wrapping a stdio MCP child
+	srv, _ := scenarioBootstrap(t, "echo")
+
+	// When a notification frame is POSTed
+	body := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	resp, raw := httpPostJSON(t, t.Context(), "http://"+srv.Addr().String()+"/mcp", body)
+
+	// Then the shim accepts it with 202 and an empty body
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.Empty(t, raw)
+}
+
+// TestScenario_HealthEndpoint_TracksChild documents the /healthz contract.
+func TestScenario_HealthEndpoint_TracksChild(t *testing.T) {
+	t.Parallel()
+
+	// Given a running shim wrapping a healthy stdio MCP child
+	srv, bridge := scenarioBootstrap(t, "echo")
+
+	// When /healthz is queried
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+srv.Addr().String()+"/healthz", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	// Then the shim reports OK
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// And when the child has been stopped
+	require.NoError(t, bridge.Stop(time.Second))
+
+	// Then /healthz reports unavailable
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestScenario_ConcurrentRequests_AreMultiplexed documents the multiplexing
+// guarantee: each Send waits for the response carrying its own id, even when
+// the child writes responses out of order.
+func TestScenario_ConcurrentRequests_AreMultiplexed(t *testing.T) {
+	t.Parallel()
+
+	// Given a child that returns responses in reverse arrival order
+	srv, _ := scenarioBootstrap(t, "out_of_order")
+
+	type result struct {
+		id   int
+		body []byte
+	}
+	results := make(chan result, 2)
+	for _, id := range []int{11, 22} {
+		go func(id int) {
+			body := []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"x"}`)
+			resp, raw := httpPostJSON(t, t.Context(), "http://"+srv.Addr().String()+"/mcp", body)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			results <- result{id: id, body: raw}
+		}(id)
+	}
+
+	// When both responses arrive
+	got := map[int][]byte{}
+	for range 2 {
+		r := <-results
+		got[r.id] = r.body
+	}
+
+	// Then each request body carries its own id, never the other request's
+	require.Len(t, got, 2)
+	for id, raw := range got {
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(raw, &parsed))
+		require.EqualValues(t, id, parsed["id"])
+	}
+}
+
+// scenarioBootstrap stands up a Bridge + Server against the fake child for a
+// scenario test.
+func scenarioBootstrap(t *testing.T, mode string) (*Server, *Bridge) {
+	t.Helper()
+	cmd, args, env := runChildArgs(mode)
+	bridge := NewBridge(BridgeOptions{
+		Command: cmd,
+		Args:    args,
+		Env:     parseEnv(env),
+		Logger:  testLogger(t),
+	})
+	require.NoError(t, bridge.Start(t.Context()))
+	t.Cleanup(func() { _ = bridge.Stop(time.Second) })
+
+	srv, err := NewServer(Config{
+		Bridge:     bridge,
+		ListenAddr: loopbackEphemeral,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, srv.Start(t.Context()))
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+	return srv, bridge
+}

--- a/cmd/musterstdio/server.go
+++ b/cmd/musterstdio/server.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// BridgeIface is the surface Server consumes from Bridge. It exists so tests
+// can substitute a fake without spawning a real child process.
+type BridgeIface interface {
+	Send(ctx context.Context, frame []byte) ([]byte, error)
+	IsHealthy() bool
+	Stop(timeout time.Duration) error
+}
+
+// Config configures a Server.
+type Config struct {
+	// Bridge handles JSON-RPC framing to the child. Required.
+	Bridge BridgeIface
+	// ListenAddr is the host:port for the main HTTP listener (POST /mcp and
+	// GET /healthz when HealthAddr is empty).
+	ListenAddr string
+	// HealthAddr, when non-empty, hosts a second listener that serves only
+	// GET /healthz.
+	HealthAddr string
+	// MaxRequestBytes caps the size of incoming POST /mcp bodies. Zero uses
+	// a 1 MiB default.
+	MaxRequestBytes int64
+	// SendTimeout caps how long a single POST /mcp waits on the child.
+	// Zero uses a 60s default.
+	SendTimeout time.Duration
+	// Logger receives structured diagnostics. Required.
+	Logger *slog.Logger
+}
+
+// Server exposes the shim's HTTP surface.
+type Server struct {
+	cfg Config
+
+	main   *http.Server
+	health *http.Server
+
+	mainAddr   net.Addr
+	healthAddr net.Addr
+
+	inFlight atomic.Int64
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopped   chan struct{}
+}
+
+// NewServer constructs a Server. It validates Config but does not bind any
+// listener until Start is called.
+func NewServer(cfg Config) (*Server, error) {
+	if cfg.Bridge == nil {
+		return nil, errors.New("server: bridge is required")
+	}
+	if cfg.ListenAddr == "" {
+		return nil, errors.New("server: listen address is required")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.MaxRequestBytes == 0 {
+		cfg.MaxRequestBytes = 1 << 20
+	}
+	if cfg.SendTimeout == 0 {
+		cfg.SendTimeout = 60 * time.Second
+	}
+	return &Server{cfg: cfg, stopped: make(chan struct{})}, nil
+}
+
+// Start binds the listeners and serves in background goroutines. Errors from
+// the listeners are routed through ctx done via shutdown.
+func (s *Server) Start(ctx context.Context) error {
+	var startErr error
+	s.startOnce.Do(func() {
+		mainListener, err := net.Listen("tcp", s.cfg.ListenAddr)
+		if err != nil {
+			startErr = fmt.Errorf("listen on %s: %w", s.cfg.ListenAddr, err)
+			return
+		}
+		s.mainAddr = mainListener.Addr()
+		mainMux := http.NewServeMux()
+		mainMux.HandleFunc("/mcp", s.handleMCP)
+		if s.cfg.HealthAddr == "" {
+			mainMux.HandleFunc("/healthz", s.handleHealth)
+		}
+		s.main = &http.Server{
+			Handler:           mainMux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		go func() {
+			if err := s.main.Serve(mainListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				s.cfg.Logger.Error("main listener exited", "err", err)
+			}
+		}()
+
+		if s.cfg.HealthAddr != "" {
+			healthListener, err := net.Listen("tcp", s.cfg.HealthAddr)
+			if err != nil {
+				_ = s.main.Close()
+				startErr = fmt.Errorf("listen on %s: %w", s.cfg.HealthAddr, err)
+				return
+			}
+			s.healthAddr = healthListener.Addr()
+			healthMux := http.NewServeMux()
+			healthMux.HandleFunc("/healthz", s.handleHealth)
+			s.health = &http.Server{
+				Handler:           healthMux,
+				ReadHeaderTimeout: 5 * time.Second,
+			}
+			go func() {
+				if err := s.health.Serve(healthListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					s.cfg.Logger.Error("health listener exited", "err", err)
+				}
+			}()
+		}
+	})
+	return startErr
+}
+
+// Shutdown stops accepting new requests, waits for in-flight requests to
+// drain (bounded by ctx), and closes the listeners. Subsequent calls are
+// no-ops.
+func (s *Server) Shutdown(ctx context.Context) error {
+	var err error
+	s.stopOnce.Do(func() {
+		defer close(s.stopped)
+		if s.main != nil {
+			err = s.main.Shutdown(ctx)
+		}
+		if s.health != nil {
+			if e := s.health.Shutdown(ctx); err == nil {
+				err = e
+			}
+		}
+	})
+	return err
+}
+
+// InFlight returns the count of POST /mcp requests currently being processed.
+func (s *Server) InFlight() int64 { return s.inFlight.Load() }
+
+// Addr returns the address the main HTTP listener is bound to. Returns nil
+// before Start succeeds.
+func (s *Server) Addr() net.Addr { return s.mainAddr }
+
+// HealthAddr returns the address the separate /healthz listener is bound to,
+// or nil if /healthz is served on the main listener.
+func (s *Server) HealthAddr() net.Addr { return s.healthAddr }
+
+func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.cfg.Bridge.IsHealthy() {
+		writeJSONRPCError(w, http.StatusServiceUnavailable, "child unavailable")
+		return
+	}
+
+	s.inFlight.Add(1)
+	defer s.inFlight.Add(-1)
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.cfg.MaxRequestBytes))
+	if err != nil {
+		writeJSONRPCError(w, http.StatusBadRequest, fmt.Sprintf("read request body: %s", err))
+		return
+	}
+	if len(body) == 0 {
+		writeJSONRPCError(w, http.StatusBadRequest, "empty request body")
+		return
+	}
+	if !json.Valid(body) {
+		writeJSONRPCError(w, http.StatusBadRequest, "request body is not valid JSON")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.cfg.SendTimeout)
+	defer cancel()
+
+	resp, err := s.cfg.Bridge.Send(ctx, body)
+	if err != nil {
+		switch {
+		case errors.Is(err, errInvalidFrame):
+			writeJSONRPCError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, errBridgeUnavailable):
+			writeJSONRPCError(w, http.StatusServiceUnavailable, err.Error())
+		case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+			writeJSONRPCError(w, http.StatusGatewayTimeout, err.Error())
+		default:
+			writeJSONRPCError(w, http.StatusBadGateway, err.Error())
+		}
+		return
+	}
+	if resp == nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(resp)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.cfg.Bridge.IsHealthy() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"status":"unhealthy"}`))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func writeJSONRPCError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"error": map[string]any{
+			"code":    -32000,
+			"message": msg,
+		},
+		"id": nil,
+	})
+	_, _ = w.Write(body)
+}

--- a/cmd/musterstdio/server_test.go
+++ b/cmd/musterstdio/server_test.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBridge is a hand-rolled stand-in for *Bridge that lets server tests
+// inject arbitrary responses and health states without spawning a process.
+type fakeBridge struct {
+	mu        sync.Mutex
+	healthy   bool
+	send      func(ctx context.Context, frame []byte) ([]byte, error)
+	stopCalls int
+}
+
+func (f *fakeBridge) Send(ctx context.Context, frame []byte) ([]byte, error) {
+	f.mu.Lock()
+	send := f.send
+	f.mu.Unlock()
+	if send == nil {
+		return nil, nil
+	}
+	return send(ctx, frame)
+}
+
+func (f *fakeBridge) IsHealthy() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.healthy
+}
+
+func (f *fakeBridge) Stop(timeout time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopCalls++
+	return nil
+}
+
+// TestServer_PostMCP_Request_ReturnsBody verifies the happy path: POST /mcp
+// returns whatever the bridge produced as the response body.
+func TestServer_PostMCP_Request_ReturnsBody(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true, send: func(ctx context.Context, frame []byte) ([]byte, error) {
+		return []byte(`{"jsonrpc":"2.0","id":1,"result":{"echo":true}}`), nil
+	}}
+
+	srv := serverForTest(t, br)
+	resp, body := httpPostJSON(t, t.Context(), srv.URL+"/mcp", []byte(`{"jsonrpc":"2.0","id":1,"method":"x"}`))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":1,"result":{"echo":true}}`, string(body))
+	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+}
+
+// TestServer_PostMCP_Notification_Returns202 verifies that a JSON-RPC
+// notification (Send returns nil body) translates to a 202 Accepted.
+func TestServer_PostMCP_Notification_Returns202(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true, send: func(ctx context.Context, frame []byte) ([]byte, error) {
+		return nil, nil
+	}}
+	srv := serverForTest(t, br)
+	resp, body := httpPostJSON(t, t.Context(), srv.URL+"/mcp", []byte(`{"jsonrpc":"2.0","method":"ping"}`))
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.Empty(t, body)
+}
+
+// TestServer_PostMCP_BridgeError_Returns502 verifies bridge errors surface as
+// 502 with a JSON-RPC-style error body.
+func TestServer_PostMCP_BridgeError_Returns502(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true, send: func(ctx context.Context, frame []byte) ([]byte, error) {
+		return nil, errors.New("boom: child returned nonsense")
+	}}
+	srv := serverForTest(t, br)
+	resp, body := httpPostJSON(t, t.Context(), srv.URL+"/mcp", []byte(`{"jsonrpc":"2.0","id":1,"method":"x"}`))
+	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	require.NotEmpty(t, body)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	require.Contains(t, parsed, "error")
+}
+
+// TestServer_PostMCP_Unhealthy_Returns503 verifies that requests are refused
+// when the bridge is not healthy.
+func TestServer_PostMCP_Unhealthy_Returns503(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: false}
+	srv := serverForTest(t, br)
+	resp, _ := httpPostJSON(t, t.Context(), srv.URL+"/mcp", []byte(`{"jsonrpc":"2.0","id":1,"method":"x"}`))
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestServer_PostMCP_EmptyBody_Returns400 covers the empty-body branch.
+func TestServer_PostMCP_EmptyBody_Returns400(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true}
+	srv := serverForTest(t, br)
+	resp, _ := httpPostJSON(t, t.Context(), srv.URL+"/mcp", nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestServer_PostMCP_InvalidJSON_Returns400 covers the JSON-validation branch.
+func TestServer_PostMCP_InvalidJSON_Returns400(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true}
+	srv := serverForTest(t, br)
+	resp, _ := httpPostJSON(t, t.Context(), srv.URL+"/mcp", []byte(`not json`))
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestServer_Healthz_POST_Returns405 verifies POST on /healthz is rejected.
+func TestServer_Healthz_POST_Returns405(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true}
+	srv := serverForTest(t, br)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/healthz", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+// TestNewServer_Validates rejects missing required Config fields.
+func TestNewServer_Validates(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewServer(Config{ListenAddr: loopbackEphemeral})
+	require.Error(t, err)
+
+	_, err = NewServer(Config{Bridge: &fakeBridge{}})
+	require.Error(t, err)
+}
+
+// TestServer_PostMCP_NonPOST_Returns405 verifies method-not-allowed for GETs.
+func TestServer_PostMCP_NonPOST_Returns405(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true}
+	srv := serverForTest(t, br)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/mcp", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+// TestServer_Healthz_HealthyAndUnhealthy verifies /healthz mirrors bridge state.
+func TestServer_Healthz_HealthyAndUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true}
+	srv := serverForTest(t, br)
+
+	resp, _ := httpGet(t, t.Context(), srv.URL+"/healthz")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	br.mu.Lock()
+	br.healthy = false
+	br.mu.Unlock()
+	resp, _ = httpGet(t, t.Context(), srv.URL+"/healthz")
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestServer_Shutdown_DrainsInflight verifies in-flight requests complete
+// before Shutdown returns and new requests are rejected during drain.
+func TestServer_Shutdown_DrainsInflight(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	br := &fakeBridge{healthy: true, send: func(ctx context.Context, frame []byte) ([]byte, error) {
+		<-release
+		return []byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`), nil
+	}}
+	srv := serverForTest(t, br)
+
+	type result struct {
+		status int
+		body   []byte
+	}
+	results := make(chan result, 1)
+	go func() {
+		resp, body := httpPostJSON(t, t.Context(), srv.URL+"/mcp", []byte(`{"jsonrpc":"2.0","id":1,"method":"x"}`))
+		results <- result{status: resp.StatusCode, body: body}
+	}()
+
+	require.Eventually(t, func() bool { return srv.InFlight() == 1 }, time.Second, 5*time.Millisecond)
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		shutdownDone <- srv.Shutdown(shutdownCtx)
+	}()
+
+	close(release)
+	require.NoError(t, <-shutdownDone)
+	r := <-results
+	require.Equal(t, http.StatusOK, r.status)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`, string(r.body))
+}
+
+// TestServer_SeparateHealthPort_Listens verifies that when a separate health
+// port is configured, /healthz is served on it and the main listener does not
+// expose it.
+func TestServer_SeparateHealthPort_Listens(t *testing.T) {
+	t.Parallel()
+
+	br := &fakeBridge{healthy: true}
+	srv, err := NewServer(Config{
+		Bridge:     br,
+		ListenAddr: loopbackEphemeral,
+		HealthAddr: loopbackEphemeral,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, srv.Start(t.Context()))
+	t.Cleanup(func() {
+		_ = srv.Shutdown(context.Background())
+	})
+
+	require.NotNil(t, srv.Addr())
+	require.NotNil(t, srv.HealthAddr())
+
+	resp, _ := httpGet(t, t.Context(), "http://"+srv.HealthAddr().String()+"/healthz")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp, _ = httpGet(t, t.Context(), "http://"+srv.Addr().String()+"/healthz")
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// serverForTest constructs and starts a Server bound to an ephemeral port and
+// returns it. The server is shut down via t.Cleanup.
+type testServer struct {
+	URL string
+	*Server
+}
+
+func serverForTest(t *testing.T, br BridgeIface) *testServer {
+	t.Helper()
+	srv, err := NewServer(Config{
+		Bridge:     br,
+		ListenAddr: loopbackEphemeral,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, srv.Start(t.Context()))
+	t.Cleanup(func() {
+		_ = srv.Shutdown(context.Background())
+	})
+	addr := srv.Addr().String()
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, time.Second, 5*time.Millisecond)
+	return &testServer{URL: "http://" + addr, Server: srv}
+}
+
+func httpGet(t *testing.T, ctx context.Context, url string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, data
+}

--- a/cmd/musterstdio/testhelpers_test.go
+++ b/cmd/musterstdio/testhelpers_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	envTestChild       = "MUSTERSTDIO_TEST_CHILD"
+	envTestChildMode   = "MUSTERSTDIO_TEST_CHILD_MODE"
+	envTestChildStderr = "MUSTERSTDIO_TEST_CHILD_STDERR"
+
+	flagChildCommand = "--child-command"
+	flagChildArg     = "--child-arg"
+	flagChildEnv     = "--child-env"
+	flagListenPort   = "--listen-port"
+
+	loopbackEphemeral = "127.0.0.1:0"
+)
+
+// TestMain re-executes this binary as a fake stdio MCP child when the
+// envTestChild env var is set so we never depend on an external helper.
+func TestMain(m *testing.M) {
+	if os.Getenv(envTestChild) == "1" {
+		fakeChildMain()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// fakeChildMain implements behaviors used by tests, controlled via
+// envTestChildMode:
+//
+//	"echo"        — for each request frame, reply with a result echoing params
+//	"slow"        — sleep before responding (used to test cancellation/drain)
+//	"crash"       — exit non-zero before reading anything
+//	"ignore_term" — install handler that ignores SIGTERM so the shim falls back to SIGKILL
+//	"out_of_order" — buffer up to 2 requests and respond in reverse order
+func fakeChildMain() {
+	mode := os.Getenv(envTestChildMode)
+	if msg := os.Getenv(envTestChildStderr); msg != "" {
+		_, _ = fmt.Fprintln(os.Stderr, msg)
+	}
+	switch mode {
+	case "crash":
+		os.Exit(7)
+	case "ignore_term":
+		ignoreSIGTERM()
+	}
+
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer func() { _ = out.Flush() }()
+
+	pending := make([][]byte, 0, 2)
+	for {
+		line, err := in.ReadBytes('\n')
+		if len(line) > 0 {
+			line = bytes.TrimRight(line, "\n")
+			respond := func(req []byte) {
+				resp, hasID := buildResponse(req)
+				if !hasID {
+					return
+				}
+				if mode == "slow" {
+					time.Sleep(200 * time.Millisecond)
+				}
+				_, _ = out.Write(resp)
+				_ = out.WriteByte('\n')
+				_ = out.Flush()
+			}
+			if mode == "out_of_order" {
+				pending = append(pending, append([]byte(nil), line...))
+				if len(pending) == 2 {
+					respond(pending[1])
+					respond(pending[0])
+					pending = pending[:0]
+				}
+			} else {
+				respond(line)
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func buildResponse(req []byte) ([]byte, bool) {
+	var probe struct {
+		ID     *json.RawMessage `json:"id,omitempty"`
+		Method string           `json:"method,omitempty"`
+		Params json.RawMessage  `json:"params,omitempty"`
+	}
+	if err := json.Unmarshal(req, &probe); err != nil {
+		return nil, false
+	}
+	if probe.ID == nil {
+		return nil, false
+	}
+	params := probe.Params
+	if len(params) == 0 {
+		params = json.RawMessage(`null`)
+	}
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"echo":%s,"method":%q}}`,
+		string(*probe.ID), string(params), probe.Method)
+	return []byte(body), true
+}
+
+// ignoreSIGTERM installs a signal handler that swallows SIGTERM so the shim
+// has to fall back to SIGKILL when stopping the child.
+func ignoreSIGTERM() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGTERM)
+	go func() {
+		for range ch {
+			// drop
+		}
+	}()
+}
+
+// buildShimBinary compiles cmd/musterstdio into a temp directory and returns
+// the resulting binary path. Tests that need a real subprocess use this; pure
+// unit tests use the in-process API instead.
+func buildShimBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "musterstdio")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Run(), "go build failed: %s", stderr.String())
+	return bin
+}
+
+func waitForHealth(t *testing.T, url string, deadline time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return false
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, deadline, 10*time.Millisecond, "shim never became healthy at %s", url)
+}
+
+// runChildArgs returns the cmd/args/env that re-exec the test binary as the
+// fake child in the given mode.
+func runChildArgs(mode string) (string, []string, []string) {
+	env := []string{envTestChild + "=1", envTestChildMode + "=" + mode}
+	return os.Args[0], []string{"-test.run=ZZZ_NoRealTests_ZZZ"}, env
+}
+
+// childFlagsFor returns flags that point the shim at the fake child running
+// in the given mode.
+func childFlagsFor(t *testing.T, mode string, listenPort int) []string {
+	t.Helper()
+	cmd, args, env := runChildArgs(mode)
+	flags := []string{
+		flagChildCommand, cmd,
+		flagListenPort, strconv.Itoa(listenPort),
+	}
+	for _, a := range args {
+		flags = append(flags, flagChildArg, a)
+	}
+	for _, e := range env {
+		flags = append(flags, flagChildEnv, e)
+	}
+	return flags
+}
+
+// captured is a thread-safe collector for stderr/log output read in assertions.
+type captured struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (c *captured) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+func (c *captured) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+// httpPostJSON is a tiny helper around POST /mcp.
+func httpPostJSON(t *testing.T, ctx context.Context, url string, body []byte) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, data
+}
+
+// parseEnv converts KEY=VALUE strings into a map.
+func parseEnv(pairs []string) map[string]string {
+	m := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		k, v, ok := strings.Cut(p, "=")
+		if !ok {
+			continue
+		}
+		m[k] = v
+	}
+	return m
+}
+
+// testLogger returns a slog logger that writes through the test's logger so
+// failed-test output remains readable.
+func testLogger(t *testing.T) *slog.Logger {
+	return slog.New(slog.NewTextHandler(testWriter{t: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(bytes.TrimRight(p, "\n")))
+	return len(p), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/reconciler/translator/shimimage.go
+++ b/internal/reconciler/translator/shimimage.go
@@ -1,0 +1,14 @@
+package translator
+
+// ShimImage is the OCI reference of the musterstdio shim image emitted by the
+// K8s emitter for every stdio-derived backend. It is pinned to the muster
+// version this binary was built against so the shim deployed in cluster mode
+// matches the reconciler that wrote the Deployment.
+//
+// The image is built from Dockerfile.musterstdio in this repository and
+// published as part of the muster release pipeline (see .goreleaser.yaml's
+// musterstdio build target).
+//
+// Bumping the muster version is a deliberate change: update this constant in
+// the same PR that bumps go.mod / CHANGELOG.md.
+const ShimImage = "gsoci.azurecr.io/giantswarm/musterstdio:dev"

--- a/internal/reconciler/translator/shimimage_test.go
+++ b/internal/reconciler/translator/shimimage_test.go
@@ -1,0 +1,20 @@
+package translator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/reconciler/translator"
+)
+
+// TestShimImage_RegistryAndRepository documents the contract callers depend
+// on so a sloppy rename here is caught immediately.
+func TestShimImage_RegistryAndRepository(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, strings.HasPrefix(translator.ShimImage, "gsoci.azurecr.io/giantswarm/musterstdio"),
+		"shim image must live in the giantswarm registry under the musterstdio repo, got %q", translator.ShimImage)
+	require.Contains(t, translator.ShimImage, ":", "shim image must be tagged, got %q", translator.ShimImage)
+}


### PR DESCRIPTION
**Step 5 of the 10-PR translator series** ([plan](../CLAUDE.md)).

Standalone Go binary that wraps an stdio MCP child as MCP-over-StreamableHTTP. It is the shim image referenced by the translator stack for `spec.type: stdio` MCPServer specs — filesystem mode (PR 7+) will run it as a local subprocess, cluster mode (PR 3) as a `Deployment`+`Service`.

## What's in

| Path | Purpose |
|---|---|
| `cmd/musterstdio/main.go` | `Run(ctx, args, stderr, logger)` + `main()` wired to `signal.NotifyContext` for SIGTERM/SIGINT |
| `cmd/musterstdio/server.go` | HTTP listener: `POST /mcp`, `GET /healthz`, optional separate health port, drain-on-shutdown |
| `cmd/musterstdio/bridge.go` | `os/exec` child + JSON-RPC frame demuxer keyed on the `id` field; SIGTERM → wait → SIGKILL fallback |
| `cmd/musterstdio/*_test.go` | Unit + scenario + end-to-end + goroutine-leak tests (≥80% coverage; race-clean) |
| `Dockerfile.musterstdio` | Distroless multi-arch (`linux/amd64`, `linux/arm64`) image |
| `.goreleaser.yaml` / `Makefile.custom.mk` | Release pipeline + `make musterstdio-image[-multiarch]` targets |
| `internal/reconciler/translator/shimimage.go` | Single `ShimImage` constant pinned to the muster version |

## Behaviour

- Flags: `--child-command`, `--child-arg` (repeatable), `--child-env KEY=VAL` (repeatable), `--listen-port` (default 8080), `--health-port` (optional, separate listener), `--shutdown-timeout`, `--startup-timeout`, `--max-request-bytes`, `--version`
- `POST /mcp` reads the body as a JSON-RPC frame, writes it as a `\n`-terminated line to the child's stdin, and waits for the response frame carrying the same `id`. Notifications (no `id`) return `202 Accepted`.
- `GET /healthz` reports `200` while the child is running and stdout has not errored, `503` otherwise.
- Concurrent POSTs are multiplexed by JSON-RPC `id`; out-of-order responses from the child are routed back to the correct caller.
- SIGTERM stops accepting new HTTP requests, drains in-flight Sends, closes the child's stdin, sends SIGTERM, waits up to `--shutdown-timeout`, then SIGKILLs.
- Child crash → `Run` returns a wrapped error → exit non-zero with a diagnostic.

## Tests

- `bridge_test.go` — request/response, notification, concurrent out-of-order multiplexing, context-cancel cleanup, child exit, SIGKILL fallback, invalid frame.
- `server_test.go` — happy path, notification 202, bridge-error 502, unhealthy 503, empty/invalid body 400, method-not-allowed 405, in-flight drain on shutdown, separate health listener.
- `scenarios_test.go` — Given/When/Then BDD-style end-to-end coverage against the in-process fake stdio child (CRD-driven YAML scenarios for the shim land in PR 6/9 once the reconciler wires it through `MCPServer`).
- `main_test.go` — flag validation, `--version`, in-process `Run` lifecycle, real-subprocess SIGTERM clean-exit, real-subprocess child crash, `goleak.VerifyNone` after shutdown.

Coverage: **81.9%** on the new package. `make test -race` clean. `make lint` introduces 0 new findings (verified against the PR 4 baseline).

## Lint

A tightly scoped `.golangci.yml` exemption covers `gosec G204` in the three files that actually exec subprocesses (`bridge.go` — the whole point of the binary; `main_test.go` and `testhelpers_test.go` — test infra). Everything else under `cmd/musterstdio/` is still scanned.

## Sample HTTP trace

```text
$ musterstdio --child-command /tmp/demo-child.sh --listen-port 0
time=2026-05-18T18:25:49 level=INFO msg="musterstdio ready" version=dev listen_addr=[::]:40777 child=/tmp/demo-child.sh

$ curl -i http://[::]:40777/healthz
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 15

{"status":"ok"}

$ curl -i -H 'Content-Type: application/json' \
       -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
       http://[::]:40777/mcp
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 61

{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo"}]}}

$ curl -i -H 'Content-Type: application/json' \
       -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
       http://[::]:40777/mcp
HTTP/1.1 202 Accepted
Content-Length: 0

$ kill -TERM <pid>   # clean exit, no leaked goroutines
```

## LOC

| | Lines |
|---|--:|
| Added (production) | ~790 (`bridge.go` 331 + `server.go` 245 + `main.go` 201 + `doc.go` 6 + `shimimage.go` 14) |
| Added (tests) | ~1,210 |
| Build / release wiring | `Dockerfile.musterstdio` (33), `.goreleaser.yaml` (+~30), `Makefile.custom.mk` (+~15) |

All production + test files are ≤400 LOC.

## Out of scope (deferred)

- JSON-RPC batch demuxing — single frame in / single frame out is the MCP stdio shape today; batch support lands when an actual client needs it.
- Server-to-client notification streaming — current bridge drops unmatched frames; the StreamableHTTP spec supports it via SSE upgrade, which a future PR can layer over `bridge.deliver`.