### PR TITLE
docs: retitle stale duplicate Unreleased changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,7 @@ All notable changes to this project will be documented in this file.
 
 * align files according to platform standards ([#767](https://github.com/giantswarm/muster/issues/767)) ([d7b7c9a](https://github.com/giantswarm/muster/commit/d7b7c9a7a63a809e644d6991e3806095a53ed938))
 
-## [Unreleased]
+## Shipped between v0.1.223 and v0.3.11 (previously misfiled as Unreleased)
 
 ### Fixed
 


### PR DESCRIPTION
## What

Retitles the second `## [Unreleased]` heading in CHANGELOG.md (left over from the release-please era, sitting below the 0.1.223 section) so the file has exactly one Unreleased section. The entries under it shipped at some point between v0.1.223 and v0.3.11 but were never attributed to a release; the content is kept.

## Why

The devctl release flow (`Create Release PR` on `main#release#*`) fails with:

```
Error: Execution failed: 2 pattern `## \[Unreleased\]` matches found, expected 1
```

so no release can currently be cut. This unblocks v0.3.12, which carries the mcp-oauth v0.2.199 audience fix (#822).

Made with [Cursor](https://cursor.com)