### PR TITLE
fix: workflow availability check rejects family-grouped tools with more than one provider

### DIFF
--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -897,6 +897,24 @@ func (r *ServerRegistry) IsFamilyTool(exposedName string) bool {
 	return ok
 }
 
+// FamilyProviderCount returns the number of servers currently providing the
+// given family-grouped exposed tool name. Returns 0 for solo tools, core
+// tools, and unknown names.
+//
+// This exists so callers can decide that a family tool *exists* (the family
+// has at least one provider) independently of whether a single call can be
+// routed without the instance-selector arg. ResolveToolName intentionally
+// returns an ambiguity error once a family has more than one provider, which
+// must not be conflated with "tool does not exist" (see #761).
+func (r *ServerRegistry) FamilyProviderCount(exposedName string) int {
+	r.nameMu.RLock()
+	defer r.nameMu.RUnlock()
+	if bucket, ok := r.familyMappings[exposedName]; ok {
+		return len(bucket.providers)
+	}
+	return 0
+}
+
 // FamilyInstanceArgFor returns the required instance-selector arg name for a
 // family-grouped exposed tool, or empty string if the name is not family-
 // grouped or unknown.

--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -897,24 +897,6 @@ func (r *ServerRegistry) IsFamilyTool(exposedName string) bool {
 	return ok
 }
 
-// FamilyProviderCount returns the number of servers currently providing the
-// given family-grouped exposed tool name. Returns 0 for solo tools, core
-// tools, and unknown names.
-//
-// This exists so callers can decide that a family tool *exists* (the family
-// has at least one provider) independently of whether a single call can be
-// routed without the instance-selector arg. ResolveToolName intentionally
-// returns an ambiguity error once a family has more than one provider, which
-// must not be conflated with "tool does not exist" (see #761).
-func (r *ServerRegistry) FamilyProviderCount(exposedName string) int {
-	r.nameMu.RLock()
-	defer r.nameMu.RUnlock()
-	if bucket, ok := r.familyMappings[exposedName]; ok {
-		return len(bucket.providers)
-	}
-	return 0
-}
-
 // FamilyInstanceArgFor returns the required instance-selector arg name for a
 // family-grouped exposed tool, or empty string if the name is not family-
 // grouped or unknown.

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -2111,6 +2111,15 @@ func (a *AggregatorServer) IsToolAvailable(toolName string) bool {
 		return true // Found in registry
 	}
 
