### PR TITLE
refactor(config): share DefaultValkeyKeyPrefix across aggregator and oauth

### DIFF
--- a/internal/aggregator/capability_store_valkey.go
+++ b/internal/aggregator/capability_store_valkey.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/valkey-io/valkey-go"
 
+	"github.com/giantswarm/muster/internal/config"
 	"github.com/giantswarm/muster/pkg/logging"
 )
 
@@ -28,7 +29,7 @@ type ValkeyCapabilityStore struct {
 // keyPrefix is prepended to all Valkey keys (default "muster:" if empty).
 func NewValkeyCapabilityStore(client valkey.Client, ttl time.Duration, keyPrefix string) *ValkeyCapabilityStore {
 	if keyPrefix == "" {
-		keyPrefix = defaultValkeyKeyPrefix
+		keyPrefix = config.DefaultValkeyKeyPrefix
 	}
 	return &ValkeyCapabilityStore{
 		client:    client,

--- a/internal/aggregator/constants.go
+++ b/internal/aggregator/constants.go
@@ -2,12 +2,6 @@ package aggregator
 
 import "time"
 
-const (
-	// defaultValkeyKeyPrefix is the key prefix used by all Valkey-backed
-	// aggregator stores when the caller does not specify one.
-	defaultValkeyKeyPrefix = "muster:"
-
-	// httpReadHeaderTimeout caps how long the HTTP servers wait for request
-	// headers. Bounds Slowloris-style request-header attacks.
-	httpReadHeaderTimeout = 30 * time.Second
-)
+// httpReadHeaderTimeout caps how long the HTTP servers wait for request
+// headers. Bounds Slowloris-style request-header attacks.
+const httpReadHeaderTimeout = 30 * time.Second

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -517,7 +517,7 @@ func createStores(cfg AggregatorConfig) storeBundle {
 	if ok && oauthCfg.Storage.Type == "valkey" && oauthCfg.Storage.Valkey.URL != "" {
 		keyPrefix := oauthCfg.Storage.Valkey.KeyPrefix
 		if keyPrefix == "" {
-			keyPrefix = defaultValkeyKeyPrefix
+			keyPrefix = config.DefaultValkeyKeyPrefix
 		}
 
 		client, err := newValkeyClient(oauthCfg.Storage.Valkey)
@@ -548,7 +548,7 @@ func createStores(cfg AggregatorConfig) storeBundle {
 	return storeBundle{
 		authStore:       NewInMemorySessionAuthStore(DefaultCapabilityStoreTTL),
 		capabilityStore: NewInMemoryCapabilityStore(DefaultCapabilityStoreTTL),
-		keyPrefix:       defaultValkeyKeyPrefix,
+		keyPrefix:       config.DefaultValkeyKeyPrefix,
 	}
 }
 

--- a/internal/aggregator/session_auth_store_valkey.go
+++ b/internal/aggregator/session_auth_store_valkey.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/valkey-io/valkey-go"
 
+	"github.com/giantswarm/muster/internal/config"
 	"github.com/giantswarm/muster/pkg/logging"
 )
 
@@ -27,7 +28,7 @@ type ValkeySessionAuthStore struct {
 // keyPrefix is prepended to all Valkey keys (default "muster:" if empty).
 func NewValkeySessionAuthStore(client valkey.Client, ttl time.Duration, keyPrefix string) *ValkeySessionAuthStore {
 	if keyPrefix == "" {
-		keyPrefix = defaultValkeyKeyPrefix
+		keyPrefix = config.DefaultValkeyKeyPrefix
 	}
 	return &ValkeySessionAuthStore{
 		client:    client,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -2,6 +2,12 @@ package config
 
 import "strings"
 
+// DefaultValkeyKeyPrefix is the default prefix prepended to every Valkey key
+// used by muster's backed stores when the operator does not override it via
+// ValkeyConfig.KeyPrefix. Centralised here so the OAuth client/state stores
+// and the aggregator session/capability stores agree on the namespace.
+const DefaultValkeyKeyPrefix = "muster:"
+
 // MusterConfig is the top-level configuration structure for muster.
 type MusterConfig struct {
 	Aggregator AggregatorConfig `yaml:"aggregator"`

--- a/internal/oauth/state_store_valkey.go
+++ b/internal/oauth/state_store_valkey.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/valkey-io/valkey-go"
 
+	"github.com/giantswarm/muster/internal/config"
 	"github.com/giantswarm/muster/pkg/logging"
 )
 
@@ -50,7 +51,7 @@ type ValkeyStateStore struct {
 // encryptor enables AES-256-GCM encryption at rest; pass nil to disable.
 func NewValkeyStateStore(client valkey.Client, keyPrefix string, encryptor *security.Encryptor) *ValkeyStateStore {
 	if keyPrefix == "" {
-		keyPrefix = "muster:"
+		keyPrefix = config.DefaultValkeyKeyPrefix
 	}
 	return &ValkeyStateStore{
 		valkeyEncryption: valkeyEncryption{encryptor: encryptor},

--- a/internal/oauth/token_store_valkey.go
+++ b/internal/oauth/token_store_valkey.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/valkey-io/valkey-go"
 
+	"github.com/giantswarm/muster/internal/config"
 	"github.com/giantswarm/muster/pkg/logging"
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 )
@@ -60,7 +61,7 @@ type ValkeyTokenStore struct {
 // encryptor enables AES-256-GCM encryption at rest; pass nil to disable.
 func NewValkeyTokenStore(client valkey.Client, ttl time.Duration, keyPrefix string, encryptor *security.Encryptor) *ValkeyTokenStore {
 	if keyPrefix == "" {
-		keyPrefix = "muster:"
+		keyPrefix = config.DefaultValkeyKeyPrefix
 	}
 	return &ValkeyTokenStore{
 		valkeyEncryption: valkeyEncryption{encryptor: encryptor},


### PR DESCRIPTION
## Summary

Stacked on #703.

The \`muster:\` Valkey key prefix was duplicated as a local default in four Valkey-backed stores:
- \`internal/aggregator/capability_store_valkey.go\`
- \`internal/aggregator/session_auth_store_valkey.go\`
- \`internal/oauth/token_store_valkey.go\`
- \`internal/oauth/state_store_valkey.go\`

Plus the aggregator HTTP-server constants file held a third copy as \`defaultValkeyKeyPrefix\` (introduced in #700).

Lifts the constant to \`internal/config.DefaultValkeyKeyPrefix\`, adjacent to the existing \`ValkeyConfig.KeyPrefix\` field that already owns the operator override. Every store now derives the same default from one symbol, so changing the namespace requires touching exactly one line.

\`internal/aggregator/constants.go\` keeps only \`httpReadHeaderTimeout\`.