### PR TITLE
fix(oauth): plumb private-IP flag to the forwarded-token JWKS client

### DIFF
--- a/internal/server/new_oauth_server_config_test.go
+++ b/internal/server/new_oauth_server_config_test.go
@@ -88,3 +88,32 @@ func TestNewOAuthServerConfig_PreservesAdjacentFields(t *testing.T) {
 	require.Equal(t, DefaultMaxClientsPerIP, got.MaxClientsPerIP)
 	require.Equal(t, int64(time.Hour/time.Second), got.RefreshTokenTTL)
 }
+
+func TestNewOAuthServerConfig_AllowPrivateIPJWKSMirrorsDexFlag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   bool
+		want bool
+	}{
+		{name: "private-IP Dex enables forwarded-token JWKS private IPs", in: true, want: true},
+		{name: "public Dex leaves forwarded-token JWKS private IPs disabled", in: false, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.OAuthServerConfig{
+				BaseURL: "https://muster.example.com",
+				Dex:     config.DexConfig{AllowPrivateIPOIDC: tc.in},
+			}
+
+			got := newOAuthServerConfig(cfg, time.Hour)
+
+			require.Equal(t, tc.want, got.AllowPrivateIPJWKS,
+				"AllowPrivateIPJWKS must mirror Dex.AllowPrivateIPOIDC")
+		})
+	}
+}

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -39,6 +39,13 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		TrustedPublicRegistrationRedirectURIs: cfg.TrustedPublicRegistrationRedirectURIs,
 		AllowLocalhostRedirectURIs:            cfg.AllowLocalhostRedirectURIs,
 		TrustedAudiences:                      cfg.TrustedAudiences,
+		// The forwarded-ID-token (TrustedAudiences) JWKS validation in
+		// mcp-oauth is gated on this top-level flag. Mirror the provider-side
+		// intent: when the operator has opted into a private-IP Dex via
+		// Dex.AllowPrivateIPOIDC, the forwarded-token JWKS client must accept
+		// the same private-IP issuer instead of rejecting it as a DNS-rebinding
+		// attack. Public-hostname Dex deployments are unaffected.
+		AllowPrivateIPJWKS: cfg.Dex.AllowPrivateIPOIDC,
 	}
 	if cfg.EnableJWTMode {
 		result.AccessTokenFormat = oauthserver.AccessTokenFormatJWT


### PR DESCRIPTION
## What

In `internal/server/oauth_server_config.go`, `newOAuthServerConfig` never set the top-level `AllowPrivateIPJWKS` field on the mcp-oauth `Config`. That flag gates the forwarded-ID-token (`TrustedAudiences`) JWKS validation in mcp-oauth.

As a result, validating a forwarded ID token issued by a Dex on a private IP was rejected ("DNS rebinding attack detected") — even when the operator had already opted into `Dex.AllowPrivateIPOIDC` for the provider client.

## Change

Mirror the existing provider-side intent:

```go
TrustedAudiences:   cfg.TrustedAudiences,
AllowPrivateIPJWKS: cfg.Dex.AllowPrivateIPOIDC,
```

This is consistent with the provider-side flag (`AllowPrivateIP: cfg.Dex.AllowPrivateIPOIDC` is already wired up in `oauth_http.go`). It's mostly relevant to private-IP/dev/test Dex; a public-hostname Dex is unaffected.

## Tests

Added `TestNewOAuthServerConfig_AllowPrivateIPJWKSMirrorsDexFlag` covering both the private-IP-enabled and public (disabled) cases.

## Context

Found while validating muster + mcp-kubernetes token-exchange across two Dex trust domains on a local kind setup.

Refs #805 (Issue 2). Issue 1 (forwarded ID token dropped for emailless identities) is submitted as a separate PR; Issue 3 lives in `mcp-oauth`.