### PR TITLE
refactor: extract JSON Schema, OAuth wire, and workflow op constants

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,14 +16,6 @@ linters:
         - logging.WarnWithAttrs
         - logging.ErrorWithAttrs
         - fmt.Errorf
-      # JSON-key / column-name vocabulary that's defined by an external spec
-      # (JSON Schema, MCP, OpenAPI) or by CLI table headers. Extracting these
-      # to constants would only rename them, not improve safety. ArgMetadata
-      # type vocabulary is handled by the api.ArgType enum instead.
-      ignore-string-values:
-        - '^(description|additionalProperties|properties|items|required|default|enum)$'
-        - '^(name|status|state|health|command|args|tools|services|service|workflow|workflows|executions|mcpServer|mcpServers|mimeType)$'
-        - '^(NAME|DESCRIPTION|VALUE|PROPERTY)$'
 
   exclusions:
     rules:
@@ -36,3 +28,16 @@ linters:
         linters:
           - gosec
         text: "G101"
+      # pkg/oauth/wire.go is a constants-only file holding RFC 6749/6750/8693
+      # vocabulary; G101 heuristically flags the grant-type URN string.
+      - path: pkg/oauth/wire\.go
+        linters:
+          - gosec
+        text: "G101"
+      # internal/testing/mock/* is the mock OAuth server used by BDD tests.
+      # It must honor the OAuth redirect_uri parameter, which gosec flags as
+      # an open redirect; the mock is never bundled into the production image.
+      - path: internal/testing/mock/.*\.go
+        linters:
+          - gosec
+        text: "G710"

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -172,7 +173,7 @@ func (s *Server) handleReconnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("reconnect: %v", err), http.StatusInternalServerError)
 		return
 	}
-	http.Redirect(w, r, "/sessions/"+id, http.StatusSeeOther)
+	http.Redirect(w, r, "/sessions/"+url.PathEscape(id), http.StatusSeeOther)
 }
 
 // render buffers the template output so a template error produces a clean

--- a/internal/agent/commands/constants.go
+++ b/internal/agent/commands/constants.go
@@ -1,0 +1,9 @@
+package commands
+
+// Stringly-typed boolean literals produced by the CLI's positional argument
+// parsing. The CLI accepts case-insensitive "true"/"false"; commands compare
+// lowercased input against these.
+const (
+	boolStringTrue  = "true"
+	boolStringFalse = "false"
+)

--- a/internal/agent/commands/filter_command.go
+++ b/internal/agent/commands/filter_command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/metatools"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -31,8 +32,8 @@ func (f *FilterCommand) Execute(ctx context.Context, args []string) error {
 	}
 
 	target := strings.ToLower(parsed[0])
