### PR TITLE
fix(helm): render jwtSigningKeyFile when enableJWTMode is true

### DIFF
--- a/helm/muster/templates/configmap.yaml
+++ b/helm/muster/templates/configmap.yaml
@@ -92,6 +92,9 @@ data:
           {{- end }}
           {{- if .Values.muster.oauth.server.enableJWTMode }}
           enableJWTMode: true
+          {{- if or .Values.muster.oauth.server.jwtSigningKey .Values.muster.oauth.server.existingSecret }}
+          jwtSigningKeyFile: {{ printf "%s/jwt-signing-key" $secretsPath | quote }}
+          {{- end }}
           {{- end }}
           {{- with .Values.muster.oauth.server.resourceIdentifier }}
           resourceIdentifier: {{ . | quote }}


### PR DESCRIPTION
## What

When `enableJWTMode: true` is set in values, the configmap template rendered
`enableJWTMode: true` in the config file but omitted `jwtSigningKeyFile`. This
caused muster to crash at startup with:

```
invalid server config: AccessTokenSigningKey is required when AccessTokenFormat is "jwt"
```

even when a signing key was correctly provided via `jwtSigningKey` or `existingSecret`.

## Fix

Render `jwtSigningKeyFile` when `enableJWTMode` is true and either `jwtSigningKey`
or `existingSecret` is set — consistent with how `registrationTokenFile`,
`encryptionKeyFile`, and other secret-backed file paths are already handled in
this template.

## Why

`enableJWTMode` makes muster sign its own JWTs instead of relaying Dex tokens,
required for agentgateway to validate tokens against muster's own JWKS endpoint
(`/.well-known/jwks.json`). Without the signing key loaded, muster never starts
its OAuth server and never exposes JWKS.