### PR TITLE
ci: attach release binaries to GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,17 @@ workflows:
             branches:
               ignore: /.*/
 
+      - architect/upload-release-assets:
+          context: architect
+          binary: muster
+          requires:
+            - go-build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
       # muster-crds: the standalone CRD-only chart. Versioned in lockstep with
       # muster off the same git tag (.abs replace-chart-version-with-git). The
       # same four-job shape as muster: build, ATS tests, branch push, tag push.


### PR DESCRIPTION
Adds `upload-release-assets` to the tag workflow so the `muster-linux-amd64` and `muster-linux-arm64` binaries (and their cosign `.bundle` files) are attached to the GitHub Release on each tag.

Previously, `go-build` produced the binaries but nothing uploaded them to the release page.