### PR TITLE
fix(oauth): attempt forwarded ID token injection for emailless (ServiceAccount) identities

### DIFF
--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -303,6 +303,15 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 		}
 
 		if userInfo.Email == "" {
+			// An emailless identity can still be a valid forwarded ID token
+			// (e.g. a Kubernetes ServiceAccount identity pre-exchanged at Dex —
+			// SA tokens carry a `sub` but no email). The TrustedAudiences
+			// forwarded-token path authenticates on `sub`, not email, so try
+			// it before giving up. Falls through unchanged when the bearer is
+			// not an acceptable forwarded ID token.
+			if s.injectExternalIDToken(w, r, ctx, next) {
+				return
+			}
 			if s.debug {
 				logging.Debug("OAuth", "User info has no email, proceeding without token injection")
 			}

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	oauth "github.com/giantswarm/mcp-oauth"
+	oauthhandler "github.com/giantswarm/mcp-oauth/handler"
 	"github.com/giantswarm/mcp-oauth/providers"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 	"github.com/stretchr/testify/assert"
@@ -435,6 +436,59 @@ func TestCreateAccessTokenInjectorMiddleware(t *testing.T) {
 		// but we can verify the pattern works
 		require.NotNil(t, next)
 		assert.False(t, called) // Not called yet
+	})
+
+	// A Kubernetes ServiceAccount identity carries a `sub` but no email. The
+	// forwarded-token (TrustedAudiences) path authenticates on `sub`, so an
+	// emailless UserInfo must still attempt injectExternalIDToken rather than
+	// being dropped outright.
+	t.Run("emailless identity attempts forwarded ID token injection", func(t *testing.T) {
+		token := fakeJWT(t, map[string]interface{}{"sub": "system:serviceaccount:ns:sa"})
+		defer stubAcceptForwardedIDToken(func(_ context.Context, bearer string) (*oauthserver.ForwardedIDTokenAcceptance, error) {
+			return acceptanceFor(bearer, "system:serviceaccount:ns:sa", ""), nil
+		})()
+
+		s := &OAuthHTTPServer{config: config.OAuthServerConfig{BaseURL: "https://muster.test"}}
+
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+		})
+
+		r := requestWithBearer(token)
+		r = r.WithContext(oauthhandler.ContextWithUserInfo(r.Context(), &providers.UserInfo{ID: "system:serviceaccount:ns:sa"}))
+
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(httptest.NewRecorder(), r)
+
+		require.NotNil(t, capturedCtx, "next must be invoked with the enriched context")
+		idToken, ok := GetIDTokenFromContext(capturedCtx)
+		require.True(t, ok, "forwarded ID token should be injected for the emailless identity")
+		assert.Equal(t, token, idToken)
+	})
+
+	// When the bearer is not an acceptable forwarded ID token, the emailless
+	// path must fall through unchanged: next is still called, but no ID token
+	// is injected.
+	t.Run("emailless identity falls through when forwarded token rejected", func(t *testing.T) {
+		defer stubAcceptForwardedIDToken(func(context.Context, string) (*oauthserver.ForwardedIDTokenAcceptance, error) {
+			return nil, oauth.ErrTrustedAudienceMismatch
+		})()
+
+		s := &OAuthHTTPServer{config: config.OAuthServerConfig{BaseURL: "https://muster.test"}}
+
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+		})
+
+		r := requestWithBearer("opaque-or-wrong-aud")
+		r = r.WithContext(oauthhandler.ContextWithUserInfo(r.Context(), &providers.UserInfo{ID: "system:serviceaccount:ns:sa"}))
+
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(httptest.NewRecorder(), r)
+
+		require.NotNil(t, capturedCtx, "next must still be called when the bearer is not a forwarded ID token")
+		_, ok := GetIDTokenFromContext(capturedCtx)
+		assert.False(t, ok, "no ID token should be injected when the forwarded token is rejected")
 	})
 }
 


### PR DESCRIPTION
## What

In `internal/server/oauth_http.go`, `createAccessTokenInjectorMiddleware` returned early without attempting `injectExternalIDToken` whenever `userInfo.Email == ""`. A Kubernetes ServiceAccount identity legitimately carries a `sub` but **no email**, and the `TrustedAudiences` forwarded-token path authenticates on `sub`, not email.

As a result, a workload's projected SA token — pre-exchanged at Dex into a Dex-issued ID token (carrying the SA `sub`, no email) and presented to muster as a forwarded ID token — was dropped, so the per-target RFC 8693 exchange had no `subject_token`.

## Change

Attempt `injectExternalIDToken` for emailless identities before giving up:

```go
if userInfo.Email == "" {
    if s.injectExternalIDToken(w, r, ctx, next) {
        return
    }
    next.ServeHTTP(w, r)
    return
}
```

This is **additive and safe**: it only adds an attempt and falls through unchanged when the bearer is not an acceptable forwarded ID token (audience mismatch, bad signature, etc.).

## Tests

Added two subtests to `TestCreateAccessTokenInjectorMiddleware`:
- emailless identity with a valid forwarded ID token → bearer is injected as the ID token
- emailless identity whose bearer is rejected → falls through to `next` with no ID token injected

## Context

Found while validating muster + mcp-kubernetes token-exchange across two Dex trust domains on a local kind setup.

Refs #805 (Issue 1). Issue 2 (private-IP JWKS flag) is submitted as a separate PR; Issue 3 lives in `mcp-oauth`.