### PR TITLE
feat(networkpolicy): add additionalEgress values knob for both flavors

### DIFF
--- a/helm/muster/templates/ciliumnetworkpolicy.yaml
+++ b/helm/muster/templates/ciliumnetworkpolicy.yaml
@@ -127,4 +127,10 @@ spec:
     {{- end }}
     {{- end }}
     {{- end }}
+
+    {{- with .Values.networkPolicy.cilium.additionalEgress }}
+    # Additional in-cluster egress entries supplied via values (e.g. MCP servers
+    # on non-80/443 ports). Each item is appended verbatim to the egress list.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/helm/muster/templates/networkpolicy.yaml
+++ b/helm/muster/templates/networkpolicy.yaml
@@ -96,4 +96,10 @@ spec:
     {{- end }}
     {{- end }}
     {{- end }}
+
+    {{- with .Values.networkPolicy.kubernetes.additionalEgress }}
+    # Additional in-cluster egress entries supplied via values (e.g. MCP servers
+    # on non-80/443 ports). Each item is appended verbatim to the egress list.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/helm/muster/tests/networkpolicy_test.yaml
+++ b/helm/muster/tests/networkpolicy_test.yaml
@@ -117,3 +117,61 @@ tests:
                 protocol: TCP
               - port: 443
                 protocol: TCP
+
+  - it: cilium additionalEgress appends raw rules to spec.egress
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.flavor: cilium
+      networkPolicy.cilium.additionalEgress:
+        - toEndpoints:
+            - matchLabels:
+                k8s:io.kubernetes.pod.namespace: mcp-runbooks
+                app.kubernetes.io/name: mcp-runbooks
+          toPorts:
+            - ports:
+                - port: "8080"
+                  protocol: TCP
+    template: templates/ciliumnetworkpolicy.yaml
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            toEndpoints:
+              - matchLabels:
+                  k8s:io.kubernetes.pod.namespace: mcp-runbooks
+                  app.kubernetes.io/name: mcp-runbooks
+            toPorts:
+              - ports:
+                  - port: "8080"
+                    protocol: TCP
+
+  - it: kubernetes additionalEgress appends raw rules to spec.egress
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.flavor: kubernetes
+      networkPolicy.kubernetes.additionalEgress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: mcp-runbooks
+              podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: mcp-runbooks
+          ports:
+            - port: 8080
+              protocol: TCP
+    template: templates/networkpolicy.yaml
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: mcp-runbooks
+                podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: mcp-runbooks
+            ports:
+              - port: 8080
+                protocol: TCP

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -607,7 +607,11 @@
         "cilium": {
           "type": "object",
           "properties": {
-            "allowClusterIngress": { "type": "boolean" }
+            "allowClusterIngress": { "type": "boolean" },
+            "additionalEgress": {
+              "type": "array",
+              "items": { "type": "object" }
+            }
           }
         },
         "kubernetes": {
@@ -618,6 +622,10 @@
             "worldExcludedCIDRs": {
               "type": "array",
               "items": { "type": "string" }
+            },
+            "additionalEgress": {
+              "type": "array",
+              "items": { "type": "object" }
             }
           }
         }

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -573,6 +573,20 @@ networkPolicy:
       ports:
         - 10080
         - 10443
+    # Additional egress rules appended to muster's egress allowlist. Each entry
+    # is a raw Cilium egress rule (toEndpoints / toEntities / toCIDR / toFQDNs +
+    # optional toPorts). Use this for in-cluster MCP servers that listen on
+    # non-80/443 ports — `allowClusterIngress` only opens 80/443. Example:
+    #   additionalEgress:
+    #     - toEndpoints:
+    #         - matchLabels:
+    #             k8s:io.kubernetes.pod.namespace: mcp-runbooks
+    #             app.kubernetes.io/name: mcp-runbooks
+    #       toPorts:
+    #         - ports:
+    #             - port: "8080"
+    #               protocol: TCP
+    additionalEgress: []
   kubernetes:
     apiServerCIDR: 0.0.0.0/0
     # Empty disables the cluster CIDR egress rule. Set to your cluster's
@@ -584,3 +598,18 @@ networkPolicy:
       - 172.16.0.0/12
       - 192.168.0.0/16
       - 169.254.0.0/16
+    # Additional egress rules appended to muster's egress allowlist. Vanilla
+    # NetworkPolicy syntax — each entry uses `to:` (with podSelector /
+    # namespaceSelector / ipBlock) and optional `ports`. Example:
+    #   additionalEgress:
+    #     - to:
+    #         - namespaceSelector:
+    #             matchLabels:
+    #               kubernetes.io/metadata.name: mcp-runbooks
+    #           podSelector:
+    #             matchLabels:
+    #               app.kubernetes.io/name: mcp-runbooks
+    #       ports:
+    #         - port: 8080
+    #           protocol: TCP
+    additionalEgress: []


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35670

Allows operators to extend muster's egress allowlist via Helm values instead of having to add chart code per-target. 

It is necessary to be able to get data from MCPs in other namespaces