### PR TITLE
refactor(cli,api): share resource-type and JSON-key constants

### DIFF
--- a/cmd/mcp_types.go
+++ b/cmd/mcp_types.go
@@ -1,21 +1,26 @@
 package cmd
 
-const (
-	resourceTypeService            = "service"
-	resourceTypeServices           = "services"
-	resourceTypeMCPServer          = "mcpserver"
-	resourceTypeMCPServers         = "mcpservers"
-	resourceTypeWorkflow           = "workflow"
-	resourceTypeWorkflows          = "workflows"
-	resourceTypeWorkflowExecution  = "workflow-execution"
-	resourceTypeWorkflowExecutions = "workflow-executions"
+import "github.com/giantswarm/muster/internal/api"
 
-	mcpPrimitiveTool      = "tool"
-	mcpPrimitiveTools     = "tools"
-	mcpPrimitiveResource  = "resource"
-	mcpPrimitiveResources = "resources"
-	mcpPrimitivePrompt    = "prompt"
-	mcpPrimitivePrompts   = "prompts"
+// Local aliases for resource-type identifiers so the existing cmd/*
+// switch statements and slice literals stay terse. Source of truth lives
+// in internal/api so internal/cli can reference the same identifiers.
+const (
+	resourceTypeService            = api.ResourceTypeService
+	resourceTypeServices           = api.ResourceTypeServices
+	resourceTypeMCPServer          = api.ResourceTypeMCPServer
+	resourceTypeMCPServers         = api.ResourceTypeMCPServers
+	resourceTypeWorkflow           = api.ResourceTypeWorkflow
+	resourceTypeWorkflows          = api.ResourceTypeWorkflows
+	resourceTypeWorkflowExecution  = api.ResourceTypeWorkflowExecution
+	resourceTypeWorkflowExecutions = api.ResourceTypeWorkflowExecutions
+
+	mcpPrimitiveTool      = api.MCPPrimitiveTool
+	mcpPrimitiveTools     = api.MCPPrimitiveTools
+	mcpPrimitiveResource  = api.MCPPrimitiveResource
+	mcpPrimitiveResources = api.MCPPrimitiveResources
+	mcpPrimitivePrompt    = api.MCPPrimitivePrompt
+	mcpPrimitivePrompts   = api.MCPPrimitivePrompts
 )
 
 // mcpPrimitiveTypes maps MCP primitive type aliases (singular and plural)

--- a/internal/api/json_keys.go
+++ b/internal/api/json_keys.go
@@ -1,0 +1,38 @@
+package api
+
+// JSON Schema specification keys used when building MCP/OpenAPI-style
+// schemas as map[string]any. These are wire-format strings: renaming them
+// would break the protocol.
+const (
+	SchemaKeyType                 = "type"
+	SchemaKeyDescription          = "description"
+	SchemaKeyProperties           = "properties"
+	SchemaKeyItems                = "items"
+	SchemaKeyRequired             = "required"
+	SchemaKeyDefault              = "default"
+	SchemaKeyEnum                 = "enum"
+	SchemaKeyAdditionalProperties = "additionalProperties"
+)
+
+// Field names used as keys when emitting muster API responses through
+// untyped map[string]any (status payloads, tool results, mock responses).
+const (
+	FieldName        = "name"
+	FieldStatus      = "status"
+	FieldState       = "state"
+	FieldHealth      = "health"
+	FieldCommand     = "command"
+	FieldArgs        = "args"
+	FieldTools       = "tools"
+	FieldSteps       = "steps"
+	FieldError       = "error"
+	FieldSuccess     = "success"
+	FieldMessage     = "message"
+	FieldServer      = "server"
+	FieldMimeType    = "mimeType"
+	FieldExecutionID = "execution_id"
+	FieldInputSchema = "inputSchema"
+	FieldURI         = "uri"
+	FieldLabel       = "label"
+	FieldID          = "id"
+)

--- a/internal/api/resource_types.go
+++ b/internal/api/resource_types.go
@@ -1,0 +1,33 @@
+package api
+
+// Resource-type identifiers used by the muster CLI and exposed as keys in
+// list/get JSON responses. Each kind has a singular form (CLI argument,
+// detail-response key) and a plural form (list-response wrapper key).
+const (
+	ResourceTypeService            = "service"
+	ResourceTypeServices           = "services"
+	ResourceTypeMCPServer          = "mcpserver"
+	ResourceTypeMCPServers         = "mcpservers"
+	ResourceTypeWorkflow           = "workflow"
+	ResourceTypeWorkflows          = "workflows"
+	ResourceTypeWorkflowExecution  = "workflow-execution"
+	ResourceTypeWorkflowExecutions = "workflow-executions"
+
+	// Response-only wrapper keys. These match the JSON shape emitted by the
+	// muster API; they differ from the singular CLI forms above (e.g. the
+	// API returns "mcpServers" camelCase, while the CLI accepts "mcpserver").
+	ResponseKeyMCPServer      = "mcpServer"
+	ResponseKeyMCPServers     = "mcpServers"
+	ResponseKeyServiceClass   = "serviceClass"
+	ResponseKeyServiceClasses = "serviceClasses"
+	ResponseKeyExecutions     = "executions"
+
+	// MCP primitive aliases recognised at the CLI surface. Singular and
+	// plural both resolve to the singular canonical form.
+	MCPPrimitiveTool      = "tool"
+	MCPPrimitiveTools     = "tools"
+	MCPPrimitiveResource  = "resource"
+	MCPPrimitiveResources = "resources"
+	MCPPrimitivePrompt    = "prompt"
+	MCPPrimitivePrompts   = "prompts"
+)

--- a/internal/cli/columns.go
+++ b/internal/cli/columns.go
@@ -1,0 +1,9 @@
+package cli
+
+// Table column header labels used by the kubectl-style table output.
+const (
+	headerName        = "NAME"
+	headerDescription = "DESCRIPTION"
+	headerValue       = "VALUE"
+	headerProperty    = "PROPERTY"
+)

--- a/internal/cli/mcp_output.go
+++ b/internal/cli/mcp_output.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/giantswarm/muster/internal/api"
 	pkgstrings "github.com/giantswarm/muster/pkg/strings"
 
 	"gopkg.in/yaml.v3"
@@ -114,9 +115,9 @@ func FormatMCPToolsWithOptions(tools []MCPTool, format OutputFormat, noHeaders b
 	// Wide mode: add SERVER column and show input schema summary
 	isWide := format == OutputFormatWide
 	if isWide {
-		tw.SetHeaders([]string{"NAME", "DESCRIPTION", "SERVER", "ARGS"})
+		tw.SetHeaders([]string{headerName, headerDescription, "SERVER", "ARGS"})
 	} else {
-		tw.SetHeaders([]string{"NAME", "DESCRIPTION"})
+		tw.SetHeaders([]string{headerName, headerDescription})
 	}
 	tw.SetNoHeaders(noHeaders)
 
@@ -213,9 +214,9 @@ func FormatMCPResourcesWithOptions(resources []MCPResource, format OutputFormat,
 	// Wide mode: add NAME column
 	isWide := format == OutputFormatWide
 	if isWide {
-		tw.SetHeaders([]string{"URI", "NAME", "DESCRIPTION", "MIME TYPE"})
+		tw.SetHeaders([]string{"URI", headerName, headerDescription, "MIME TYPE"})
 	} else {
-		tw.SetHeaders([]string{"URI", "DESCRIPTION", "MIME TYPE"})
+		tw.SetHeaders([]string{"URI", headerDescription, "MIME TYPE"})
 	}
 	tw.SetNoHeaders(noHeaders)
 
@@ -291,9 +292,9 @@ func FormatMCPPromptsWithOptions(prompts []MCPPrompt, format OutputFormat, noHea
 	// Wide mode: add ARGS column
 	isWide := format == OutputFormatWide
 	if isWide {
-		tw.SetHeaders([]string{"NAME", "DESCRIPTION", "ARGS"})
+		tw.SetHeaders([]string{headerName, headerDescription, "ARGS"})
 	} else {
-		tw.SetHeaders([]string{"NAME", "DESCRIPTION"})
+		tw.SetHeaders([]string{headerName, headerDescription})
 	}
 	tw.SetNoHeaders(noHeaders)
 
@@ -341,9 +342,9 @@ func countPromptArgs(prompt MCPPrompt) string {
 func FormatMCPToolDetail(tool MCPTool, format OutputFormat) error {
 	if format == OutputFormatJSON || format == OutputFormatYAML {
 		toolInfo := map[string]interface{}{
-			"name":        tool.Name,
-			"description": tool.Description,
-			"inputSchema": tool.InputSchema,
+			api.FieldName:            tool.Name,
+			api.SchemaKeyDescription: tool.Description,
+			api.FieldInputSchema:     tool.InputSchema,
 		}
 		if format == OutputFormatJSON {
 			return outputJSON(toolInfo)
@@ -389,7 +390,7 @@ func renderSchemaProperties(properties map[string]interface{}, required []string
 
 		// Get type
 		propType := "any" //nolint:goconst
-		if t, ok := propMap["type"].(string); ok {
+		if t, ok := propMap[api.SchemaKeyType].(string); ok {
 			propType = t
 		}
 
@@ -403,7 +404,7 @@ func renderSchemaProperties(properties map[string]interface{}, required []string
 		fmt.Printf("%s%s (%s%s)\n", indent, name, propType, requiredStr)
 
 		// Description
-		if desc, ok := propMap["description"].(string); ok && desc != "" {
+		if desc, ok := propMap[api.SchemaKeyDescription].(string); ok && desc != "" {
 			// Wrap long descriptions
 			wrapped := wrapText(desc, 60)
 			for i, line := range wrapped {
@@ -416,7 +417,7 @@ func renderSchemaProperties(properties map[string]interface{}, required []string
 		}
 
 		// Default value
-		if def, ok := propMap["default"]; ok {
+		if def, ok := propMap[api.SchemaKeyDefault]; ok {
 			fmt.Printf("%s  Default: %v\n", indent, def)
 		}
 
@@ -431,9 +432,9 @@ func renderSchemaProperties(properties map[string]interface{}, required []string
 
 		// Handle nested object properties
 		if propType == "object" { //nolint:goconst
-			if nestedProps, ok := propMap["properties"].(map[string]interface{}); ok {
+			if nestedProps, ok := propMap[api.SchemaKeyProperties].(map[string]interface{}); ok {
 				var nestedRequired []string
-				if req, ok := propMap["required"].([]interface{}); ok {
+				if req, ok := propMap[api.SchemaKeyRequired].([]interface{}); ok {
 					for _, r := range req {
 						if s, ok := r.(string); ok {
 							nestedRequired = append(nestedRequired, s)
@@ -444,7 +445,7 @@ func renderSchemaProperties(properties map[string]interface{}, required []string
 				renderSchemaProperties(nestedProps, nestedRequired, indent+"    ")
 			}
 			// Handle additionalProperties for map-like objects
-			if addProps, ok := propMap["additionalProperties"].(map[string]interface{}); ok {
+			if addProps, ok := propMap[api.SchemaKeyAdditionalProperties].(map[string]interface{}); ok {
 				fmt.Printf("%s  Value Schema:\n", indent)
 				renderAdditionalProperties(addProps, indent+"    ")
 			}
@@ -452,7 +453,7 @@ func renderSchemaProperties(properties map[string]interface{}, required []string
 
 		// Handle array items
 		if propType == "array" {
-			if items, ok := propMap["items"].(map[string]interface{}); ok {
+			if items, ok := propMap[api.SchemaKeyItems].(map[string]interface{}); ok {
 				fmt.Printf("%s  Items:\n", indent)
 				renderArrayItems(items, indent+"    ")
 			}
@@ -463,19 +464,19 @@ func renderSchemaProperties(properties map[string]interface{}, required []string
 // renderAdditionalProperties renders the schema for additionalProperties.
 func renderAdditionalProperties(props map[string]interface{}, indent string) {
 	propType := "any"
-	if t, ok := props["type"].(string); ok {
+	if t, ok := props[api.SchemaKeyType].(string); ok {
 		propType = t
 	}
 	fmt.Printf("%sType: %s\n", indent, propType)
 
-	if desc, ok := props["description"].(string); ok && desc != "" {
+	if desc, ok := props[api.SchemaKeyDescription].(string); ok && desc != "" {
 		fmt.Printf("%sDescription: %s\n", indent, desc)
 	}
 
 	if propType == "object" {
-		if nestedProps, ok := props["properties"].(map[string]interface{}); ok {
+		if nestedProps, ok := props[api.SchemaKeyProperties].(map[string]interface{}); ok {
 			var nestedRequired []string
-			if req, ok := props["required"].([]interface{}); ok {
+			if req, ok := props[api.SchemaKeyRequired].([]interface{}); ok {
 				for _, r := range req {
 					if s, ok := r.(string); ok {
 						nestedRequired = append(nestedRequired, s)
@@ -491,19 +492,19 @@ func renderAdditionalProperties(props map[string]interface{}, indent string) {
 // renderArrayItems renders the schema for array items.
 func renderArrayItems(items map[string]interface{}, indent string) {
 	itemType := "any"
-	if t, ok := items["type"].(string); ok {
+	if t, ok := items[api.SchemaKeyType].(string); ok {
 		itemType = t
 	}
 	fmt.Printf("%sType: %s\n", indent, itemType)
 
-	if desc, ok := items["description"].(string); ok && desc != "" {
+	if desc, ok := items[api.SchemaKeyDescription].(string); ok && desc != "" {
 		fmt.Printf("%sDescription: %s\n", indent, desc)
 	}
 
 	if itemType == "object" {
-		if nestedProps, ok := items["properties"].(map[string]interface{}); ok {
+		if nestedProps, ok := items[api.SchemaKeyProperties].(map[string]interface{}); ok {
 			var nestedRequired []string
-			if req, ok := items["required"].([]interface{}); ok {
+			if req, ok := items[api.SchemaKeyRequired].([]interface{}); ok {
 				for _, r := range req {
 					if s, ok := r.(string); ok {
 						nestedRequired = append(nestedRequired, s)
@@ -549,10 +550,10 @@ func wrapText(text string, width int) []string {
 func FormatMCPResourceDetail(resource MCPResource, format OutputFormat) error {
 	if format == OutputFormatJSON || format == OutputFormatYAML {
 		resourceInfo := map[string]interface{}{
-			"uri":         resource.URI,
-			"name":        resource.Name,
-			"description": resource.Description,
-			"mimeType":    resource.MIMEType,
+			api.FieldURI:             resource.URI,
+			api.FieldName:            resource.Name,
+			api.SchemaKeyDescription: resource.Description,
+			api.FieldMimeType:        resource.MIMEType,
 		}
 		if format == OutputFormatJSON {
 			return outputJSON(resourceInfo)
@@ -578,16 +579,16 @@ func FormatMCPResourceDetail(resource MCPResource, format OutputFormat) error {
 func FormatMCPPromptDetail(prompt MCPPrompt, format OutputFormat) error {
 	if format == OutputFormatJSON || format == OutputFormatYAML {
 		promptInfo := map[string]interface{}{
-			"name":        prompt.Name,
-			"description": prompt.Description,
+			api.FieldName:            prompt.Name,
+			api.SchemaKeyDescription: prompt.Description,
 		}
 		if len(prompt.Arguments) > 0 {
 			args := make([]map[string]interface{}, len(prompt.Arguments))
 			for i, arg := range prompt.Arguments {
 				args[i] = map[string]interface{}{
-					"name":        arg.Name,
-					"description": arg.Description,
-					"required":    arg.Required,
+					api.FieldName:            arg.Name,
+					api.SchemaKeyDescription: arg.Description,
+					api.SchemaKeyRequired:    arg.Required,
 				}
 			}
 			promptInfo["arguments"] = args

--- a/internal/cli/table_builder.go
+++ b/internal/cli/table_builder.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/giantswarm/muster/internal/api"
 )
 
 // TableBuilder handles cell formatting and styling for table display.
@@ -41,9 +43,9 @@ func (b *TableBuilder) FormatCellValuePlain(column string, value interface{}, ro
 	colLower := strings.ToLower(column)
 
 	switch colLower {
-	case "name", "label", "id", "workflow", "execution_id", "workflow_name", "resource_name":
+	case api.FieldName, "label", "id", api.ResourceTypeWorkflow, "execution_id", "workflow_name", "resource_name":
 		return strValue
-	case "health", "status":
+	case api.FieldHealth, api.FieldStatus:
 		// Return "-" for empty health/status values
 		if strValue == "" {
 			return "-"
@@ -53,7 +55,7 @@ func (b *TableBuilder) FormatCellValuePlain(column string, value interface{}, ro
 		return b.formatAvailableStatusPlain(value)
 	case "autostart":
 		return b.formatAutoStartStatusPlain(value)
-	case "state":
+	case api.FieldState:
 		// State represents infrastructure state for MCPServers and services
 		// MCPServer values are context-appropriate: Running/Connected/Starting/Connecting/Stopped/Disconnected/Failed
 		serverType := b.getServerTypeFromContext(rowContext)
@@ -82,19 +84,19 @@ func (b *TableBuilder) FormatCellValuePlain(column string, value interface{}, ro
 		return b.formatDurationPlain(value)
 	case "metadata":
 		return b.formatMetadataPlain(value)
-	case "requiredtools", "tools":
+	case "requiredtools", api.FieldTools:
 		return b.formatToolsListPlain(value)
-	case "description":
+	case api.SchemaKeyDescription:
 		return b.formatDescriptionPlain(strValue)
-	case "steps":
+	case api.FieldSteps:
 		return b.formatStepsPlain(value)
 	case "timeout":
 		// Format timeout values with "s" suffix for seconds
 		return b.formatTimeoutPlain(value)
-	case "url", "command", "uri", "endpoint":
+	case "url", api.FieldCommand, "uri", "endpoint":
 		// Don't truncate URLs, commands, URIs, or endpoints - show full value
 		return strValue
-	case "type", "service_type", "servicetype", "servertype":
+	case api.SchemaKeyType, "service_type", "servicetype", "servertype":
 		// Type fields are typically short, don't truncate
 		return strValue
 	default:
@@ -575,7 +577,7 @@ func (b *TableBuilder) formatObjectPlain(obj map[string]interface{}) string {
 		return "{}"
 	}
 
-	displayFields := []string{"name", "type", "status", "id"}
+	displayFields := []string{api.FieldName, api.SchemaKeyType, api.FieldStatus, "id"}
 	for _, field := range displayFields {
 		if value, exists := obj[field]; exists && value != nil {
 			return fmt.Sprintf("%v", value)

--- a/internal/cli/table_formatter.go
+++ b/internal/cli/table_formatter.go
@@ -6,15 +6,17 @@ import (
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/giantswarm/muster/internal/api"
 )
 
 // columnDisplayNames maps internal field names to user-friendly column headers.
 // This allows consistent presentation of column names across CLI output.
 var columnDisplayNames = map[string]map[string]string{
-	"mcpServers": {
+	api.ResponseKeyMCPServers: {
 		"sessionAuth": "session", // Session auth status shown as "SESSION" per issue #337
 	},
-	"mcpServer": {
+	api.ResponseKeyMCPServer: {
 		"sessionAuth": "session",
 	},
 }
@@ -33,20 +35,20 @@ var columnDisplayNames = map[string]map[string]string{
 //   - statusMessage: Shown in footer notes instead of column
 //   - consecutiveFailures, lastAttempt, nextRetryAfter: Diagnostic fields for verbose/debug use
 var unwantedColumnsByResourceType = map[string][]string{
-	"mcpServers": {
-		"args", "command", "url", "env", "headers", "timeout", "toolPrefix",
-		"error", "description", "auth", "health", "statusMessage",
+	api.ResponseKeyMCPServers: {
+		api.FieldArgs, api.FieldCommand, "url", "env", "headers", "timeout", "toolPrefix",
+		api.FieldError, api.SchemaKeyDescription, "auth", api.FieldHealth, "statusMessage",
 		"consecutiveFailures", "lastAttempt", "nextRetryAfter",
 	},
-	"mcpServer": {
-		"args", "command", "url", "env", "headers", "timeout", "toolPrefix",
-		"error", "description", "auth", "health", "statusMessage",
+	api.ResponseKeyMCPServer: {
+		api.FieldArgs, api.FieldCommand, "url", "env", "headers", "timeout", "toolPrefix",
+		api.FieldError, api.SchemaKeyDescription, "auth", api.FieldHealth, "statusMessage",
 		"consecutiveFailures", "lastAttempt", "nextRetryAfter",
 	},
-	"service": {
+	api.ResourceTypeService: {
 		"metadata", // Nested data doesn't display well in list view
 	},
-	"services": {
+	api.ResourceTypeServices: {
 		"metadata", // Nested data doesn't display well in list view
 	},
 }
@@ -289,7 +291,12 @@ func (f *TableFormatter) printServerStatusNotes(data map[string]interface{}) {
 // Returns:
 //   - string: The key name containing array data, or empty string if none found
 func (f *TableFormatter) findArrayKey(data map[string]interface{}) string {
-	arrayKeys := []string{"services", "serviceClasses", "mcpServers", "workflows", "executions", "capabilities", "items", "results", "tools", "resources", "prompts"}
+	arrayKeys := []string{
+		api.ResourceTypeServices, api.ResponseKeyServiceClasses, api.ResponseKeyMCPServers,
+		api.ResourceTypeWorkflows, api.ResponseKeyExecutions,
+		"capabilities", api.SchemaKeyItems, "results",
+		api.MCPPrimitiveTools, api.MCPPrimitiveResources, api.MCPPrimitivePrompts,
+	}
 
 	for _, key := range arrayKeys {
 		if value, exists := data[key]; exists {
@@ -344,7 +351,7 @@ func (f *TableFormatter) formatTableFromArray(data []interface{}) error {
 			row := make([]string, len(columns))
 			for i, col := range columns {
 				// Use context-aware formatting for MCP servers (plain text version)
-				if resourceType == "mcpServers" || resourceType == "mcpServer" {
+				if resourceType == api.ResponseKeyMCPServers || resourceType == api.ResponseKeyMCPServer {
 					row[i] = f.builder.FormatCellValuePlain(col, itemMap[col], itemMap)
 				} else {
 					row[i] = f.builder.FormatCellValuePlain(col, itemMap[col], nil)
@@ -396,7 +403,7 @@ func (f *TableFormatter) optimizeColumns(objects []interface{}) []string {
 	sample := objects[0].(map[string]interface{})
 
 	// Always prioritize name/ID fields first
-	nameFields := []string{"name", "label", "id", "workflow"}
+	nameFields := []string{api.FieldName, "label", "id", api.ResourceTypeWorkflow}
 	var columns []string
 
 	// Add the primary identifier first (Name/ID/Label)
@@ -409,21 +416,21 @@ func (f *TableFormatter) optimizeColumns(objects []interface{}) []string {
 
 	// Define priority columns for different resource types (excluding name fields already added)
 	priorityColumns := map[string][]string{
-		"service":        {"health", "state", "service_type"},
-		"services":       {"health", "state", "service_type"},
-		"serviceClasses": {"available", "serviceType", "description", "requiredTools"},
-		"serviceClass":   {"available", "serviceType", "description", "requiredTools"},
-		"mcpServers":     {"state", "type", "sessionAuth"},
-		"mcpServer":      {"state", "type", "sessionAuth"},
-		"workflows":      {"status", "description", "steps"},
-		"workflow":       {"status", "description", "steps"},
-		"executions":     {"workflow_name", "status", "started_at", "duration_ms"},
-		"execution":      {"workflow_name", "status", "started_at", "duration_ms"},
-		"event":          {"timestamp", "type", "resource_type", "resource_name", "reason", "message"},
-		"mcpTool":        {"description"},
-		"mcpResource":    {"uri", "description", "mimeType"},
-		"mcpPrompt":      {"description"},
-		"generic":        {"status", "type", "description", "available"},
+		api.ResourceTypeService:       {api.FieldHealth, api.FieldState, "service_type"},
+		api.ResourceTypeServices:      {api.FieldHealth, api.FieldState, "service_type"},
+		api.ResponseKeyServiceClasses: {"available", "serviceType", api.SchemaKeyDescription, "requiredTools"},
+		api.ResponseKeyServiceClass:   {"available", "serviceType", api.SchemaKeyDescription, "requiredTools"},
+		api.ResponseKeyMCPServers:     {api.FieldState, api.SchemaKeyType, "sessionAuth"},
+		api.ResponseKeyMCPServer:      {api.FieldState, api.SchemaKeyType, "sessionAuth"},
+		api.ResourceTypeWorkflows:     {api.FieldStatus, api.SchemaKeyDescription, api.FieldSteps},
+		api.ResourceTypeWorkflow:      {api.FieldStatus, api.SchemaKeyDescription, api.FieldSteps},
+		api.ResponseKeyExecutions:     {"workflow_name", api.FieldStatus, "started_at", "duration_ms"},
+		"execution":                   {"workflow_name", api.FieldStatus, "started_at", "duration_ms"},
+		"event":                       {"timestamp", api.SchemaKeyType, "resource_type", "resource_name", "reason", api.FieldMessage},
+		"mcpTool":                     {api.SchemaKeyDescription},
+		"mcpResource":                 {"uri", api.SchemaKeyDescription, api.FieldMimeType},
+		"mcpPrompt":                   {api.SchemaKeyDescription},
+		"generic":                     {api.FieldStatus, api.SchemaKeyType, api.SchemaKeyDescription, "available"},
 	}
 
 	// Extended columns for wide mode (-o wide)
@@ -874,7 +881,7 @@ func (f *TableFormatter) displayWorkflowInputs(workflowData map[string]interface
 	fmt.Println("\nInput Args:")
 
 	tw := NewPlainTableWriter(os.Stdout)
-	tw.SetHeaders([]string{"ARGUMENT", "TYPE", "DESCRIPTION", "REQUIRED"})
+	tw.SetHeaders([]string{"ARGUMENT", "TYPE", headerDescription, "REQUIRED"})
 	tw.SetNoHeaders(f.options.NoHeaders)
 
 	// Sort arg names
@@ -948,7 +955,7 @@ func (f *TableFormatter) displayWorkflowSteps(workflowData map[string]interface{
 	fmt.Println("\nWorkflow Steps:")
 
 	tw := NewPlainTableWriter(os.Stdout)
-	tw.SetHeaders([]string{"STEP", "TOOL", "DESCRIPTION"})
+	tw.SetHeaders([]string{"STEP", "TOOL", headerDescription})
 	tw.SetNoHeaders(f.options.NoHeaders)
 
 	for i, step := range steps {


### PR DESCRIPTION
## Summary

Stacked on #701.

Lifts the resource-type identifiers (\`service\`, \`mcpserver\`, \`workflow\`, \`workflow-execution\`, ...) from \`cmd/mcp_types.go\` to \`internal/api/resource_types.go\` so \`internal/cli/table_formatter.go\` and friends reference the same source of truth instead of duplicating the literal strings.

Adds two more constants packages alongside:
- \`internal/api/json_keys.go\` — JSON-Schema spec keys (\`description\`, \`properties\`, \`items\`, \`required\`, \`default\`, \`enum\`, \`additionalProperties\`) and muster API response field names (\`name\`, \`status\`, \`state\`, \`health\`, \`command\`, \`mimeType\`, \`inputSchema\`, ...).
- \`internal/cli/columns.go\` — kubectl-style table header labels (\`headerName\`, \`headerDescription\`, ...).

Sweeps \`internal/cli/{table_formatter,table_builder,mcp_output}.go\` to reference the named constants instead of repeated string literals. Applied consistently to every occurrence in those files, not only the ones goconst flagged, so the \`description\`/\`name\` field-name vocabulary has a single canonical symbol rather than a mix of literals and constants.

\`cmd/mcp_types.go\` keeps short package-local aliases (\`resourceTypeService = api.ResourceTypeService\`, etc.) so the existing \`cmd/*.go\` switches and slice literals stay terse.