### PR TITLE
feat: auto-update CHANGELOG.md on each release (option A)

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -144,3 +144,89 @@ jobs:
             --title "$TAG" \
             --notes-file release-notes.md \
             --target "$GITHUB_SHA"
+
+      # Splice the newly-rendered release-notes.md into CHANGELOG.md and
+      # push the resulting commit back to the branch. The release tag and
+      # GitHub Release already exist at this point (previous step) — this
+      # step is best-effort historical record-keeping. If it fails (branch
+      # protection rejects the push, race with a human commit, etc.) the
+      # release itself is unaffected; the file falls one release behind and
+      # self-heals on the next successful run.
+      #
+      # The splice uses a sentinel comment `<!-- auto-release: insert below -->`
+      # in CHANGELOG.md as the insertion point. Pre-conventional-commit
+      # history above the marker is preserved verbatim. New sections are
+      # inserted ABOVE older auto-generated ones, so reading top-to-bottom
+      # walks releases newest -> oldest, matching the existing file's order.
+      - name: Update CHANGELOG.md and commit back
+        if: steps.decide.outputs.tag != ''
+        env:
+          TAG: ${{ steps.decide.outputs.tag }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          MARKER='<!-- auto-release: insert below -->'
+          if ! grep -qF "$MARKER" CHANGELOG.md; then
+            echo "Marker '$MARKER' not found in CHANGELOG.md - skipping update."
+            echo "(The release itself succeeded; CHANGELOG.md will self-heal once the marker is restored.)"
+            exit 0
+          fi
+
+          # Previous reachable tag for the compare URL. Empty on the first
+          # release of a repo, in which case we drop the compare link.
+          PREV=$(git describe --tags --abbrev=0 --match='v*.*.*' "${TAG}^" 2>/dev/null || echo "")
+          DATE=$(date -u +%Y-%m-%d)
+          REPO_URL="https://github.com/${REPO}"
+
+          if [ -n "$PREV" ]; then
+            HEADER="## [${TAG}](${REPO_URL}/compare/${PREV}...${TAG}) - ${DATE}"
+          else
+            HEADER="## [${TAG}] - ${DATE}"
+          fi
+
+          # Build the new section. release-notes.md (from the earlier cliff
+          # step) already contains the Added/Fixed/Changed/Security bullet
+          # groups for this release - the only thing missing is the version
+          # header above them.
+          {
+            echo "$HEADER"
+            echo
+            cat release-notes.md
+          } > /tmp/new-section.md
+
+          # awk-splice: print every line, and after the marker line, emit a
+          # blank separator followed by the new section verbatim.
+          awk -v marker="$MARKER" '
+            { print }
+            $0 == marker {
+              print ""
+              while ((getline line < "/tmp/new-section.md") > 0) print line
+              close("/tmp/new-section.md")
+            }
+          ' CHANGELOG.md > CHANGELOG.new
+          mv CHANGELOG.new CHANGELOG.md
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md unchanged after splice - nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          # `[skip ci]` keeps GitHub Actions (and CircleCI) from running on
+          # this commit. Combined with the cliff.toml skip rule for
+          # `^chore: update CHANGELOG.md`, future releases also exclude it
+          # from bump computation and rendered notes.
+          git commit -m "chore: update CHANGELOG.md for ${TAG} [skip ci]"
+
+          # Pull-rebase guards the narrow window between job start and push
+          # where a human could have merged something else to the branch.
+          # The concurrency group serializes auto-release jobs against each
+          # other, but not against human pushes. If rebase fails (genuine
+          # conflict on CHANGELOG.md, exotic), the job errors out - the
+          # release is already shipped, and the next release re-splices.
+          git pull --rebase origin "$BRANCH"
+          git push origin "HEAD:$BRANCH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+<!-- auto-release: insert below -->
+
 ## [Unreleased]
 
 ### Added

--- a/cliff.toml
+++ b/cliff.toml
@@ -46,6 +46,17 @@ commit_preprocessors = [
 # include it anywhere either. Bump decision is unaffected by these group
 # names: git-cliff only bumps on feat / fix / breaking regardless.
 commit_parsers = [
+  # The auto-release workflow commits a "chore: update CHANGELOG.md for vX.Y.Z"
+  # commit back to the branch after each release (see .github/workflows/auto-
+  # release.yaml). `[skip ci]` in that commit message prevents the workflow
+  # itself from re-running on it, but a *subsequent* feature push would still
+  # see the chore in the --unreleased range and: (a) potentially trigger a
+  # patch bump on its own, (b) show up in the next release's "Changed"
+  # section as noise. Skipping this specific message via commit_parsers
+  # filters it out of both bump computation and the rendered notes. Must be
+  # listed BEFORE the general `^chore` rule — parsers are evaluated in order
+  # and first match wins.
+  { message = "^chore: update CHANGELOG\\.md", skip = true },
   { message = "^feat",     group = "Added" },
   { message = "^fix",      group = "Fixed" },
   { message = "^refactor", group = "Changed" },


### PR DESCRIPTION
## Summary

Extends the push-based auto-release workflow added in #792 to also keep `CHANGELOG.md` in sync with each release. After `gh release create` succeeds, the workflow splices the rendered release notes into `CHANGELOG.md` and pushes the resulting commit back to the branch.

This implements **option A** from the design discussion — direct commit-back from the workflow (not a follow-up PR).

## Design

**Splice, not regenerate.** The existing `CHANGELOG.md` carries ~650 lines of hand-curated pre-conventional-commit history (the `## [0.1.0] - 2026-02-23` section and everything below it). A full `git-cliff --output` regenerate would destroy that, so this PR uses an insertion-marker approach instead:

```markdown
# Changelog

All notable changes to this project will be documented in this file.

<!-- auto-release: insert below -->        <-- new sentinel

## [Unreleased]                            <-- stale release-please residue, untouched
...                                        <-- all pre-existing content preserved verbatim
```

On each release, the workflow:
1. Renders the new release section (version header + the same Added / Fixed / Changed / Security bullets that go into the GitHub Release) into a temp file.
2. awk-splices it into `CHANGELOG.md` directly under the marker, so newest releases land at the top — matching the existing file's ordering.
3. Commits with `chore: update CHANGELOG.md for vX.Y.Z [skip ci]` and pushes.

**Loop protection (two layers):**
- `[skip ci]` in the commit message prevents the auto-release workflow (and CircleCI) from running on the chore commit itself.
- A new `cliff.toml` `commit_parsers` rule (`^chore: update CHANGELOG\.md` -> skip) ensures that even if the chore commit ends up inside a future `--unreleased` range, git-cliff filters it out of both the version bump computation and the rendered notes. Placed before the general `^chore` rule (first match wins).

**Race protection:** The concurrency group serializes auto-release jobs against each other but not against human pushes to the branch. The commit-back step does `git pull --rebase origin "$BRANCH"` before `git push` to handle the narrow window between job start and push. If the rebase fails (genuine conflict on `CHANGELOG.md` itself, exotic), the step errors out — the release tag and GitHub Release are already created, so nothing is half-finished; the next release re-splices.

## Required branch-protection change before this works in production

The main-branch protection currently requires 1 PR review, and the `github-actions[bot]` is not in any bypass list. **Until that's adjusted, the commit-back step will fail at `git push`** with a 403.

Two options:

1. **Add `github-actions[bot]` (or a dedicated App) to "Allow specified actors to bypass required pull requests"** in the branch protection rule for `main`. Lowest-friction.
2. Switch the workflow's checkout to use a token from a dedicated GitHub App (re-use the release-please-approver app, or a new one) with bypass permissions. More setup; reuses existing infra.

The release itself is unaffected if the commit-back fails — `gh release create` happens *before* the commit-back step, and the file self-heals on the next release once the protection allows the push.

## Out of scope (called out for awareness)

- The `## [Unreleased]` section in `CHANGELOG.md` (release-please residue) is left untouched. It will become permanently stale once this lands — worth deleting separately, but not bundled here to keep the diff focused.

## Test plan

- [ ] Branch-protection bypass for `github-actions[bot]` (or App token) configured on `main`
- [ ] After merge: next `feat:` / `fix:` lands on `main` -> workflow runs -> new release tag created -> new section appears in `CHANGELOG.md` directly under the marker -> chore commit lands with `[skip ci]`
- [ ] Subsequent feature push does NOT include the chore in the bumped version or rendered notes (cliff.toml skip rule works)
- [ ] If the commit-back ever fails, the release itself still succeeded (tag + GitHub Release exist) and the next release recovers