### PR TITLE
ci: revert upload-release-assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,17 +108,6 @@ workflows:
             branches:
               ignore: /.*/
 
-      - architect/upload-release-assets:
-          context: architect
-          binary: muster
-          requires:
-            - go-build
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-
       # muster-crds: the standalone CRD-only chart. Versioned in lockstep with
       # muster off the same git tag (.abs replace-chart-version-with-git). The
       # same four-job shape as muster: build, ATS tests, branch push, tag push.


### PR DESCRIPTION
Reverts #785.

GoReleaser in `auto-release.yaml` already builds and uploads all release binaries (linux/darwin/windows × amd64/arm64, archives, checksums, extra_files) to the GitHub Release via `GITHUB_TOKEN`. The `upload-release-assets` job was redundant and would have conflicted with GoReleaser's artifact naming. The 403 failure in CI was the tell.