+	// Family-grouped tools with more than one provider intentionally make
+	// ResolveToolName return an ambiguity error: the instance-selector arg is
+	// required only to route a call, not to determine that the tool exists.
+	// Such a tool is still available as long as its family has >= 1 provider.
+	// Treating the ambiguity error as "missing" is the #761 regression.
+	if a.registry.FamilyProviderCount(toolName) > 0 {
+		return true // Family tool with at least one provider
+	}
+
 	// Check if it's a core tool by name pattern (avoid deadlock)
 	if a.isCoreToolByName(toolName) {
 		return true // Found in core tools

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -2093,8 +2093,11 @@ func (a *AggregatorServer) callCoreToolDirectly(ctx context.Context, toolName st
 //
 // The check process:
 //  1. Attempts to resolve the tool through the server registry
-//  2. If not found, checks if it matches core tool naming patterns
-//  3. Returns true if found in either location
+//  2. If unresolved because the tool is a family backed by more than one
+//     provider (an intentional ambiguity error), treats it as available since
+//     the family still exists; routing only needs the instance-selector arg
+//  3. If still not found, checks if it matches core tool naming patterns
+//  4. Returns true if found in any of these
 //
 // This method is used by:
 //   - Workflow manager for validating workflow step tools
@@ -2114,9 +2117,10 @@ func (a *AggregatorServer) IsToolAvailable(toolName string) bool {
 	// Family-grouped tools with more than one provider intentionally make
 	// ResolveToolName return an ambiguity error: the instance-selector arg is
 	// required only to route a call, not to determine that the tool exists.
-	// Such a tool is still available as long as its family has >= 1 provider.
-	// Treating the ambiguity error as "missing" is the #761 regression.
-	if a.registry.FamilyProviderCount(toolName) > 0 {
+	// The tool is still available as long as the family is registered (a family
+	// bucket always has >= 1 provider). Treating the ambiguity error as
+	// "missing" is the #761 regression.
+	if a.registry.IsFamilyTool(toolName) {
 		return true // Family tool with at least one provider
 	}
 

--- a/internal/aggregator/server_test.go
+++ b/internal/aggregator/server_test.go
@@ -1138,3 +1138,58 @@ func TestAggregatorServer_CallToolInternal_FamilyRouting(t *testing.T) {
 		assert.Contains(t, err.Error(), `"management_cluster" parameter is required`)
 	})
 }
+
+// TestAggregatorServer_IsToolAvailable_FamilyTools is the regression guard for
+// #761: a family-grouped tool backed by more than one provider must still be
+// reported as available even though ResolveToolName intentionally returns an
+// ambiguity error for it (the instance-selector arg is required only to route
+// a call, not to prove existence).
+func TestAggregatorServer_IsToolAvailable_FamilyTools(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("family tool with two providers is available despite ambiguity error", func(t *testing.T) {
+		reg := NewServerRegistry("x")
+		require.NoError(t, reg.Register(ctx, ServerRegistration{
+			Name:   "mc1-mcp-kubernetes",
+			Family: family("kubernetes", "management_cluster"),
+		}, &mockMCPClient{tools: []mcp.Tool{{Name: "list", Description: "List"}}}))
+		require.NoError(t, reg.Register(ctx, ServerRegistration{
+			Name:   "mc2-mcp-kubernetes",
+			Family: family("kubernetes", "management_cluster"),
+		}, &mockMCPClient{tools: []mcp.Tool{{Name: "list", Description: "List"}}}))
+		_ = reg.GetAllTools() // prime familyMappings
+
+		// Sanity: the call-time resolver is still ambiguous without a selector.
+		_, _, err := reg.ResolveToolName("x_kubernetes_list")
+		require.Error(t, err)
+
+		a := &AggregatorServer{registry: reg}
+		assert.True(t, a.IsToolAvailable("x_kubernetes_list"),
+			"a family tool with >= 1 provider must be reported available")
+	})
+
+	t.Run("family tool with a single provider is available", func(t *testing.T) {
+		reg := NewServerRegistry("x")
+		require.NoError(t, reg.Register(ctx, ServerRegistration{
+			Name:   "mc1-mcp-kubernetes",
+			Family: family("kubernetes", "management_cluster"),
+		}, &mockMCPClient{tools: []mcp.Tool{{Name: "list", Description: "List"}}}))
+		_ = reg.GetAllTools()
+
+		a := &AggregatorServer{registry: reg}
+		assert.True(t, a.IsToolAvailable("x_kubernetes_list"))
+	})
+
+	t.Run("genuinely absent tool is not available", func(t *testing.T) {
+		reg := NewServerRegistry("x")
+		require.NoError(t, reg.Register(ctx, ServerRegistration{
+			Name:   "mc1-mcp-kubernetes",
+			Family: family("kubernetes", "management_cluster"),
+		}, &mockMCPClient{tools: []mcp.Tool{{Name: "list", Description: "List"}}}))
+		_ = reg.GetAllTools()
+
+		a := &AggregatorServer{registry: reg}
+		assert.False(t, a.IsToolAvailable("x_kubernetes_does_not_exist"))
+		assert.False(t, a.IsToolAvailable("x_nonexistent_tool"))
+	})
+}

--- a/internal/testing/scenarios/workflow-family-tool-availability.yaml
+++ b/internal/testing/scenarios/workflow-family-tool-availability.yaml
@@ -1,0 +1,231 @@
+name: "workflow-family-tool-availability"
+description: "A workflow that references family-grouped tools backed by more than one provider is reported available and executes (regression #761)"
+category: "behavioral"
+concept: "workflow"
+tags: ["workflow", "family", "aggregator", "availability", "regression"]
+timeout: "5m"
+
+# Regression coverage for #761 (a regression from #670):
+#
+# Given: Two MCP servers share spec.family.name = prometheus and two more share
+#        spec.family.name = kubernetes, so each family tool has > 1 provider.
+#        ResolveToolName intentionally returns an ambiguity error for those tools
+#        unless the instance-selector arg is supplied.
+# And:   A workflow references the bare family tools (x_prometheus_execute_query,
+#        x_kubernetes_list) and supplies the instance selector as a templated
+#        step arg resolved only at execution time.
+# When:  Availability is checked and the workflow is executed.
+# Then:  The workflow is reported available (>= 1 provider per family) and runs,
+#        routing each step to the backend selected by the template — it must NOT
+#        be rejected by the Execute availability precheck.
+
+pre_configuration:
+  mcp_servers:
+    - name: "mc1-mcp-prometheus"
+      config:
+        family:
+          name: "prometheus"
+          instanceArg: "management_cluster"
+        tools:
+          - name: "execute_query"
+            description: "Execute a PromQL query"
+            input_schema:
+              type: "object"
+              properties:
+                query: { type: "string" }
+            responses:
+              - response:
+                  source: "mc1-mcp-prometheus"
+                  query: "{{ .query }}"
+    - name: "mc2-mcp-prometheus"
+      config:
+        family:
+          name: "prometheus"
+          instanceArg: "management_cluster"
+        tools:
+          - name: "execute_query"
+            description: "Execute a PromQL query"
+            input_schema:
+              type: "object"
+              properties:
+                query: { type: "string" }
+            responses:
+              - response:
+                  source: "mc2-mcp-prometheus"
+                  query: "{{ .query }}"
+    - name: "mc1-mcp-kubernetes"
+      config:
+        family:
+          name: "kubernetes"
+          instanceArg: "management_cluster"
+        tools:
+          - name: "list"
+            description: "List resources"
+            input_schema:
+              type: "object"
+              properties:
+                namespace: { type: "string" }
+            responses:
+              - response:
+                  source: "mc1-mcp-kubernetes"
+                  namespace: "{{ .namespace }}"
+    - name: "mc2-mcp-kubernetes"
+      config:
+        family:
+          name: "kubernetes"
+          instanceArg: "management_cluster"
+        tools:
+          - name: "list"
+            description: "List resources"
+            input_schema:
+              type: "object"
+              properties:
+                namespace: { type: "string" }
+            responses:
+              - response:
+                  source: "mc2-mcp-kubernetes"
+                  namespace: "{{ .namespace }}"
+
+  workflows:
+    - name: "alert-runbook"
+      config:
+        name: "alert-runbook"
+        input_schema:
+          type: object
+          args:
+            mc:
+              type: "string"
+          required:
+            - mc
+        steps:
+          - id: "query-prometheus"
+            tool: "x_prometheus_execute_query"
+            args:
+              management_cluster: "{{ .input.mc }}-mcp-prometheus"
+              query: "up"
+            store: true
+          - id: "list-kubernetes"
+            tool: "x_kubernetes_list"
+            args:
+              management_cluster: "{{ .input.mc }}-mcp-kubernetes"
+              namespace: "kube-system"
+            store: true
+
+steps:
+  - id: "wait-for-prometheus-mc1"
+    tool: "core_service_status"
+    args:
+      name: "mc1-mcp-prometheus"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        state: "running"
+
+  - id: "wait-for-prometheus-mc2"
+    tool: "core_service_status"
+    args:
+      name: "mc2-mcp-prometheus"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        state: "running"
+
+  - id: "wait-for-kubernetes-mc1"
+    tool: "core_service_status"
+    args:
+      name: "mc1-mcp-kubernetes"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        state: "running"
+
+  - id: "wait-for-kubernetes-mc2"
+    tool: "core_service_status"
+    args:
+      name: "mc2-mcp-kubernetes"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        state: "running"
+
+  # Core of the regression: with > 1 provider per family the workflow must still
+  # report available, because the family has >= 1 provider. Pre-fix this returns
+  # available: false because the ambiguity error is treated as "tool missing".
+  - id: "workflow-reported-available"
+    tool: "core_workflow_available"
+    args:
+      name: "alert-runbook"
+    expected:
+      success: true
+      json_path:
+        available: true
+
+  - id: "workflow-listed"
+    tool: "core_workflow_list"
+    args: {}
+    expected:
+      success: true
+      contains: ["alert-runbook"]
+
+  # Execution must not be refused by the availability precheck and must route
+  # each step to the backend selected by the templated instance arg.
+  - id: "execute-runbook-mc1"
+    tool: "workflow_alert-runbook"
+    args:
+      mc: "mc1"
+    expected:
+      success: true
+      contains: ["mc1-mcp-prometheus", "mc1-mcp-kubernetes"]
+      not_contains: ["mc2-mcp-prometheus", "mc2-mcp-kubernetes"]
+    timeout: "1m"
+
+  - id: "execute-runbook-mc2"
+    tool: "workflow_alert-runbook"
+    args:
+      mc: "mc2"
+    expected:
+      success: true
+      contains: ["mc2-mcp-prometheus", "mc2-mcp-kubernetes"]
+      not_contains: ["mc1-mcp-prometheus", "mc1-mcp-kubernetes"]
+    timeout: "1m"
+
+cleanup:
+  - id: "cleanup-workflow"
+    tool: "core_workflow_delete"
+    args:
+      name: "alert-runbook"
+    expected:
+      success: true
+    continue_on_failure: true
+  - id: "cleanup-prometheus-mc1"
+    tool: "core_service_stop"
+    args:
+      name: "mc1-mcp-prometheus"
+    expected:
+      success: true
+    continue_on_failure: true
+  - id: "cleanup-prometheus-mc2"
+    tool: "core_service_stop"
+    args:
+      name: "mc2-mcp-prometheus"
+    expected:
+      success: true
+    continue_on_failure: true
+  - id: "cleanup-kubernetes-mc1"
+    tool: "core_service_stop"
+    args:
+      name: "mc1-mcp-kubernetes"
+    expected:
+      success: true
+    continue_on_failure: true
+  - id: "cleanup-kubernetes-mc2"
+    tool: "core_service_stop"
+    args:
+      name: "mc2-mcp-kubernetes"
+    expected:
+      success: true
+    continue_on_failure: true


### PR DESCRIPTION
## Summary

Fixes #761 — a regression from #670. Workflows referencing a family-grouped tool backed by **more than one provider** were reported as unavailable and refused at execution time, effectively disabling all workflows in multi-instance `kubernetes`/`prometheus` deployments.

- `AggregatorServer.IsToolAvailable` resolved the bare exposed name via `registry.ResolveToolName` and treated **any** error as "not available".
- Since #670, `ResolveToolName` intentionally returns an ambiguity error once a family has `> 1` provider (the instance-selector arg is required to *route a call*). This was conflated with "tool does not exist".
- Now `IsToolAvailable` treats a family-grouped tool as available when its family is registered, via the existing `ServerRegistry.IsFamilyTool` (a family bucket always has `>= 1` provider, since `Deregister` deletes empty buckets). The call-time routing path (`ResolveToolNameForServer` with the injected selector) is unchanged.

## Changes

- `internal/aggregator/server.go`: `IsToolAvailable` is now family-aware, reusing `IsFamilyTool` (consistent with the sibling routing path); godoc updated to document the family step.
- `internal/aggregator/server_test.go`: regression unit tests (multi-provider family available; single provider available; genuinely absent tool unavailable).
- `internal/testing/scenarios/workflow-family-tool-availability.yaml`: BDD scenario covering reporting, listing, and routed execution for multi-provider families.

## Test plan

- [x] `make test` (unrelated pre-existing race in `internal/server` OAuth tests; all touched packages pass)
- [x] `muster test --scenario workflow-family-tool-availability --verbose` — 13/13 steps pass
- [x] `goimports -w . && go fmt ./...`

Made with [Cursor](https://cursor.com)