### PR TITLE
Update Chart.yaml metadata

### DIFF
--- a/helm/muster/Chart.yaml
+++ b/helm/muster/Chart.yaml
@@ -13,6 +13,9 @@ keywords:
   - ai-agents
   - model-context-protocol
   - aggregator
+maintainers:
+  - name: Giant Swarm
+    email: team-bumblebee@giantswarm.io
 annotations:
   io.giantswarm.application.audience: all
   io.giantswarm.application.team: bumblebee

--- a/helm/muster/Chart.yaml
+++ b/helm/muster/Chart.yaml
@@ -12,11 +12,7 @@ keywords:
   - mcp
   - ai-agents
   - model-context-protocol
-  - platform-engineering
   - aggregator
-maintainers:
-  - name: Giant Swarm
-    email: team-planeteers@giantswarm.io
 annotations:
   io.giantswarm.application.audience: all
-  io.giantswarm.application.team: planeteers
+  io.giantswarm.application.team: bumblebee


### PR DESCRIPTION
Primarily, this PR should change ownership for the chart and alerts related to it to bumblebee

It also removes the generic keyword "platform-engineering".