### PR TITLE
ci: add .circleci/custom.yml with repo-specific jobs for generated CI

### DIFF
--- a/.circleci/custom.yml
+++ b/.circleci/custom.yml
@@ -1,0 +1,121 @@
+# Repo-specific CircleCI jobs. The dynamic-config setup workflow in
+# .circleci/config.yml deep-merges this file into the generated
+# .circleci/workflows.yml at pipeline runtime (yq `*+`: maps merge, job lists
+# append). devctl never touches this file.
+#
+# Generated job names referenced in `requires` below: go-build,
+# push-to-registries-release, execute-chart-tests.
+#
+# What this file carries beyond the golden pipeline:
+#   - branch dev-image push (the golden pipeline only builds + tests on branches)
+#   - branch dev-chart push for the muster chart
+#   - the standalone muster-crds chart (build, ATS tests, branch + tag push),
+#     versioned in lockstep with muster off the same git tag
+version: 2.1
+
+workflows:
+  build:
+    jobs:
+    # ---- Branch builds: dev image for PR validation. split-china-push is
+    #      safe on branches: registries-data marks Aliyun push_dev_image=false.
+    - architect/push-to-registries:
+        context: architect
+        name: push-to-registries
+        split-china-push: true
+        platforms: "linux/amd64,linux/arm64"
+        requires:
+        - go-build
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # ---- Branch: push dev chart after tests + the dev image ----
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-muster-to-giantswarm-app-catalog
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: muster
+        requires:
+        - execute-chart-tests
+        - push-to-registries
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # ---- muster-crds: the standalone CRD-only chart. Versioned in lockstep
+    #      with muster off the same git tag (.abs
+    #      replace-chart-version-with-git). Same shape as the generated muster
+    #      chart pipeline: build, ATS tests, branch push, tag push.
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: build-muster-crds-chart
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: muster-crds
+        # chart name differs from the repo (muster) -- required by the orb's
+        # chart-name check to publish a second chart from this repo.
+        explicit_allow_chart_name_mismatch: true
+        push_to_appcatalog: false
+        push_to_oci_registry: false
+        persist_chart_archive: true
+        requires:
+        - go-build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    - architect/run-tests-with-ats:
+        name: execute-muster-crds-chart-tests
+        requires:
+        - build-muster-crds-chart
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    # ---- Branch: push dev CRD chart after tests + the dev image ----
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-muster-crds-to-giantswarm-app-catalog
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: muster-crds
+        explicit_allow_chart_name_mismatch: true
+        requires:
+        - execute-muster-crds-chart-tests
+        - push-to-registries
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # ---- Tag: push CRD chart after tests + the gsoci image. Intentionally
+    #      does NOT depend on sync-china-registry so the chart catalog can
+    #      publish even if the in-China Aliyun mirror is slow or fails.
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-muster-crds-to-giantswarm-app-catalog-release
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: muster-crds
+        explicit_allow_chart_name_mismatch: true
+        requires:
+        - execute-muster-crds-chart-tests
+        - push-to-registries-release
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/


### PR DESCRIPTION
## Summary

- Prepares muster for devctl-generated CircleCI (`gen.ci.generate: true`, giantswarm/github#5384 follow-up). The generated setup config deep-merges this repo-owned `custom.yml` into the golden `workflows.yml` at pipeline runtime (devctl#1945).
- Carries everything the golden pipeline does not cover: the branch dev-image push, the branch dev-chart push for the muster chart, and the standalone `muster-crds` chart pipeline (build, ATS tests, branch + tag push).
- This file is inert until the generated `.circleci/config.yml`/`workflows.yml` land via align-files -- merging it now is safe.

## Validation

Generated the golden pipeline with devctl from main, ran the exact yq `*+` merge the setup job uses, and validated the result with `circleci config validate`. Diffed job names merged-vs-current: every current job is covered (generated equivalent or carried here).

Made with [Cursor](https://cursor.com)