### PR TITLE
fix(release): add version literal to pkg/project for devctl release flow

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -4,24 +4,26 @@ package project
 // invocations without ldflags keep this so `muster version` stays printable.
 const dev = "dev"
 
-// Populated at link time via `-X` ldflags. Two injection paths:
+// version holds the current release version as a literal so the devctl
+// release flow can rewrite it on each release. Build pipelines additionally
+// override these at link time via `-X` ldflags:
 //
 //   - goreleaser (release archives) sets `version` to the semver tag,
 //     `gitSHA` to the short commit, `buildTimestamp` to the build date.
-//   - architect-orb's `go-build` job (container images) sets `gitSHA` to
-//     `CIRCLE_SHA1` and `buildTimestamp` to the UTC build time; `version`
-//     stays at its default because no tag is plumbed through.
+//   - architect-orb's `go-build` job (container images) sets `version` via
+//     gitsemver, `gitSHA` to `CIRCLE_SHA1`, and `buildTimestamp` to the UTC
+//     build time.
 var (
-	version        = dev
+	version        = "0.3.11"
 	gitSHA         = dev
 	buildTimestamp = "unknown"
 )
 
 // Version returns the best human-readable build identifier available: the
-// release tag if goreleaser injected one, otherwise the commit SHA if CI
+// injected or literal release version, otherwise the commit SHA if CI
 // injected one, otherwise the placeholder "dev".
 func Version() string {
-	if version != dev {
+	if version != dev && version != "" {
 		return version
 	}
 	if gitSHA != dev {


### PR DESCRIPTION
## What

Sets `pkg/project.version` to a literal version string (`"0.3.11"`) instead of the `dev` placeholder, keeping the existing ldflags injection paths intact.

## Why

The platform-standard devctl release flow (`Create Release PR` on `main#release#*` branches) rewrites a `version = "x.y.z"` literal in the project package and fails when none exists:

```
Error: Execution failed: no match for pattern `(version\s*=\s*)"[0-9]+\.[0-9]+\.[0-9]+\S*"` found in data
```

Since the migration to the platform-standard workflows, no release can be cut. This unblocks v0.3.12, which carries the mcp-oauth v0.2.199 JWT audience fix (#822).

Behavior note: local `go build` without ldflags now reports the last release version instead of `dev`; CI/goreleaser builds are unchanged (ldflags still override).

Made with [Cursor](https://cursor.com)