-	if target != "tools" {
-		return f.validateTarget(target, []string{"tools"})
+	if target != api.FieldTools {
+		return f.validateTarget(target, []string{api.FieldTools})
 	}
 
 	// Get pattern and description filter from args
@@ -46,10 +47,10 @@ func (f *FilterCommand) Execute(ctx context.Context, args []string) error {
 		descriptionFilter = parsed[2]
 	}
 	if len(parsed) > 3 {
-		caseSensitive = strings.ToLower(parsed[3]) == "true" //nolint:goconst
+		caseSensitive = strings.ToLower(parsed[3]) == boolStringTrue
 	}
 	if len(parsed) > 4 {
-		detailed = strings.ToLower(parsed[4]) == "true"
+		detailed = strings.ToLower(parsed[4]) == boolStringTrue
 	}
 
 	return f.filterTools(ctx, pattern, descriptionFilter, caseSensitive, detailed)
@@ -164,7 +165,7 @@ func (f *FilterCommand) Completions(input string) []string {
 	parts := strings.Fields(input)
 
 	if len(parts) == 1 {
-		return []string{"tools"}
+		return []string{api.FieldTools}
 	}
 
 	return []string{}

--- a/internal/agent/commands/notifications_command.go
+++ b/internal/agent/commands/notifications_command.go
@@ -27,14 +27,14 @@ func (n *NotificationsCommand) Execute(ctx context.Context, args []string) error
 
 	action := strings.ToLower(parsed[0])
 	switch action {
-	case "on", "enable", "true": //nolint:goconst
+	case "on", "enable", boolStringTrue:
 		if !n.transport.SupportsNotifications() {
 			n.output.Error("Notifications are not supported with current transport. Use --transport=sse or --transport=streamable-http for notification support.")
 			return nil
 		}
 		// Enable notifications (implementation would go here)
 		n.output.Success("Notifications enabled")
-	case "off", "disable", "false":
+	case "off", "disable", boolStringFalse:
 		// Disable notifications (implementation would go here)
 		n.output.Success("Notifications disabled")
 	default:

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -123,7 +123,7 @@ func establishConnection(
 			logging.TruncateIdentifier(sessionID), serverName, issuer)
 	} else {
 		headers := map[string]string{
-			"Authorization": "Bearer " + accessToken,
+			pkgoauth.HeaderAuthorization: pkgoauth.SchemeBearer + " " + accessToken,
 		}
 		client = internalmcp.NewStreamableHTTPClientWithHeaders(serverURL, headers)
 		logging.Debug("Connection", "Using static auth headers for session %s, server %s",
@@ -686,7 +686,7 @@ func EstablishConnectionWithTokenExchange(
 	// returns 401. In that case, callToolWithTokenExchangeRetry evicts the stale
 	// pool entry, re-exchanges a fresh token, and retries the tool call.
 	headerFunc := func(_ context.Context) map[string]string {
-		return map[string]string{"Authorization": "Bearer " + exchangedToken}
+		return map[string]string{pkgoauth.HeaderAuthorization: pkgoauth.SchemeBearer + " " + exchangedToken}
 	}
 
 	// Create a client with the dynamic header function.
@@ -890,7 +890,7 @@ func makeTokenForwardingHeaderFunc(
 			}
 		}
 		return map[string]string{
-			"Authorization": "Bearer " + latestToken,
+			pkgoauth.HeaderAuthorization: pkgoauth.SchemeBearer + " " + latestToken,
 		}
 	}
 }

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1500,7 +1500,10 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 			a.ssoTracker.ClearAllSSOFailed(userID)
 		}
 
-		go a.initSSOForSession(ctx, userID, sessionID, idToken)
+		// initSSOForSession is meant to outlive the request that triggered it;
+		// pass a fresh background context so cancellation when the handler
+		// returns does not abort the SSO bootstrap.
+		go a.initSSOForSession(context.Background(), userID, sessionID, idToken) //nolint:gosec // G118: SSO bootstrap must outlive the request handler that triggered it
 	})
 
 	logging.InfoWithAttrs("Aggregator", "OAuth 2.1 server protection enabled",
@@ -2664,7 +2667,7 @@ func (a *AggregatorServer) exchangeTokenAndCreateClient(
 	}
 
 	headerFunc := func(_ context.Context) map[string]string {
-		return map[string]string{"Authorization": "Bearer " + exchangedToken}
+		return map[string]string{pkgoauth.HeaderAuthorization: pkgoauth.SchemeBearer + " " + exchangedToken}
 	}
 
 	var client MCPClient
@@ -2778,7 +2781,7 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 			if latestToken == "" {
 				return map[string]string{}
 			}
-			return map[string]string{"Authorization": "Bearer " + latestToken}
+			return map[string]string{pkgoauth.HeaderAuthorization: pkgoauth.SchemeBearer + " " + latestToken}
 		}
 		client = internalmcp.NewStreamableHTTPClientWithHeaderFunc(serverInfo.URL, headerFunc)
 

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -317,59 +317,59 @@ func mcpServerArgs(typeRequired bool) []api.ArgMetadata {
 		{Name: "autoStart", Type: api.ArgTypeBoolean, Required: false, Description: "Whether server should auto-start"},
 		{Name: "command", Type: api.ArgTypeString, Required: false, Description: "Command executable path (required for stdio)"},
 		{Name: "args", Type: api.ArgTypeArray, Required: false, Description: "Command arguments (stdio only)", Schema: map[string]interface{}{
-			"type":        "array",
-			"items":       map[string]interface{}{"type": "string"},
-			"description": "Command line arguments for stdio servers",
+			api.SchemaKeyType:        string(api.ArgTypeArray),
+			api.SchemaKeyItems:       map[string]interface{}{api.SchemaKeyType: string(api.ArgTypeString)},
+			api.SchemaKeyDescription: "Command line arguments for stdio servers",
 		}},
 		{Name: "url", Type: api.ArgTypeString, Required: false, Description: "Server endpoint URL (required for streamable-http and sse)"},
 		{Name: "env", Type: api.ArgTypeObject, Required: false, Description: "Environment variables", Schema: map[string]interface{}{
-			"type":                 "object",
-			"additionalProperties": map[string]interface{}{"type": "string"},
-			"description":          "Environment variables for the server",
+			api.SchemaKeyType:                 string(api.ArgTypeObject),
+			api.SchemaKeyAdditionalProperties: map[string]interface{}{api.SchemaKeyType: string(api.ArgTypeString)},
+			api.SchemaKeyDescription:          "Environment variables for the server",
 		}},
 		{Name: "headers", Type: api.ArgTypeObject, Required: false, Description: "HTTP headers (streamable-http and sse only)", Schema: map[string]interface{}{
-			"type":                 "object",
-			"additionalProperties": map[string]interface{}{"type": "string"},
-			"description":          "HTTP headers for remote servers",
+			api.SchemaKeyType:                 string(api.ArgTypeObject),
+			api.SchemaKeyAdditionalProperties: map[string]interface{}{api.SchemaKeyType: string(api.ArgTypeString)},
+			api.SchemaKeyDescription:          "HTTP headers for remote servers",
 		}},
 		{Name: "timeout", Type: api.ArgTypeInteger, Required: false, Description: "Connection timeout in seconds"},
 		{Name: "auth", Type: api.ArgTypeObject, Required: false, Description: "Authentication configuration for remote servers", Schema: map[string]interface{}{
-			"type":        "object",
-			"description": "Authentication configuration (oauth, teleport, or none)",
-			"properties": map[string]interface{}{
-				"type": map[string]interface{}{
-					"type":        "string",
-					"description": "Authentication type: oauth, teleport, or none",
-					"enum":        []string{"oauth", "teleport", "none"},
+			api.SchemaKeyType:        string(api.ArgTypeObject),
+			api.SchemaKeyDescription: "Authentication configuration (oauth, teleport, or none)",
+			api.SchemaKeyProperties: map[string]interface{}{
+				api.SchemaKeyType: map[string]interface{}{
+					api.SchemaKeyType:        string(api.ArgTypeString),
+					api.SchemaKeyDescription: "Authentication type: oauth, teleport, or none",
+					api.SchemaKeyEnum:        []string{"oauth", "teleport", "none"},
 				},
 				"forwardToken": map[string]interface{}{
-					"type":        "boolean",
-					"description": "Enable SSO token forwarding (oauth only)",
+					api.SchemaKeyType:        string(api.ArgTypeBoolean),
+					api.SchemaKeyDescription: "Enable SSO token forwarding (oauth only)",
 				},
 				"requiredAudiences": map[string]interface{}{
-					"type":        "array",
-					"items":       map[string]interface{}{"type": "string"},
-					"description": "Additional audiences to request from IdP for token forwarding (e.g., dex-k8s-authenticator for Kubernetes OIDC)",
+					api.SchemaKeyType:        string(api.ArgTypeArray),
+					api.SchemaKeyItems:       map[string]interface{}{api.SchemaKeyType: string(api.ArgTypeString)},
+					api.SchemaKeyDescription: "Additional audiences to request from IdP for token forwarding (e.g., dex-k8s-authenticator for Kubernetes OIDC)",
 				},
 				"teleport": map[string]interface{}{
-					"type":        "object",
-					"description": "Teleport authentication configuration",
-					"properties": map[string]interface{}{
+					api.SchemaKeyType:        string(api.ArgTypeObject),
+					api.SchemaKeyDescription: "Teleport authentication configuration",
+					api.SchemaKeyProperties: map[string]interface{}{
 						"identityDir": map[string]interface{}{
-							"type":        "string",
-							"description": "Filesystem path to tbot identity files",
+							api.SchemaKeyType:        string(api.ArgTypeString),
+							api.SchemaKeyDescription: "Filesystem path to tbot identity files",
 						},
 						"identitySecretName": map[string]interface{}{
-							"type":        "string",
-							"description": "Kubernetes Secret name containing tbot identity files",
+							api.SchemaKeyType:        string(api.ArgTypeString),
+							api.SchemaKeyDescription: "Kubernetes Secret name containing tbot identity files",
 						},
 						"identitySecretNamespace": map[string]interface{}{
-							"type":        "string",
-							"description": "Kubernetes namespace of the identity secret",
+							api.SchemaKeyType:        string(api.ArgTypeString),
+							api.SchemaKeyDescription: "Kubernetes namespace of the identity secret",
 						},
 						"appName": map[string]interface{}{
-							"type":        "string",
-							"description": "Teleport application name for routing",
+							api.SchemaKeyType:        string(api.ArgTypeString),
+							api.SchemaKeyDescription: "Teleport application name for routing",
 						},
 					},
 				},

--- a/internal/metatools/formatters.go
+++ b/internal/metatools/formatters.go
@@ -40,8 +40,8 @@ func NewFormatters() *Formatters {
 //
 //	[
 //	  {
-//	    "name": "tool_name",
-//	    "description": "Tool description"
+//	    api.FieldName: "tool_name",
+//	    api.SchemaKeyDescription: "Tool description"
 //	  }
 //	]
 //
@@ -90,11 +90,11 @@ func (f *Formatters) FormatToolsListJSON(tools []mcp.Tool) (string, error) {
 // Output format:
 //
 //	{
-//	  "tools": [...],
+//	  api.FieldTools: [...],
 //	  "servers_requiring_auth": [
 //	    {
-//	      "name": "server-name",
-//	      "status": "auth_required",
+//	      api.FieldName: "server-name",
+//	      api.FieldStatus: "auth_required",
 //	      "auth_tool": "core_auth_login"
 //	    }
 //	  ]
@@ -229,15 +229,15 @@ func (f *Formatters) FormatPromptsListJSON(prompts []mcp.Prompt) (string, error)
 // Output format:
 //
 //	{
-//	  "name": "tool_name",
-//	  "description": "Tool description",
-//	  "inputSchema": { ... }
+//	  api.FieldName: "tool_name",
+//	  api.SchemaKeyDescription: "Tool description",
+//	  api.FieldInputSchema: { ... }
 //	}
 func (f *Formatters) FormatToolDetailJSON(tool mcp.Tool) (string, error) {
 	toolInfo := map[string]interface{}{
-		"name":        tool.Name,
-		"description": tool.Description,
-		"inputSchema": tool.InputSchema,
+		api.FieldName:            tool.Name,
+		api.SchemaKeyDescription: tool.Description,
+		api.FieldInputSchema:     tool.InputSchema,
 	}
 
 	jsonData, err := json.MarshalIndent(toolInfo, "", "  ")
@@ -260,10 +260,10 @@ func (f *Formatters) FormatToolDetailJSON(tool mcp.Tool) (string, error) {
 //   - error: JSON marshaling errors (should be rare)
 func (f *Formatters) FormatResourceDetailJSON(resource mcp.Resource) (string, error) {
 	resourceInfo := map[string]interface{}{
-		"uri":         resource.URI,
-		"name":        resource.Name,
-		"description": resource.Description,
-		"mimeType":    resource.MIMEType,
+		"uri":                    resource.URI,
+		api.FieldName:            resource.Name,
+		api.SchemaKeyDescription: resource.Description,
+		api.FieldMimeType:        resource.MIMEType,
 	}
 
 	jsonData, err := json.MarshalIndent(resourceInfo, "", "  ")
@@ -286,17 +286,17 @@ func (f *Formatters) FormatResourceDetailJSON(resource mcp.Resource) (string, er
 //   - error: JSON marshaling errors (should be rare)
 func (f *Formatters) FormatPromptDetailJSON(prompt mcp.Prompt) (string, error) {
 	promptInfo := map[string]interface{}{
-		"name":        prompt.Name,
-		"description": prompt.Description,
+		api.FieldName:            prompt.Name,
+		api.SchemaKeyDescription: prompt.Description,
 	}
 
 	if len(prompt.Arguments) > 0 {
 		args := make([]map[string]interface{}, len(prompt.Arguments))
 		for i, arg := range prompt.Arguments {
 			args[i] = map[string]interface{}{
-				"name":        arg.Name,
-				"description": arg.Description,
-				"required":    arg.Required,
+				api.FieldName:            arg.Name,
+				api.SchemaKeyDescription: arg.Description,
+				api.SchemaKeyRequired:    arg.Required,
 			}
 		}
 		promptInfo["arguments"] = args
@@ -388,15 +388,15 @@ func SerializeContent(content []mcp.Content) []interface{} {
 			})
 		} else if imageContent, ok := mcp.AsImageContent(item); ok {
 			result = append(result, map[string]interface{}{
-				"type":     "image",
-				"mimeType": imageContent.MIMEType,
-				"dataSize": len(imageContent.Data),
+				"type":            "image",
+				api.FieldMimeType: imageContent.MIMEType,
+				"dataSize":        len(imageContent.Data),
 			})
 		} else if audioContent, ok := mcp.AsAudioContent(item); ok {
 			result = append(result, map[string]interface{}{
-				"type":     "audio",
-				"mimeType": audioContent.MIMEType,
-				"dataSize": len(audioContent.Data),
+				"type":            "audio",
+				api.FieldMimeType: audioContent.MIMEType,
+				"dataSize":        len(audioContent.Data),
 			})
 		} else {
 			// Fallback for unknown content types

--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -228,8 +228,8 @@ func (p *Provider) handleFilterTools(ctx context.Context, args map[string]interf
 
 		if matches {
 			toolInfo := map[string]interface{}{
-				"name":        tool.Name,
-				"description": tool.Description,
+				api.FieldName:            tool.Name,
+				api.SchemaKeyDescription: tool.Description,
 			}
 
 			if includeSchema {
@@ -249,7 +249,7 @@ func (p *Provider) handleFilterTools(ctx context.Context, args map[string]interf
 		},
 		"total_tools":    len(tools),
 		"filtered_count": len(filteredTools),
-		"tools":          filteredTools,
+		api.FieldTools:   filteredTools,
 	}
 
 	jsonData, err := json.MarshalIndent(result, "", "  ")
@@ -511,16 +511,16 @@ func serializePromptContent(content mcp.Content) (json.RawMessage, error) {
 	}
 	if imageContent, ok := mcp.AsImageContent(content); ok {
 		return json.Marshal(map[string]interface{}{
-			"type":     "image",
-			"mimeType": imageContent.MIMEType,
-			"dataSize": len(imageContent.Data),
+			"type":            "image",
+			api.FieldMimeType: imageContent.MIMEType,
+			"dataSize":        len(imageContent.Data),
 		})
 	}
 	if audioContent, ok := mcp.AsAudioContent(content); ok {
 		return json.Marshal(map[string]interface{}{
-			"type":     "audio",
-			"mimeType": audioContent.MIMEType,
-			"dataSize": len(audioContent.Data),
+			"type":            "audio",
+			api.FieldMimeType: audioContent.MIMEType,
+			"dataSize":        len(audioContent.Data),
 		})
 	}
 	if resource, ok := mcp.AsEmbeddedResource(content); ok {

--- a/internal/testing/mock/oauth_server.go
+++ b/internal/testing/mock/oauth_server.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 )
 
 // jwtHeader is the pre-computed base64-encoded JWT header for unsigned tokens.
@@ -493,7 +495,7 @@ func (s *OAuthServer) SimulateCallback(code string) (*TokenResponse, error) {
 	return &TokenResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		TokenType:    "Bearer",
+		TokenType:    pkgoauth.SchemeBearer,
 		ExpiresIn:    int(s.config.TokenLifetime.Seconds()),
 		Scope:        entry.Scope,
 		IDToken:      idToken,
@@ -556,7 +558,7 @@ func (s *OAuthServer) GenerateTestToken(clientID, scope string) *TokenResponse {
 	return &TokenResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		TokenType:    "Bearer",
+		TokenType:    pkgoauth.SchemeBearer,
 		ExpiresIn:    int(s.config.TokenLifetime.Seconds()),
 		Scope:        scope,
 		IDToken:      idToken,
@@ -598,7 +600,7 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(s.config.SimulateErrors.AuthorizeEndpointDelay)
 	}
 
-	clientID := r.URL.Query().Get("client_id")
+	clientID := r.URL.Query().Get(pkgoauth.FormFieldClientID)
 	redirectURI := r.URL.Query().Get("redirect_uri")
 	scope := r.URL.Query().Get("scope")
 	state := r.URL.Query().Get("state")
@@ -689,15 +691,15 @@ func (s *OAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	grantType := r.FormValue("grant_type") //nolint:gosec
+	grantType := r.FormValue(pkgoauth.FormFieldGrantType) //nolint:gosec
 
 	if s.config.SimulateErrors != nil {
 		if s.config.SimulateErrors.TokenEndpointError != "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error":             "server_error",
-				"error_description": s.config.SimulateErrors.TokenEndpointError,
+				pkgoauth.JSONFieldError:            pkgoauth.ErrServerError,
+				pkgoauth.JSONFieldErrorDescription: s.config.SimulateErrors.TokenEndpointError,
 			})
 			return
 		}
@@ -705,17 +707,17 @@ func (s *OAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error":             "invalid_grant",
-				"error_description": "authorization code is invalid",
+				pkgoauth.JSONFieldError:            pkgoauth.ErrInvalidGrant,
+				pkgoauth.JSONFieldErrorDescription: "authorization code is invalid",
 			})
 			return
 		}
 	}
 
 	switch grantType {
-	case "authorization_code":
+	case pkgoauth.GrantTypeAuthorizationCode:
 		s.handleAuthCodeExchange(w, r)
-	case "refresh_token":
+	case pkgoauth.GrantTypeRefreshToken:
 		s.handleRefreshToken(w, r)
 	case "urn:ietf:params:oauth:grant-type:token-exchange":
 		s.handleTokenExchange(w, r)
@@ -723,16 +725,16 @@ func (s *OAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "unsupported_grant_type",
-			"error_description": fmt.Sprintf("grant_type %s not supported", grantType),
+			pkgoauth.JSONFieldError:            pkgoauth.ErrUnsupportedGrantType,
+			pkgoauth.JSONFieldErrorDescription: fmt.Sprintf("grant_type %s not supported", grantType),
 		})
 	}
 }
 
 func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Request) {
-	code := r.FormValue("code")                  //nolint:gosec
-	codeVerifier := r.FormValue("code_verifier") //nolint:gosec
-	clientID := r.FormValue("client_id")         //nolint:gosec
+	code := r.FormValue("code")                                 //nolint:gosec
+	codeVerifier := r.FormValue(pkgoauth.FormFieldCodeVerifier) //nolint:gosec
+	clientID := r.FormValue(pkgoauth.FormFieldClientID)         //nolint:gosec
 
 	if s.config.Debug {
 		fmt.Fprintf(os.Stderr, "🔐 Token exchange request: code=%s..., client_id=%s\n",
@@ -750,8 +752,8 @@ func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Requ
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_grant",
-			"error_description": "authorization code not found or expired",
+			pkgoauth.JSONFieldError:            pkgoauth.ErrInvalidGrant,
+			pkgoauth.JSONFieldErrorDescription: "authorization code not found or expired",
 		})
 		return
 	}
@@ -762,8 +764,8 @@ func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Requ
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error":             "invalid_grant",
-				"error_description": "code_verifier required",
+				pkgoauth.JSONFieldError:            pkgoauth.ErrInvalidGrant,
+				pkgoauth.JSONFieldErrorDescription: "code_verifier required",
 			})
 			return
 		}
@@ -773,8 +775,8 @@ func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Requ
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]string{
-				"error":             "invalid_grant",
-				"error_description": "code_verifier verification failed",
+				pkgoauth.JSONFieldError:            pkgoauth.ErrInvalidGrant,
+				pkgoauth.JSONFieldErrorDescription: "code_verifier verification failed",
 			})
 			return
 		}
@@ -821,7 +823,7 @@ func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Requ
 	response := TokenResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		TokenType:    "Bearer",
+		TokenType:    pkgoauth.SchemeBearer,
 		ExpiresIn:    int(s.config.TokenLifetime.Seconds()),
 		Scope:        entry.Scope,
 		IDToken:      idToken,
@@ -836,7 +838,7 @@ func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *OAuthServer) handleRefreshToken(w http.ResponseWriter, r *http.Request) {
-	refreshToken := r.FormValue("refresh_token") //nolint:gosec
+	refreshToken := r.FormValue(pkgoauth.FormFieldRefreshToken) //nolint:gosec
 
 	// Find the token by refresh token
 	var originalToken *issuedToken
@@ -853,8 +855,8 @@ func (s *OAuthServer) handleRefreshToken(w http.ResponseWriter, r *http.Request)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_grant",
-			"error_description": "refresh token not found",
+			pkgoauth.JSONFieldError:            pkgoauth.ErrInvalidGrant,
+			pkgoauth.JSONFieldErrorDescription: "refresh token not found",
 		})
 		return
 	}
@@ -892,7 +894,7 @@ func (s *OAuthServer) handleRefreshToken(w http.ResponseWriter, r *http.Request)
 	_ = json.NewEncoder(w).Encode(TokenResponse{ //nolint:gosec
 		AccessToken:  newAccessToken,
 		RefreshToken: newRefreshToken,
-		TokenType:    "Bearer",
+		TokenType:    pkgoauth.SchemeBearer,
 		ExpiresIn:    int(s.config.TokenLifetime.Seconds()),
 		Scope:        originalToken.Scope,
 		IDToken:      newIDToken,
@@ -1007,8 +1009,8 @@ func (s *OAuthServer) tokenExchangeError(w http.ResponseWriter, errorCode, descr
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"error":             errorCode,
-		"error_description": description,
+		"error":                            errorCode,
+		pkgoauth.JSONFieldErrorDescription: description,
 	})
 }
 

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -1526,7 +1526,7 @@ func (m *musterInstanceManager) checkMCPServersAvailability(client MCPTestClient
 
 	// Method 1: Try reflection to access the Content field dynamically
 	resultValue := reflect.ValueOf(result)
-	if resultValue.Kind() == reflect.Ptr {
+	if resultValue.Kind() == reflect.Pointer {
 		resultValue = resultValue.Elem()
 	}
 

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -15,10 +15,15 @@ import (
 
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 
+	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/testing/mock"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// defaultTestUser is the user identifier for the implicit "default" user
+// session in multi-user BDD test scenarios.
+const defaultTestUser = "default"
 
 // Test tool name constants for BDD test scenarios.
 const (
@@ -80,7 +85,7 @@ func NewTestToolsHandler(instanceManager MusterInstanceManager, instance *Muster
 		instanceManager: manager,
 		currentInstance: instance,
 		userClients:     make(map[string]MCPTestClient),
-		currentUser:     "default",
+		currentUser:     defaultTestUser,
 		debug:           debug,
 		logger:          logger,
 	}
@@ -94,13 +99,13 @@ func (h *TestToolsHandler) SetMCPClient(client MCPTestClient) {
 	if h.userClients == nil {
 		h.userClients = make(map[string]MCPTestClient)
 	}
-	h.userClients["default"] = client
-	h.currentUser = "default" //nolint:goconst
+	h.userClients[defaultTestUser] = client
+	h.currentUser = defaultTestUser
 }
 
 // GetCurrentClient returns the MCP client for the currently active user.
 func (h *TestToolsHandler) GetCurrentClient() MCPTestClient {
-	if h.currentUser != "" && h.currentUser != "default" {
+	if h.currentUser != "" && h.currentUser != defaultTestUser {
 		if client, exists := h.userClients[h.currentUser]; exists {
 			return client
 		}
@@ -111,7 +116,7 @@ func (h *TestToolsHandler) GetCurrentClient() MCPTestClient {
 // GetCurrentUserName returns the name of the currently active user.
 func (h *TestToolsHandler) GetCurrentUserName() string {
 	if h.currentUser == "" {
-		return "default"
+		return defaultTestUser
 	}
 	return h.currentUser
 }
@@ -120,7 +125,7 @@ func (h *TestToolsHandler) GetCurrentUserName() string {
 // The default client is managed by the test runner.
 func (h *TestToolsHandler) CloseAllUserClients() {
 	for name, client := range h.userClients {
-		if name != "default" && client != nil {
+		if name != defaultTestUser && client != nil {
 			if h.debug {
 				h.logger.Debug("🔌 Closing MCP client for user %s\n", name)
 			}
@@ -373,10 +378,10 @@ func (h *TestToolsHandler) handleSimulateOAuthCallback(ctx context.Context, args
 		// that masked aggregator bugs and didn't match real user behavior.
 
 		return map[string]interface{}{
-			"success":     true,
-			"message":     "OAuth callback completed successfully - token stored",
-			"server":      serverName,
-			"status_code": resp.StatusCode,
+			api.FieldSuccess: true,
+			api.FieldMessage: "OAuth callback completed successfully - token stored",
+			api.FieldServer:  serverName,
+			"status_code":    resp.StatusCode,
 		}, nil
 	}
 
@@ -397,7 +402,7 @@ func (h *TestToolsHandler) callAuthenticateTool(ctx context.Context, serverName 
 	}
 
 	result, err := h.mcpClient.CallTool(ctx, authToolName, map[string]interface{}{
-		"server": serverName,
+		api.FieldServer: serverName,
 	})
 	if err != nil {
 		return "", fmt.Errorf("authenticate tool call failed: %w", err)
@@ -492,13 +497,13 @@ func (h *TestToolsHandler) fallbackDirectTokenInjection(ctx context.Context, ser
 	// The aggregator will get a 401, create an auth challenge, and we'd need to complete the flow
 
 	return map[string]interface{}{
-		"success":      true,
-		"message":      "OAuth callback simulated via direct token exchange (fallback mode)",
-		"server":       serverName,
-		"access_token": tokenResp.AccessToken,
-		"token_type":   tokenResp.TokenType,
-		"expires_in":   tokenResp.ExpiresIn,
-		"note":         "Token is valid in mock OAuth server but may not be in muster's token store",
+		api.FieldSuccess: true,
+		api.FieldMessage: "OAuth callback simulated via direct token exchange (fallback mode)",
+		api.FieldServer:  serverName,
+		"access_token":   tokenResp.AccessToken,
+		"token_type":     tokenResp.TokenType,
+		"expires_in":     tokenResp.ExpiresIn,
+		"note":           "Token is valid in mock OAuth server but may not be in muster's token store",
 	}, nil
 }
 
@@ -559,9 +564,9 @@ func (h *TestToolsHandler) handleInjectToken(ctx context.Context, args map[strin
 	}
 
 	return map[string]interface{}{
-		"success": true,
-		"message": fmt.Sprintf("Token injected successfully for server %s", serverName),
-		"server":  serverName,
+		api.FieldSuccess: true,
+		api.FieldMessage: fmt.Sprintf("Token injected successfully for server %s", serverName),
+		api.FieldServer:  serverName,
 	}, nil
 }
 
@@ -577,9 +582,9 @@ func (h *TestToolsHandler) handleGetOAuthServerInfo(ctx context.Context, args ma
 		servers := make(map[string]interface{})
 		for name, info := range h.currentInstance.MockOAuthServers {
 			servers[name] = map[string]interface{}{
-				"name":       info.Name,
-				"port":       info.Port,
-				"issuer_url": info.IssuerURL,
+				api.FieldName: info.Name,
+				"port":        info.Port,
+				"issuer_url":  info.IssuerURL,
 			}
 		}
 
@@ -595,9 +600,9 @@ func (h *TestToolsHandler) handleGetOAuthServerInfo(ctx context.Context, args ma
 	}
 
 	return map[string]interface{}{
-		"name":       info.Name,
-		"port":       info.Port,
-		"issuer_url": info.IssuerURL,
+		api.FieldName: info.Name,
+		"port":        info.Port,
+		"issuer_url":  info.IssuerURL,
 	}, nil
 }
 
@@ -659,8 +664,8 @@ func (h *TestToolsHandler) handleAdvanceOAuthClock(ctx context.Context, args map
 	}
 
 	return map[string]interface{}{
-		"success":          true,
-		"message":          fmt.Sprintf("Advanced OAuth clock by %s", duration),
+		api.FieldSuccess:   true,
+		api.FieldMessage:   fmt.Sprintf("Advanced OAuth clock by %s", duration),
 		"advanced_by":      d.String(),
 		"servers_advanced": advancedServers,
 	}, nil
@@ -716,8 +721,8 @@ func (h *TestToolsHandler) handleRevokeToken(ctx context.Context, args map[strin
 	}
 
 	return map[string]interface{}{
-		"success":         true,
-		"message":         fmt.Sprintf("Revoked %d tokens on %d OAuth server(s)", totalRevoked, len(revokedServers)),
+		api.FieldSuccess:  true,
+		api.FieldMessage:  fmt.Sprintf("Revoked %d tokens on %d OAuth server(s)", totalRevoked, len(revokedServers)),
 		"tokens_revoked":  totalRevoked,
 		"servers_updated": revokedServers,
 	}, nil
@@ -927,11 +932,11 @@ func (h *TestToolsHandler) handleCreateUser(ctx context.Context, args map[string
 	}
 
 	return map[string]interface{}{
-		"success":      true,
-		"message":      fmt.Sprintf("Created user session '%s'", userName),
-		"user":         userName,
-		"total_users":  len(h.userClients),
-		"current_user": h.currentUser,
+		api.FieldSuccess: true,
+		api.FieldMessage: fmt.Sprintf("Created user session '%s'", userName),
+		"user":           userName,
+		"total_users":    len(h.userClients),
+		"current_user":   h.currentUser,
 	}, nil
 }
 
@@ -966,10 +971,10 @@ func (h *TestToolsHandler) handleSwitchUser(ctx context.Context, args map[string
 	}
 
 	return map[string]interface{}{
-		"success":       true,
-		"message":       fmt.Sprintf("Switched to user '%s'", userName),
-		"current_user":  userName,
-		"previous_user": previousUser,
+		api.FieldSuccess: true,
+		api.FieldMessage: fmt.Sprintf("Switched to user '%s'", userName),
+		"current_user":   userName,
+		"previous_user":  previousUser,
 	}, nil
 }
 
@@ -1014,10 +1019,10 @@ func (h *TestToolsHandler) handleListToolsForUser(ctx context.Context, args map[
 	}
 
 	return map[string]interface{}{
-		"success":    true,
-		"user":       userName,
-		"tool_count": len(toolNames),
-		"tools":      toolNames,
+		api.FieldSuccess: true,
+		"user":           userName,
+		"tool_count":     len(toolNames),
+		api.FieldTools:   toolNames,
 	}, nil
 }
 
@@ -1061,7 +1066,7 @@ func (h *TestToolsHandler) handleGetCurrentUser(ctx context.Context, args map[st
 	}
 
 	return map[string]interface{}{
-		"success":         true,
+		api.FieldSuccess:  true,
 		"current_user":    h.currentUser,
 		"available_users": available,
 		"total_users":     len(h.userClients),
@@ -1130,8 +1135,8 @@ func (h *TestToolsHandler) handleSimulateMusterReauth(ctx context.Context, args 
 	}
 
 	return map[string]interface{}{
-		"success": true,
-		"message": "Successfully re-authenticated to muster with new token",
+		api.FieldSuccess: true,
+		api.FieldMessage: "Successfully re-authenticated to muster with new token",
 	}, nil
 }
 
@@ -1435,10 +1440,10 @@ func (h *TestToolsHandler) handleMusterAuthLogin(ctx context.Context, args map[s
 			h.logger.Debug("🔐 No muster auth code in redirect, falling back to ID token store only\n")
 		}
 		return map[string]interface{}{
-			"success":      true,
-			"message":      "Muster auth login completed - ID token stored for SSO forwarding",
-			"oauth_server": musterOAuthServerName,
-			"issuer_url":   musterOAuthServerInfo.IssuerURL,
+			api.FieldSuccess: true,
+			api.FieldMessage: "Muster auth login completed - ID token stored for SSO forwarding",
+			"oauth_server":   musterOAuthServerName,
+			"issuer_url":     musterOAuthServerInfo.IssuerURL,
 		}, nil
 	}
 
@@ -1473,10 +1478,10 @@ func (h *TestToolsHandler) handleMusterAuthLogin(ctx context.Context, args map[s
 	}
 
 	return map[string]interface{}{
-		"success":      true,
-		"message":      "Muster auth login completed - ID token stored for SSO forwarding",
-		"oauth_server": musterOAuthServerName,
-		"issuer_url":   musterOAuthServerInfo.IssuerURL,
+		api.FieldSuccess: true,
+		api.FieldMessage: "Muster auth login completed - ID token stored for SSO forwarding",
+		"oauth_server":   musterOAuthServerName,
+		"issuer_url":     musterOAuthServerInfo.IssuerURL,
 	}, nil
 }
 
@@ -1560,7 +1565,7 @@ func (h *TestToolsHandler) handleAddMockTool(ctx context.Context, args map[strin
 		Name:        toolName,
 		Description: description,
 		Responses: []mock.ToolResponse{
-			{Response: map[string]interface{}{"status": "ok", "tool": toolName}},
+			{Response: map[string]interface{}{api.FieldStatus: "ok", "tool": toolName}},
 		},
 	}
 
@@ -1585,10 +1590,10 @@ func (h *TestToolsHandler) handleAddMockTool(ctx context.Context, args map[strin
 	}
 
 	return map[string]interface{}{
-		"success": true,
-		"message": fmt.Sprintf("Added tool '%s' to mock server '%s'", toolName, serverName),
-		"server":  serverName,
-		"tool":    toolName,
+		api.FieldSuccess: true,
+		api.FieldMessage: fmt.Sprintf("Added tool '%s' to mock server '%s'", toolName, serverName),
+		api.FieldServer:  serverName,
+		"tool":           toolName,
 	}, nil
 }
 
@@ -1636,9 +1641,9 @@ func (h *TestToolsHandler) handleRemoveMockTool(ctx context.Context, args map[st
 	}
 
 	return map[string]interface{}{
-		"success": true,
-		"message": fmt.Sprintf("Removed tool '%s' from mock server '%s'", toolName, serverName),
-		"server":  serverName,
-		"tool":    toolName,
+		api.FieldSuccess: true,
+		api.FieldMessage: fmt.Sprintf("Removed tool '%s' from mock server '%s'", toolName, serverName),
+		api.FieldServer:  serverName,
+		"tool":           toolName,
 	}, nil
 }

--- a/internal/workflow/api_adapter.go
+++ b/internal/workflow/api_adapter.go
@@ -86,7 +86,7 @@ func (a *Adapter) ExecuteWorkflow(ctx context.Context, workflowName string, args
 		// Generate workflow unavailable event with missing tools
 		missingTools := a.findMissingTools(workflow)
 		a.generateCRDEvent(workflowName, events.ReasonWorkflowUnavailable, events.EventData{
-			Operation: "execute",
+			Operation: opExecute,
 			ToolNames: missingTools,
 		})
 
@@ -98,7 +98,7 @@ func (a *Adapter) ExecuteWorkflow(ctx context.Context, workflowName string, args
 
 	// Generate execution started event
 	a.generateCRDEvent(workflowName, events.ReasonWorkflowExecutionStarted, events.EventData{
-		Operation: "execute",
+		Operation: opExecute,
 		StepCount: len(workflow.Steps),
 	})
 
@@ -110,7 +110,7 @@ func (a *Adapter) ExecuteWorkflow(ctx context.Context, workflowName string, args
 	// Generate execution tracked event
 	if execution != nil {
 		a.generateCRDEvent(workflowName, events.ReasonWorkflowExecutionTracked, events.EventData{
-			Operation:   "execute",
+			Operation:   opExecute,
 			ExecutionID: execution.ExecutionID,
 		})
 	}
@@ -131,7 +131,7 @@ func (a *Adapter) ExecuteWorkflow(ctx context.Context, workflowName string, args
 	if err != nil {
 		// Generate execution failed event
 		eventData := events.EventData{
-			Operation: "execute",
+			Operation: opExecute,
 			Error:     err.Error(),
 		}
 		if execution != nil {
@@ -163,7 +163,7 @@ func (a *Adapter) ExecuteWorkflow(ctx context.Context, workflowName string, args
 
 	// Generate execution completed event
 	eventData := events.EventData{
-		Operation: "execute",
+		Operation: opExecute,
 		StepCount: len(workflow.Steps),
 	}
 	if execution != nil {
@@ -359,7 +359,7 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 		// Generate validation failure event
 		a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{
 			Error:     err.Error(),
-			Operation: "validate",
+			Operation: opValidate,
 		})
 		return err
 	}
@@ -369,7 +369,7 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 		err := fmt.Errorf("workflow name is required")
 		a.generateCRDEvent("", events.ReasonWorkflowValidationFailed, events.EventData{
 			Error:     err.Error(),
-			Operation: "validate",
+			Operation: opValidate,
 		})
 		return err
 	}
@@ -377,7 +377,7 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 		err := fmt.Errorf("workflow must have at least one step")
 		a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{
 			Error:     err.Error(),
-			Operation: "validate",
+			Operation: opValidate,
 		})
 		return err
 	}
@@ -390,7 +390,7 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 			err := fmt.Errorf("step %d: step ID cannot be empty", i)
 			a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{
 				Error:     err.Error(),
-				Operation: "validate",
+				Operation: opValidate,
 			})
 			return err
 		}
@@ -400,7 +400,7 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 			err := fmt.Errorf("duplicate step ID '%s' found", step.ID)
 			a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{
 				Error:     err.Error(),
-				Operation: "validate",
+				Operation: opValidate,
 			})
 			return err
 		}
@@ -411,7 +411,7 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 			err := fmt.Errorf("step %d (%s): tool cannot be empty", i, step.ID)
 			a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{
 				Error:     err.Error(),
-				Operation: "validate",
+				Operation: opValidate,
 			})
 			return err
 		}
@@ -419,7 +419,7 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 
 	// Generate validation success event
 	a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationSucceeded, events.EventData{
-		Operation: "validate",
+		Operation: opValidate,
 		StepCount: len(wf.Steps),
 	})
 
@@ -1104,8 +1104,8 @@ func (a *Adapter) handleList(args map[string]interface{}) (*api.CallToolResult, 
 	var result []map[string]interface{}
 	for _, wf := range workflows {
 		workflowInfo := map[string]interface{}{
-			"name":      wf.Name,
-			"available": wf.Available,
+			api.FieldName: wf.Name,
+			"available":   wf.Available,
 		}
 
 		// Only include description if it's not empty
@@ -1286,8 +1286,8 @@ func (a *Adapter) handleWorkflowAvailable(args map[string]interface{}) (*api.Cal
 	available := a.isWorkflowAvailable(workflow)
 
 	result := map[string]interface{}{
-		"name":      name,
-		"available": available,
+		api.FieldName: name,
+		"available":   available,
 	}
 
 	return &api.CallToolResult{
@@ -1466,7 +1466,7 @@ func (a *Adapter) handleExecutionGet(ctx context.Context, args map[string]interf
 		summaryResponse := map[string]interface{}{
 			"execution_id":  execution.ExecutionID,
 			"workflow_name": execution.WorkflowName,
-			"status":        execution.Status,
+			api.FieldStatus: execution.Status,
 			"started_at":    execution.StartedAt,
 			"duration_ms":   execution.DurationMs,
 			"input":         execution.Input,
@@ -1735,31 +1735,38 @@ func convertWorkflowConditionExpectation(expectParam map[string]interface{}) (ap
 // getWorkflowArgsSchema returns the detailed schema definition for workflow arguments
 func getWorkflowArgsSchema() map[string]interface{} {
 	return map[string]interface{}{
-		"type":        "object",
-		"description": "Workflow arguments definition with validation rules",
-		"additionalProperties": map[string]interface{}{
-			"type":                 "object",
-			"description":          "Argument definition with validation rules",
-			"additionalProperties": false,
-			"properties": map[string]interface{}{
-				"type": map[string]interface{}{
-					"type":        "string",
-					"description": "Expected data type for validation",
-					"enum":        []string{"string", "integer", "boolean", "number", "object", "array"},
+		api.SchemaKeyType:        string(api.ArgTypeObject),
+		api.SchemaKeyDescription: "Workflow arguments definition with validation rules",
+		api.SchemaKeyAdditionalProperties: map[string]interface{}{
+			api.SchemaKeyType:                 string(api.ArgTypeObject),
+			api.SchemaKeyDescription:          "Argument definition with validation rules",
+			api.SchemaKeyAdditionalProperties: false,
+			api.SchemaKeyProperties: map[string]interface{}{
+				api.SchemaKeyType: map[string]interface{}{
+					api.SchemaKeyType:        string(api.ArgTypeString),
+					api.SchemaKeyDescription: "Expected data type for validation",
+					api.SchemaKeyEnum: []string{
+						string(api.ArgTypeString),
+						string(api.ArgTypeInteger),
+						string(api.ArgTypeBoolean),
+						string(api.ArgTypeNumber),
+						string(api.ArgTypeObject),
+						string(api.ArgTypeArray),
+					},
 				},
-				"required": map[string]interface{}{
-					"type":        "boolean",
-					"description": "Whether this argument is required",
+				api.SchemaKeyRequired: map[string]interface{}{
+					api.SchemaKeyType:        string(api.ArgTypeBoolean),
+					api.SchemaKeyDescription: "Whether this argument is required",
 				},
-				"default": map[string]interface{}{
-					"description": "Default value if argument is not provided",
+				api.SchemaKeyDefault: map[string]interface{}{
+					api.SchemaKeyDescription: "Default value if argument is not provided",
 				},
-				"description": map[string]interface{}{
-					"type":        "string",
-					"description": "Human-readable documentation for this argument",
+				api.SchemaKeyDescription: map[string]interface{}{
+					api.SchemaKeyType:        string(api.ArgTypeString),
+					api.SchemaKeyDescription: "Human-readable documentation for this argument",
 				},
 			},
-			"required": []string{"type"},
+			api.SchemaKeyRequired: []string{"type"},
 		},
 	}
 }
@@ -1767,79 +1774,79 @@ func getWorkflowArgsSchema() map[string]interface{} {
 // getWorkflowStepsSchema returns the detailed schema definition for workflow steps
 func getWorkflowStepsSchema() map[string]interface{} {
 	return map[string]interface{}{
-		"type":        "array",
-		"description": "Workflow steps defining the sequence of operations",
-		"items": map[string]interface{}{
-			"type":                 "object",
-			"description":          "Individual workflow step configuration",
-			"additionalProperties": false,
-			"properties": map[string]interface{}{
+		api.SchemaKeyType:        string(api.ArgTypeArray),
+		api.SchemaKeyDescription: "Workflow steps defining the sequence of operations",
+		api.SchemaKeyItems: map[string]interface{}{
+			api.SchemaKeyType:                 string(api.ArgTypeObject),
+			api.SchemaKeyDescription:          "Individual workflow step configuration",
+			api.SchemaKeyAdditionalProperties: false,
+			api.SchemaKeyProperties: map[string]interface{}{
 				"id": map[string]interface{}{
-					"type":        "string",
-					"description": "Unique identifier for this step within the workflow",
+					api.SchemaKeyType:        string(api.ArgTypeString),
+					api.SchemaKeyDescription: "Unique identifier for this step within the workflow",
 				},
 				"tool": map[string]interface{}{
-					"type":        "string",
-					"description": "Name of the tool to execute for this step",
+					api.SchemaKeyType:        string(api.ArgTypeString),
+					api.SchemaKeyDescription: "Name of the tool to execute for this step",
 				},
 				"args": map[string]interface{}{
-					"type":        "object",
-					"description": "Arguments to pass to the tool, supporting templating with {{.argName}} for workflow args and {{stepId.field}} for step outputs",
+					api.SchemaKeyType:        string(api.ArgTypeObject),
+					api.SchemaKeyDescription: "Arguments to pass to the tool, supporting templating with {{.argName}} for workflow args and {{stepId.field}} for step outputs",
 				},
 				"condition": map[string]interface{}{
-					"type":                 "object",
-					"description":          "Optional condition that determines whether this step should execute",
-					"additionalProperties": false,
-					"properties": map[string]interface{}{
+					api.SchemaKeyType:                 string(api.ArgTypeObject),
+					api.SchemaKeyDescription:          "Optional condition that determines whether this step should execute",
+					api.SchemaKeyAdditionalProperties: false,
+					api.SchemaKeyProperties: map[string]interface{}{
 						"tool": map[string]interface{}{
-							"type":        "string",
-							"description": "Tool to call for condition evaluation",
+							api.SchemaKeyType:        string(api.ArgTypeString),
+							api.SchemaKeyDescription: "Tool to call for condition evaluation",
 						},
 						"args": map[string]interface{}{
-							"type":        "object",
-							"description": "Arguments for the condition tool",
+							api.SchemaKeyType:        string(api.ArgTypeObject),
+							api.SchemaKeyDescription: "Arguments for the condition tool",
 						},
 						"expect": map[string]interface{}{
-							"type":        "object",
-							"description": "Expected results for condition evaluation",
-							"properties": map[string]interface{}{
-								"success": map[string]interface{}{
-									"type":        "boolean",
-									"description": "Whether the tool call should succeed",
+							api.SchemaKeyType:        string(api.ArgTypeObject),
+							api.SchemaKeyDescription: "Expected results for condition evaluation",
+							api.SchemaKeyProperties: map[string]interface{}{
+								api.FieldSuccess: map[string]interface{}{
+									api.SchemaKeyType:        string(api.ArgTypeBoolean),
+									api.SchemaKeyDescription: "Whether the tool call should succeed",
 								},
 								"json_path": map[string]interface{}{
-									"type":        "object",
-									"description": "JSON path expressions to evaluate against tool result",
-									"additionalProperties": map[string]interface{}{
-										"description": "Expected value for the JSON path",
+									api.SchemaKeyType:        string(api.ArgTypeObject),
+									api.SchemaKeyDescription: "JSON path expressions to evaluate against tool result",
+									api.SchemaKeyAdditionalProperties: map[string]interface{}{
+										api.SchemaKeyDescription: "Expected value for the JSON path",
 									},
 								},
 							},
 						},
 					},
-					"required": []string{"tool"},
+					api.SchemaKeyRequired: []string{"tool"},
 				},
 				"allow_failure": map[string]interface{}{
-					"type":        "boolean",
-					"description": "Whether this step is allowed to fail without failing the workflow",
+					api.SchemaKeyType:        string(api.ArgTypeBoolean),
+					api.SchemaKeyDescription: "Whether this step is allowed to fail without failing the workflow",
 				},
 				"outputs": map[string]interface{}{
-					"type":        "object",
-					"description": "Defines how step results should be stored and made available to subsequent steps",
-					"additionalProperties": map[string]interface{}{
-						"description": "Output variable assignment, can be a static value or template expression",
+					api.SchemaKeyType:        string(api.ArgTypeObject),
+					api.SchemaKeyDescription: "Defines how step results should be stored and made available to subsequent steps",
+					api.SchemaKeyAdditionalProperties: map[string]interface{}{
+						api.SchemaKeyDescription: "Output variable assignment, can be a static value or template expression",
 					},
 				},
 				"store": map[string]interface{}{
-					"type":        "boolean",
-					"description": "Whether the step result should be stored in workflow results",
+					api.SchemaKeyType:        string(api.ArgTypeBoolean),
+					api.SchemaKeyDescription: "Whether the step result should be stored in workflow results",
 				},
-				"description": map[string]interface{}{
-					"type":        "string",
-					"description": "Human-readable documentation for this step's purpose",
+				api.SchemaKeyDescription: map[string]interface{}{
+					api.SchemaKeyType:        string(api.ArgTypeString),
+					api.SchemaKeyDescription: "Human-readable documentation for this step's purpose",
 				},
 			},
-			"required": []string{"id", "tool"},
+			api.SchemaKeyRequired: []string{"id", "tool"},
 		},
 		"minItems": 1,
 	}

--- a/internal/workflow/execution_tracker.go
+++ b/internal/workflow/execution_tracker.go
@@ -251,7 +251,7 @@ func (et *ExecutionTracker) extractStepsFromNewStructure(execution *api.Workflow
 		if conditionEvaluation != nil || conditionResult != nil || conditionTool != "" {
 			// For conditional steps, create a result that includes both the step result and condition info
 			enhancedResult := map[string]interface{}{
-				"status": string(stepStatus),
+				api.FieldStatus: string(stepStatus),
 			}
 
 			// Include condition evaluation (boolean) if present

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -141,10 +141,10 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 							// For failed steps, create a result structure
 							if stepMeta.Status == "failed" { //nolint:goconst
 								referencedStepResult = map[string]interface{}{
-									"error":   fmt.Sprintf("Step %s failed", stepMeta.ID),
-									"success": false,
-									"isError": true,
-									"status":  stepMeta.Status,
+									api.FieldError:   fmt.Sprintf("Step %s failed", stepMeta.ID),
+									api.FieldSuccess: false,
+									"isError":        true,
+									api.FieldStatus:  stepMeta.Status,
 								}
 								found = true
 								logging.Debug("WorkflowExecutor", "Created error result for failed step %s", step.Condition.FromStep)
@@ -152,8 +152,8 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 							} else if stepMeta.Status == "completed" { //nolint:goconst
 								// For completed steps without stored results, create a basic success structure
 								referencedStepResult = map[string]interface{}{
-									"success": true,
-									"status":  stepMeta.Status,
+									api.FieldSuccess: true,
+									api.FieldStatus:  stepMeta.Status,
 								}
 								found = true
 								logging.Debug("WorkflowExecutor", "Created basic success result for completed step %s", step.Condition.FromStep)
@@ -360,7 +360,7 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 			// Generate step failed event
 			we.eventCallback.GenerateStepEvent(workflow.Name, step.ID, "step_failed", map[string]interface{}{
 				"tool":          step.Tool,
-				"error":         err.Error(),
+				api.FieldError:  err.Error(),
 				"allow_failure": step.AllowFailure,
 			})
 
@@ -383,9 +383,9 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 				// Store the error result for subsequent steps to reference
 				if step.Store {
 					errorResult := map[string]interface{}{
-						"error":   err.Error(),
-						"success": false,
-						"isError": true,
+						api.FieldError:   err.Error(),
+						api.FieldSuccess: false,
+						"isError":        true,
 					}
 					execCtx.results[step.ID] = errorResult
 					logging.Debug("WorkflowExecutor", "Stored error result from step %s as %s: %+v", step.ID, step.ID, errorResult)
@@ -401,9 +401,9 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 			partialResult := map[string]interface{}{
 				"execution_id":  "", // Will be filled by manager
 				"workflow":      workflow.Name,
-				"status":        "failed",
+				api.FieldStatus: "failed",
 				"input":         execCtx.input,
-				"steps":         steps,
+				api.FieldSteps:  steps,
 				"template_vars": execCtx.templateVars,
 			}
 
@@ -477,7 +477,7 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 			// Generate step failed event for error result case
 			we.eventCallback.GenerateStepEvent(workflow.Name, step.ID, "step_failed", map[string]interface{}{
 				"tool":          step.Tool,
-				"error":         "step returned error result",
+				api.FieldError:  "step returned error result",
 				"allow_failure": step.AllowFailure,
 			})
 
@@ -501,9 +501,9 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 					}
 
 					errorResult := map[string]interface{}{
-						"success": false,
-						"isError": true,
-						"error":   errorMessage,
+						api.FieldSuccess: false,
+						"isError":        true,
+						api.FieldError:   errorMessage,
 					}
 					execCtx.results[step.ID] = errorResult
 					logging.Debug("WorkflowExecutor", "Stored error result from failed step %s: %+v", step.ID, errorResult)
@@ -524,9 +524,9 @@ func (we *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *api.W
 	finalResult := map[string]interface{}{
 		"execution_id":  "", // Will be filled by manager
 		"workflow":      workflow.Name,
-		"status":        "completed",
+		api.FieldStatus: "completed",
 		"input":         execCtx.input,
-		"steps":         steps,
+		api.FieldSteps:  steps,
 		"template_vars": execCtx.templateVars,
 	}
 
@@ -575,9 +575,9 @@ func (we *WorkflowExecutor) buildStepsArray(stepMetadata []stepMetadata, results
 
 	for _, stepMeta := range stepMetadata {
 		step := map[string]interface{}{
-			"id":     stepMeta.ID,
-			"tool":   stepMeta.Tool,
-			"status": stepMeta.Status,
+			"id":            stepMeta.ID,
+			"tool":          stepMeta.Tool,
+			api.FieldStatus: stepMeta.Status,
 		}
 
 		// Add condition information if present

--- a/internal/workflow/operations.go
+++ b/internal/workflow/operations.go
@@ -1,0 +1,7 @@
+package workflow
+
+// Operation names used as the Operation field in workflow lifecycle events.
+const (
+	opExecute  = "execute"
+	opValidate = "validate"
+)

--- a/pkg/oauth/wire.go
+++ b/pkg/oauth/wire.go
@@ -1,0 +1,62 @@
+package oauth
+
+// HTTP header names and authentication scheme used by OAuth/OIDC flows.
+// These match RFC 6749 / 6750 / 8693 wire format and must not be renamed.
+const (
+	HeaderAuthorization = "Authorization"
+	HeaderWWWAuth       = "WWW-Authenticate"
+	HeaderContentType   = "Content-Type"
+
+	SchemeBearer = "Bearer"
+)
+
+// Token-endpoint form field names (RFC 6749 §4 + RFC 7636 PKCE + RFC 8693).
+const (
+	FormFieldGrantType     = "grant_type"
+	FormFieldClientID      = "client_id"
+	FormFieldCode          = "code"
+	FormFieldCodeVerifier  = "code_verifier"
+	FormFieldRefreshToken  = "refresh_token"
+	FormFieldRedirectURI   = "redirect_uri"
+	FormFieldScope         = "scope"
+	FormFieldSubjectToken  = "subject_token"
+	FormFieldRequestedAud  = "audience"
+	FormFieldSubjectTokenT = "subject_token_type"
+)
+
+// Grant types accepted at the token endpoint.
+const (
+	GrantTypeAuthorizationCode = "authorization_code"
+	GrantTypeRefreshToken      = "refresh_token"
+	GrantTypeTokenExchange     = "urn:ietf:params:oauth:grant-type:token-exchange"
+)
+
+// Authorization-request PKCE challenge methods (RFC 7636).
+const (
+	CodeChallengeMethodS256  = "S256"
+	CodeChallengeMethodPlain = "plain"
+)
+
+// JSON field names returned in token-endpoint and error responses.
+const (
+	JSONFieldAccessToken      = "access_token"
+	JSONFieldRefreshToken     = "refresh_token"
+	JSONFieldIDToken          = "id_token"
+	JSONFieldTokenType        = "token_type"
+	JSONFieldExpiresIn        = "expires_in"
+	JSONFieldError            = "error"
+	JSONFieldErrorDescription = "error_description"
+)
+
+// OAuth 2.0 error codes (RFC 6749 §5.2, §4.1.2.1).
+const (
+	ErrInvalidRequest       = "invalid_request"
+	ErrInvalidClient        = "invalid_client"
+	ErrInvalidGrant         = "invalid_grant"
+	ErrUnauthorizedClient   = "unauthorized_client"
+	ErrUnsupportedGrantType = "unsupported_grant_type"
+	ErrInvalidScope         = "invalid_scope"
+	ErrAccessDenied         = "access_denied"
+	ErrServerError          = "server_error"
+	ErrInvalidToken         = "invalid_token"
+)


### PR DESCRIPTION
## Summary

Stacked on #702.

Removes the remaining duplicated string literals flagged by goconst without resorting to \`ignore-string-values\`. After this PR the \`.golangci.yml\` no longer needs that escape hatch.

- \`pkg/oauth/wire.go\` — RFC 6749/6750/7636/8693 vocabulary (\`HeaderAuthorization\`, \`SchemeBearer\`, \`FormField*\`, \`GrantType*\`, \`CodeChallengeMethod*\`, \`JSONField*\`, \`Err*\`). Adopted by \`internal/aggregator/{server,connection_helper}.go\` and the mock OAuth server, replacing scattered \`Authorization\`/\`Bearer\`/\`invalid_grant\`/\`error_description\` literals.
- \`internal/workflow/operations.go\` — \`opExecute\`/\`opValidate\` for workflow lifecycle event \`Operation\` strings; applied across \`api_adapter.go\`.
- \`internal/agent/commands/constants.go\` — \`boolStringTrue\`/\`boolStringFalse\` for stringly-typed boolean parsing in filter/notifications commands.
- \`internal/workflow/{api_adapter,executor,execution_tracker}.go\`, \`internal/mcpserver/api_adapter.go\`, \`internal/metatools/{handlers,formatters}.go\`, \`internal/testing/{test_tools,muster_manager}.go\` — JSON-key literals swapped for \`api.SchemaKey*\`/\`api.Field*\` constants. Applied consistently rather than only on goconst hot spots.
- \`internal/testing/test_tools.go\` — extracted the \`default\` user identifier to a \`defaultTestUser\` constant.

Remaining gosec/govet noise:
- \`internal/admin/handlers.go\`: \`url.PathEscape\` the session id before redirecting (G710 open-redirect taint flow).
- \`internal/aggregator/server.go\`: pass \`context.Background()\` to the SSO bootstrap goroutine since it must outlive the request handler; narrow \`//nolint:gosec\` with rationale (G118).
- \`internal/testing/muster_manager.go\`: \`reflect.Ptr\` → \`reflect.Pointer\`.
- \`.golangci.yml\`: drop \`ignore-string-values\`; add path-based exclusions for \`pkg/oauth/wire.go\` (G101 false positive on the token-exchange URN) and \`internal/testing/mock/*\` (G710 on the BDD mock OAuth server, which must honour \`redirect_uri\`).

Result: \`golangci-lint run -E=gosec -E=goconst -E=govet\` is 0 issues with no \`ignore-string-values\` escape hatch.