### PR TITLE
chore: drop auto-release.yaml from lint-yaml target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Drop the removed `.github/workflows/auto-release.yaml` from the `lint-yaml` make target.
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `muster-windows-<arch>.exe`.
 
 ### Added

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -7,7 +7,7 @@
 lint-yaml: ## Run YAML linter
 	@echo "Running YAML linter..."
 	@# Exclude zz_generated files
-	@yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml
+	@yamllint .github/workflows/ci.yaml
 
 .PHONY: helm-lint
 helm-lint: ## Run Helm linter


### PR DESCRIPTION
## Summary

The `.github/workflows/auto-release.yaml` workflow file has been removed at the platform level, so the `lint-yaml` make target currently fails (`yamllint` errors on the missing file). This drops the reference so `make lint-yaml` works again.

## Test plan

- [ ] `make lint-yaml` succeeds locally
- [ ] `make check` succeeds locally