### PR TITLE
feat(oauth): brokered RFC 8693 token exchange via tokenExchangeBroker config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Brokered RFC 8693 token exchange ([#831](https://github.com/giantswarm/muster/issues/831)): external confidential clients can POST a token-exchange request with an `audience` parameter to `/oauth/token` and receive a token minted by the audience's downstream Dex. New `oauth.server.tokenExchangeBroker` config block (per-client audience allowlist, audience → downstream Dex target mapping with per-target scopes and credential secret refs). Requires mcp-oauth >= v0.3.0; subject tokens are validated against `trustedIssuers`.
+
+### Changed
+
+- Update mcp-oauth to v0.3.0 (server-side RFC 8693 token-exchange grant with pluggable `Exchanger`).
+
 ## [0.3.12] - 2026-06-10
 
 ### Changed

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -158,6 +158,50 @@ estimate.
 | `allowedClaims` | `map[string]string` | Required claim name→pattern pairs. Keys are JWT claim names; values are exact strings or globs where `*` spans any chars including `/` and `?` matches one char. Absent or non-string claims are rejected. Empty means no restriction. |
 | `allowPrivateIPJWKS` | `bool` | Allow `jwksUrl` to resolve to a private or loopback address. Required for in-cluster Kubernetes SA trust where the JWKS endpoint is `https://kubernetes.default.svc/openid/v1/jwks`. Emits a startup warning when set. Default: `false`. |
 
+#### Brokered Token Exchange (`tokenExchangeBroker`)
+
+Exposes muster's RFC 8693 token exchange to external confidential clients: a broker client POSTs a token-exchange request with an `audience` parameter to `/oauth/token` and receives a token minted by the audience's downstream Dex (instead of a muster-issued JWT). Subject tokens are validated against `trustedIssuers`, so at least one issuer entry covering the broker client's tokens is required.
+
+Policy enforced by the broker path (mcp-oauth): client authentication is mandatory and only confidential clients are accepted; audiences are gated by the per-client allowlist; no refresh tokens are issued (`expires_in` is bounded by the downstream token's expiry — clients re-exchange); DPoP is rejected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `clientAudiences` | `map[string][]string` | `{}` | Per-client audience allowlist: broker client ID → audiences it may request. A miss returns `invalid_target`. |
+| `targets` | `map[string]BrokerTargetConfig` | `{}` | Audience name (e.g. a cluster name) → downstream Dex exchange target. |
+| `allowPrivateIP` | `bool` | `false` | Allow downstream token endpoints to resolve to private/loopback IPs. Reduces SSRF protection; internal deployments only. |
+
+**BrokerTargetConfig fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dexTokenEndpoint` | `string` | Downstream Dex token endpoint URL (HTTPS). Required. |
+| `expectedIssuer` | `string` | Expected `iss` claim of the exchanged token. Derived from `dexTokenEndpoint` when empty. |
+| `connectorId` | `string` | Downstream Dex OIDC connector that trusts the subject token's issuer. Required. |
+| `scopes` | `string` | Space-separated downstream scopes (default: `openid profile email groups`). Kubernetes-bound audiences must include the Dex cross-client scope for the apiserver's client, e.g. `audience:server:client_id:dex-k8s-authenticator` — without it the exchanged token's `aud` is the exchange client only, which the kube-apiserver rejects. The client-supplied RFC 8693 `scope` parameter is intentionally ignored. |
+| `clientCredentialsSecretRef` | `object` | Kubernetes Secret with the downstream exchange client credentials: `name` (required), `namespace` (defaults to the muster namespace), `clientIdKey` (default `client-id`), `clientSecretKey` (default `client-secret`). |
+
+Example:
+
+```yaml
+aggregator:
+  oauth:
+    server:
+      trustedIssuers:
+        - issuer: https://dex.main.example.com
+          jwksUrl: https://dex.main.example.com/keys
+          allowedAudiences: ["portal-frontend"]
+      tokenExchangeBroker:
+        clientAudiences:
+          portal-backend: ["cluster-a"]
+        targets:
+          cluster-a:
+            dexTokenEndpoint: https://dex.cluster-a.example.com/token
+            connectorId: main-dex
+            scopes: "openid profile email groups audience:server:client_id:dex-k8s-authenticator"
+            clientCredentialsSecretRef:
+              name: muster-token-exchange-cluster-a
+```
+
 #### Private-IP OIDC Discovery (Dex)
 
 By default the SSRF guard rejects an OIDC issuer URL that resolves to a private or loopback address. On clusters where the public Dex hostname resolves to an RFC 1918 address (e.g. an Azure internal load balancer, or air-gapped environments), discovery fails with `context deadline exceeded` and the server starts in degraded mode.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.2.200
+	github.com/giantswarm/mcp-oauth v0.3.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.200 h1:j1Xeydjd/25YpYRC+CGAiL9NMnralKFLF386yyc6tug=
-github.com/giantswarm/mcp-oauth v0.2.200/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
+github.com/giantswarm/mcp-oauth v0.3.0 h1:nH0OI7TPgW+G/A5Xocoq0x1FSV0bEEg28nQGBl39Fk8=
+github.com/giantswarm/mcp-oauth v0.3.0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/helm/muster/templates/configmap.yaml
+++ b/helm/muster/templates/configmap.yaml
@@ -106,6 +106,10 @@ data:
           {{- with .Values.muster.oauth.server.resourceIdentifier }}
           resourceIdentifier: {{ . | quote }}
           {{- end }}
+          {{- with .Values.muster.oauth.server.tokenExchangeBroker }}
+          tokenExchangeBroker:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
     namespace: {{ include "muster.namespace" . | quote }}
     kubernetes: true

--- a/helm/muster/tests/configmap_test.yaml
+++ b/helm/muster/tests/configmap_test.yaml
@@ -67,3 +67,48 @@ tests:
       - notMatchRegex:
           path: data["config.yaml"]
           pattern: "trustedPublicRegistrationSchemes:"
+
+  - it: renders tokenExchangeBroker into config.yaml
+    set:
+      muster.oauth.server.enabled: true
+      muster.oauth.server.baseUrl: "https://muster.example.com"
+      muster.oauth.server.existingSecret: "muster-oauth"
+      muster.oauth.server.dex.issuerUrl: "https://dex.example.com"
+      muster.oauth.server.dex.clientId: "muster"
+      muster.oauth.server.tokenExchangeBroker:
+        clientAudiences:
+          portal-backend:
+            - cluster-a
+        targets:
+          cluster-a:
+            dexTokenEndpoint: "https://dex.cluster-a.example.com/token"
+            connectorId: "main-dex"
+            scopes: "openid profile email groups audience:server:client_id:dex-k8s-authenticator"
+            clientCredentialsSecretRef:
+              name: "muster-token-exchange-cluster-a"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "tokenExchangeBroker:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "portal-backend"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "dexTokenEndpoint: https://dex.cluster-a.example.com/token"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "muster-token-exchange-cluster-a"
+
+  - it: omits tokenExchangeBroker when empty
+    set:
+      muster.oauth.server.enabled: true
+      muster.oauth.server.baseUrl: "https://muster.example.com"
+      muster.oauth.server.existingSecret: "muster-oauth"
+      muster.oauth.server.dex.issuerUrl: "https://dex.example.com"
+      muster.oauth.server.dex.clientId: "muster"
+      muster.oauth.server.tokenExchangeBroker: {}
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "tokenExchangeBroker:"

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -568,6 +568,46 @@
               "items": {"type": "string"},
               "description": "CIDRs from which X-Forwarded-Proto and X-Forwarded-Host headers are trusted for DPoP htu URL reconstruction. Required when muster runs behind a reverse proxy."
             },
+            "tokenExchangeBroker": {
+              "type": "object",
+              "description": "Brokered RFC 8693 token exchange: external confidential clients exchange a subject token plus an audience name for a token minted by the audience's downstream Dex. Subject tokens are validated against trustedIssuers.",
+              "properties": {
+                "clientAudiences": {
+                  "type": "object",
+                  "additionalProperties": {"type": "array", "items": {"type": "string"}},
+                  "description": "Per-client audience allowlist: broker client ID → audiences it may request. Requests outside the list get invalid_target."
+                },
+                "targets": {
+                  "type": "object",
+                  "description": "Audience name → downstream Dex exchange target.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "required": ["dexTokenEndpoint", "connectorId"],
+                    "properties": {
+                      "dexTokenEndpoint": {"type": "string", "pattern": "^https://", "description": "Downstream Dex token endpoint URL (HTTPS)."},
+                      "expectedIssuer": {"type": "string", "description": "Expected iss claim of the exchanged token. Derived from dexTokenEndpoint when empty."},
+                      "connectorId": {"type": "string", "description": "Downstream Dex OIDC connector that trusts the subject token's issuer."},
+                      "scopes": {"type": "string", "description": "Space-separated downstream scopes (default: openid profile email groups). Kubernetes-bound audiences must include the Dex cross-client scope, e.g. audience:server:client_id:dex-k8s-authenticator."},
+                      "clientCredentialsSecretRef": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                          "name": {"type": "string"},
+                          "namespace": {"type": "string", "description": "Defaults to the muster namespace."},
+                          "clientIdKey": {"type": "string", "description": "Defaults to client-id."},
+                          "clientSecretKey": {"type": "string", "description": "Defaults to client-secret."}
+                        },
+                        "description": "Kubernetes Secret holding the downstream exchange client credentials (same secrets the per-MCPServer tokenExchange config uses)."
+                      }
+                    }
+                  }
+                },
+                "allowPrivateIP": {
+                  "type": "boolean",
+                  "description": "Allow downstream token endpoints to resolve to private/loopback IPs. Reduces SSRF protection; internal deployments only."
+                }
+              }
+            },
             "enableJWTMode": {
               "type": "boolean",
               "description": "Issue RFC 9068 signed JWTs as access tokens instead of opaque strings"

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -498,6 +498,30 @@ muster:
       #     allowPrivateIPJWKS: true
       trustedIssuers: []
 
+      # Brokered RFC 8693 token exchange: muster as a shared token broker.
+      # An external confidential client POSTs a token-exchange request with an
+      # `audience` parameter to /oauth/token and receives a token minted by the
+      # audience's downstream Dex (instead of a muster-issued JWT). Subject
+      # tokens are validated against trustedIssuers, so at least one issuer
+      # entry covering the broker client's tokens is required.
+      # Policy enforced by mcp-oauth: confidential clients only, per-client
+      # audience allowlist, no refresh tokens, expires_in bounded by the
+      # downstream token's expiry, DPoP rejected.
+      # Example:
+      #   clientAudiences:
+      #     portal-backend: ["cluster-a", "cluster-b"]
+      #   targets:
+      #     cluster-a:
+      #       dexTokenEndpoint: https://dex.cluster-a.example.com/token
+      #       connectorId: main-dex
+      #       # k8s-bound audiences need the Dex cross-client scope, otherwise
+      #       # the exchanged token's aud is the exchange client only and the
+      #       # kube-apiserver rejects it:
+      #       scopes: "openid profile email groups audience:server:client_id:dex-k8s-authenticator"
+      #       clientCredentialsSecretRef:
+      #         name: muster-token-exchange-cluster-a
+      tokenExchangeBroker: {}
+
       # CIDRs from which X-Forwarded-Proto and X-Forwarded-Host headers are
       # trusted for DPoP htu URL reconstruction. Required when muster runs
       # behind a reverse proxy. Example: ["10.0.0.0/8", "172.16.0.0/12"]

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -402,6 +402,11 @@ func mergeOAuthServerConfig(cfg *Config) config.OAuthServerConfig {
 		serverCfg.Enabled = true
 	}
 
+	// Broker target secret refs without an explicit namespace resolve against
+	// the muster namespace (same default the per-MCPServer tokenExchange
+	// secret refs use via the MCPServer's own namespace).
+	serverCfg.TokenExchangeBroker.DefaultSecretNamespace = cfg.MusterConfig.Namespace
+
 	return serverCfg
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -333,6 +333,87 @@ type OAuthServerConfig struct {
 	// If empty the library defaults to BaseURL (the issuer URL).
 	// Example: "https://muster.example.com/mcp"
 	ResourceIdentifier string `yaml:"resourceIdentifier,omitempty"`
+
+	// TokenExchangeBroker exposes muster's RFC 8693 token exchange to external
+	// confidential clients: a broker client POSTs a token-exchange request with
+	// an `audience` parameter to /oauth/token and receives a token minted by
+	// the audience's downstream Dex (not a muster-issued JWT). Subject tokens
+	// are validated against TrustedIssuers; the per-client allowlist below
+	// gates which audiences each client may request.
+	TokenExchangeBroker TokenExchangeBrokerConfig `yaml:"tokenExchangeBroker,omitempty"`
+}
+
+// TokenExchangeBrokerConfig configures brokered RFC 8693 token exchange
+// (muster as a shared token broker for external clients).
+type TokenExchangeBrokerConfig struct {
+	// ClientAudiences maps an authenticated confidential broker client ID to
+	// the audiences it may request. Requests for audiences outside the
+	// client's list are rejected with invalid_target. Maps to mcp-oauth's
+	// Config.TokenExchangeClientAudiences.
+	ClientAudiences map[string][]string `yaml:"clientAudiences,omitempty"`
+
+	// Targets maps an RFC 8693 audience name (e.g. a management cluster name)
+	// to the downstream Dex exchange target.
+	Targets map[string]BrokerTargetConfig `yaml:"targets,omitempty"`
+
+	// AllowPrivateIP allows downstream token endpoints to resolve to private
+	// or loopback IP addresses. WARNING: reduces SSRF protection; only enable
+	// for internal/VPN deployments where the target Dex is reachable via a
+	// private address.
+	AllowPrivateIP bool `yaml:"allowPrivateIP,omitempty"`
+
+	// DefaultSecretNamespace is the namespace used for target credential
+	// secret refs that do not set an explicit namespace. Populated from the
+	// muster namespace by the serve command; not user-facing config.
+	DefaultSecretNamespace string `yaml:"-"`
+}
+
+// Enabled reports whether brokered token exchange is configured.
+func (c TokenExchangeBrokerConfig) Enabled() bool {
+	return len(c.Targets) > 0
+}
+
+// BrokerTargetConfig describes one downstream Dex target of the token broker.
+type BrokerTargetConfig struct {
+	// DexTokenEndpoint is the downstream Dex token endpoint URL (HTTPS).
+	// Example: https://dex.cluster-b.example.com/token
+	DexTokenEndpoint string `yaml:"dexTokenEndpoint"`
+
+	// ExpectedIssuer is the expected iss claim of the exchanged token. If
+	// empty, it is derived from DexTokenEndpoint (strip /token suffix).
+	ExpectedIssuer string `yaml:"expectedIssuer,omitempty"`
+
+	// ConnectorID is the downstream Dex OIDC connector that trusts the
+	// subject token's issuer.
+	ConnectorID string `yaml:"connectorId"`
+
+	// Scopes is the space-separated scope set requested downstream. Defaults
+	// to "openid profile email groups". For Kubernetes-bound audiences this
+	// must include the Dex cross-client scope for the apiserver's client,
+	// e.g. "audience:server:client_id:dex-k8s-authenticator" — without it
+	// the exchanged token's aud is the exchange client only, which mcp-*
+	// servers accept but kube-apiserver rejects.
+	Scopes string `yaml:"scopes,omitempty"`
+
+	// ClientCredentialsSecretRef references the Kubernetes Secret holding the
+	// downstream exchange client credentials (same secrets the per-MCPServer
+	// tokenExchange config uses; no duplication).
+	ClientCredentialsSecretRef *BrokerSecretRefConfig `yaml:"clientCredentialsSecretRef,omitempty"`
+}
+
+// BrokerSecretRefConfig references a Kubernetes Secret with OAuth client
+// credentials. Mirrors api.ClientCredentialsSecretRef (kept separate to avoid
+// an import cycle between config and api).
+type BrokerSecretRefConfig struct {
+	// Name is the secret name. Required.
+	Name string `yaml:"name"`
+	// Namespace defaults to the broker's DefaultSecretNamespace (the muster
+	// namespace) when empty.
+	Namespace string `yaml:"namespace,omitempty"`
+	// ClientIDKey defaults to "client-id".
+	ClientIDKey string `yaml:"clientIdKey,omitempty"`
+	// ClientSecretKey defaults to "client-secret".
+	ClientSecretKey string `yaml:"clientSecretKey,omitempty"`
 }
 
 // TrustedIssuerConfig mirrors server.TrustedIssuer.

--- a/internal/oauth/broker.go
+++ b/internal/oauth/broker.go
@@ -1,0 +1,128 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	oauthserver "github.com/giantswarm/mcp-oauth/server"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// BrokerExchanger implements mcp-oauth's server.Exchanger on top of muster's
+// TokenExchanger, turning muster into a shared RFC 8693 token broker: an
+// external confidential client (e.g. a developer-portal backend) presents a
+// subject token plus an audience name and receives a token minted by the
+// audience's downstream Dex.
+//
+// mcp-oauth owns subject-token validation (TrustedIssuers), client
+// authentication, the per-client audience allowlist
+// (Config.TokenExchangeClientAudiences), and audit. BrokerExchanger owns the
+// audience -> downstream-Dex mapping and the actual downstream exchange,
+// reusing the per-(endpoint, connector, user) token cache of TokenExchanger.
+//
+// The exchanger instance is deliberately separate from the OAuth manager's
+// internal SSO exchanger: broker targets carry their own scope sets (e.g. the
+// Dex cross-client scope for kube-apiserver-bound audiences), and sharing the
+// cache with the internal SSO path could serve a token minted with different
+// scopes for the same (endpoint, connector, user) key.
+//
+// Thread-safe: Yes.
+type BrokerExchanger struct {
+	cfg       config.TokenExchangeBrokerConfig
+	exchanger *TokenExchanger
+}
+
+// NewBrokerExchanger creates a BrokerExchanger for the configured targets.
+func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig) *BrokerExchanger {
+	// Mirror the OAuth manager's internal-deployment handling: mcp-oauth's
+	// private-IP-allowed client bypasses the process-wide augmented transport
+	// (--extra-ca-file), so hand the exchanger an explicit client backed by
+	// http.DefaultTransport when private IPs are allowed.
+	var httpClient *http.Client
+	if cfg.AllowPrivateIP {
+		httpClient = &http.Client{
+			Transport: http.DefaultTransport,
+			Timeout:   30 * time.Second,
+		}
+	}
+	return &BrokerExchanger{
+		cfg: cfg,
+		exchanger: NewTokenExchangerWithOptions(TokenExchangerOptions{
+			AllowPrivateIP: cfg.AllowPrivateIP,
+			HTTPClient:     httpClient,
+		}),
+	}
+}
+
+// Exchange maps the requested audience to a downstream Dex target and performs
+// the downstream RFC 8693 exchange, forwarding the (already validated) subject
+// token verbatim. Unknown audiences return an error wrapping
+// server.ErrInvalidTarget so the client receives invalid_target.
+func (b *BrokerExchanger) Exchange(ctx context.Context, req *oauthserver.ExchangerRequest) (*oauthserver.ExchangerResult, error) {
+	target, ok := b.cfg.Targets[req.Audience]
+	if !ok {
+		return nil, fmt.Errorf("%w: no broker target configured for audience %q", oauthserver.ErrInvalidTarget, req.Audience)
+	}
+
+	exchangeConfig := &api.TokenExchangeConfig{
+		Enabled:          true,
+		DexTokenEndpoint: target.DexTokenEndpoint,
+		ExpectedIssuer:   target.ExpectedIssuer,
+		ConnectorID:      target.ConnectorID,
+		// Scopes are operator-controlled per target (the RFC 8693 scope
+		// parameter from the client is intentionally ignored): k8s-bound
+		// audiences need the Dex cross-client scope and clients must not be
+		// able to drop or extend it.
+		Scopes: target.Scopes,
+	}
+
+	if target.ClientCredentialsSecretRef != nil {
+		creds, err := b.loadCredentials(ctx, target.ClientCredentialsSecretRef)
+		if err != nil {
+			logging.Warn("TokenBroker", "Failed to load credentials for audience=%s: %v", req.Audience, err)
+			return nil, fmt.Errorf("load broker credentials for audience %q: %w", req.Audience, err)
+		}
+		exchangeConfig.ClientID = creds.ClientID
+		exchangeConfig.ClientSecret = creds.ClientSecret
+	}
+
+	result, err := b.exchanger.Exchange(ctx, &ExchangeRequest{
+		Config:           exchangeConfig,
+		SubjectToken:     req.SubjectToken,
+		SubjectTokenType: req.SubjectTokenType,
+		UserID:           req.Subject.Subject,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logging.Debug("TokenBroker", "Brokered exchange for audience=%s user=%s (cached=%v)",
+		req.Audience, logging.TruncateIdentifier(req.Subject.Subject), result.FromCache)
+
+	return &oauthserver.ExchangerResult{
+		AccessToken:     result.AccessToken,
+		IssuedTokenType: result.IssuedTokenType,
+		ExpiresAt:       result.ExpiresAt,
+	}, nil
+}
+
+// loadCredentials resolves the downstream exchange client credentials from the
+// referenced Kubernetes Secret via the registered SecretCredentialsHandler
+// (the same mechanism the per-MCPServer tokenExchange config uses).
+func (b *BrokerExchanger) loadCredentials(ctx context.Context, ref *config.BrokerSecretRefConfig) (*api.ClientCredentials, error) {
+	handler := api.GetSecretCredentialsHandler()
+	if handler == nil {
+		return nil, fmt.Errorf("no secret credentials handler registered (broker secret refs require Kubernetes mode)")
+	}
+	return handler.LoadClientCredentials(ctx, &api.ClientCredentialsSecretRef{
+		Name:            ref.Name,
+		Namespace:       ref.Namespace,
+		ClientIDKey:     ref.ClientIDKey,
+		ClientSecretKey: ref.ClientSecretKey,
+	}, b.cfg.DefaultSecretNamespace)
+}

--- a/internal/oauth/broker_test.go
+++ b/internal/oauth/broker_test.go
@@ -1,0 +1,234 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	oauthserver "github.com/giantswarm/mcp-oauth/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+)
+
+// stubCredentialsHandler is a SecretCredentialsHandler test double.
+type stubCredentialsHandler struct {
+	creds            *api.ClientCredentials
+	err              error
+	gotRef           *api.ClientCredentialsSecretRef
+	gotDefaultNS     string
+	loadCallObserved bool
+}
+
+func (s *stubCredentialsHandler) LoadClientCredentials(_ context.Context, ref *api.ClientCredentialsSecretRef, defaultNamespace string) (*api.ClientCredentials, error) {
+	s.loadCallObserved = true
+	s.gotRef = ref
+	s.gotDefaultNS = defaultNamespace
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.creds, nil
+}
+
+// withCredentialsHandler registers h for the duration of the test and restores
+// the previous handler afterwards (the registry is a package-level global).
+func withCredentialsHandler(t *testing.T, h api.SecretCredentialsHandler) {
+	t.Helper()
+	prev := api.GetSecretCredentialsHandler()
+	api.RegisterSecretCredentialsHandler(h)
+	t.Cleanup(func() { api.RegisterSecretCredentialsHandler(prev) })
+}
+
+func newTestBroker(cfg config.TokenExchangeBrokerConfig, httpClient *http.Client) *BrokerExchanger {
+	return &BrokerExchanger{
+		cfg: cfg,
+		exchanger: NewTokenExchangerWithOptions(TokenExchangerOptions{
+			AllowPrivateIP: true, // httptest servers listen on 127.0.0.1
+			HTTPClient:     httpClient,
+		}),
+	}
+}
+
+func subjectIdentity(sub string) *oauthserver.SubjectIdentity {
+	return &oauthserver.SubjectIdentity{Subject: sub, Issuer: "https://dex.main.example.com"}
+}
+
+func TestBrokerExchanger_UnknownAudience(t *testing.T) {
+	broker := newTestBroker(config.TokenExchangeBrokerConfig{
+		Targets: map[string]config.BrokerTargetConfig{},
+	}, nil)
+
+	_, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+		Audience:     "unmapped",
+		Subject:      subjectIdentity("user-1"),
+		SubjectToken: "subject-token",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, oauthserver.ErrInvalidTarget), "unmapped audience must wrap ErrInvalidTarget, got: %v", err)
+}
+
+func TestBrokerExchanger_Exchange(t *testing.T) {
+	var gotForm map[string]string
+	var gotUser, gotPass string
+	var gotBasicAuth bool
+
+	downstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotForm = map[string]string{}
+		for k := range r.PostForm {
+			gotForm[k] = r.PostForm.Get(k)
+		}
+		gotUser, gotPass, gotBasicAuth = r.BasicAuth()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      "downstream-token",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			"token_type":        "bearer",
+			"expires_in":        1800,
+		})
+	}))
+	defer downstream.Close()
+
+	handler := &stubCredentialsHandler{
+		creds: &api.ClientCredentials{ClientID: "exchange-client", ClientSecret: "exchange-secret"},
+	}
+	withCredentialsHandler(t, handler)
+
+	scopes := "openid profile email groups audience:server:client_id:dex-k8s-authenticator"
+	broker := newTestBroker(config.TokenExchangeBrokerConfig{
+		Targets: map[string]config.BrokerTargetConfig{
+			"cluster-a": {
+				DexTokenEndpoint: downstream.URL + "/token",
+				ConnectorID:      "main-dex",
+				Scopes:           scopes,
+				ClientCredentialsSecretRef: &config.BrokerSecretRefConfig{
+					Name: "muster-token-exchange-cluster-a",
+				},
+			},
+		},
+		DefaultSecretNamespace: "muster-system",
+	}, downstream.Client())
+
+	result, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+		Audience:         "cluster-a",
+		ClientID:         "portal-backend",
+		Subject:          subjectIdentity("user-1"),
+		SubjectToken:     "main-dex-id-token",
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+		Scope:            "client-requested-scope-must-be-ignored",
+	})
+	require.NoError(t, err)
+
+	// Result propagation.
+	assert.Equal(t, "downstream-token", result.AccessToken)
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", result.IssuedTokenType)
+	assert.WithinDuration(t, time.Now().Add(1800*time.Second), result.ExpiresAt, 30*time.Second)
+
+	// Downstream request: subject token forwarded verbatim, operator-configured
+	// scopes (not the client-requested ones), connector pinned, creds from secret.
+	assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", gotForm["grant_type"])
+	assert.Equal(t, "main-dex-id-token", gotForm["subject_token"])
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:id_token", gotForm["subject_token_type"])
+	assert.Equal(t, "main-dex", gotForm["connector_id"])
+	assert.Equal(t, scopes, gotForm["scope"])
+	assert.True(t, gotBasicAuth)
+	assert.Equal(t, "exchange-client", gotUser)
+	assert.Equal(t, "exchange-secret", gotPass)
+
+	// Secret resolution went through the registered handler with the broker's
+	// default namespace.
+	require.NotNil(t, handler.gotRef)
+	assert.Equal(t, "muster-token-exchange-cluster-a", handler.gotRef.Name)
+	assert.Equal(t, "muster-system", handler.gotDefaultNS)
+
+	// Second exchange for the same user is served from the per-(endpoint,
+	// connector, user) cache and keeps a usable expiry.
+	cached, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+		Audience:         "cluster-a",
+		ClientID:         "portal-backend",
+		Subject:          subjectIdentity("user-1"),
+		SubjectToken:     "main-dex-id-token",
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "downstream-token", cached.AccessToken)
+	assert.True(t, cached.ExpiresAt.After(time.Now()))
+	stats := broker.exchanger.GetCacheStats()
+	assert.Equal(t, 1, stats.CurrentEntries)
+}
+
+func TestBrokerExchanger_CredentialsErrors(t *testing.T) {
+	target := config.BrokerTargetConfig{
+		DexTokenEndpoint: "https://dex.cluster-a.example.com/token",
+		ConnectorID:      "main-dex",
+		ClientCredentialsSecretRef: &config.BrokerSecretRefConfig{
+			Name: "muster-token-exchange-cluster-a",
+		},
+	}
+	cfg := config.TokenExchangeBrokerConfig{
+		Targets: map[string]config.BrokerTargetConfig{"cluster-a": target},
+	}
+	req := &oauthserver.ExchangerRequest{
+		Audience:     "cluster-a",
+		Subject:      subjectIdentity("user-1"),
+		SubjectToken: "subject-token",
+	}
+
+	t.Run("no handler registered", func(t *testing.T) {
+		withCredentialsHandler(t, nil)
+		_, err := newTestBroker(cfg, nil).Exchange(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no secret credentials handler registered")
+		assert.False(t, errors.Is(err, oauthserver.ErrInvalidTarget))
+	})
+
+	t.Run("secret load failure", func(t *testing.T) {
+		withCredentialsHandler(t, &stubCredentialsHandler{err: fmt.Errorf("secret not found")})
+		_, err := newTestBroker(cfg, nil).Exchange(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret not found")
+		assert.False(t, errors.Is(err, oauthserver.ErrInvalidTarget))
+	})
+}
+
+func TestBrokerExchanger_DownstreamError(t *testing.T) {
+	downstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant"})
+	}))
+	defer downstream.Close()
+
+	broker := newTestBroker(config.TokenExchangeBrokerConfig{
+		Targets: map[string]config.BrokerTargetConfig{
+			"cluster-a": {
+				DexTokenEndpoint: downstream.URL + "/token",
+				ConnectorID:      "main-dex",
+			},
+		},
+	}, downstream.Client())
+
+	_, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+		Audience:     "cluster-a",
+		Subject:      subjectIdentity("user-1"),
+		SubjectToken: "subject-token",
+	})
+	require.Error(t, err)
+	// Downstream failures must not map to invalid_target; mcp-oauth reports
+	// them to the client as a generic invalid_grant.
+	assert.False(t, errors.Is(err, oauthserver.ErrInvalidTarget))
+}
+
+func TestTokenExchangeBrokerConfig_Enabled(t *testing.T) {
+	assert.False(t, config.TokenExchangeBrokerConfig{}.Enabled())
+	assert.True(t, config.TokenExchangeBrokerConfig{
+		Targets: map[string]config.BrokerTargetConfig{"a": {}},
+	}.Enabled())
+}

--- a/internal/oauth/token_exchange.go
+++ b/internal/oauth/token_exchange.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/pkg/logging"
@@ -120,6 +121,11 @@ type ExchangeResult struct {
 	// IssuedTokenType is the type of the issued token.
 	IssuedTokenType string
 
+	// ExpiresAt is the exchanged token's expiry. Derived from the token
+	// endpoint's expires_in (or, failing that, the token's exp claim).
+	// Zero when neither is available.
+	ExpiresAt time.Time
+
 	// FromCache indicates whether the token was served from cache.
 	FromCache bool
 }
@@ -200,6 +206,7 @@ func (e *TokenExchanger) Exchange(ctx context.Context, req *ExchangeRequest) (*E
 		return &ExchangeResult{
 			AccessToken:     cached.AccessToken,
 			IssuedTokenType: cached.IssuedTokenType,
+			ExpiresAt:       cached.ExpiresAt,
 			FromCache:       true,
 		}, nil
 	}
@@ -255,9 +262,17 @@ func (e *TokenExchanger) Exchange(ctx context.Context, req *ExchangeRequest) (*E
 	logging.Info("TokenExchange", "Successfully exchanged token for user=%s endpoint=%s",
 		logging.TruncateIdentifier(req.UserID), req.Config.DexTokenEndpoint)
 
+	var expiresAt time.Time
+	if resp.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second)
+	} else if exp, err := pkgoauth.Expiry(resp.AccessToken); err == nil {
+		expiresAt = exp
+	}
+
 	return &ExchangeResult{
 		AccessToken:     resp.AccessToken,
 		IssuedTokenType: resp.IssuedTokenType,
+		ExpiresAt:       expiresAt,
 		FromCache:       false,
 	}, nil
 }

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -16,6 +16,7 @@ import (
 	valkeygo "github.com/valkey-io/valkey-go"
 
 	"github.com/giantswarm/muster/internal/config"
+	musteroauth "github.com/giantswarm/muster/internal/oauth"
 )
 
 // newOAuthServerConfig maps the muster OAuth config onto the mcp-oauth Config.
@@ -46,6 +47,10 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		// the same private-IP issuer instead of rejecting it as a DNS-rebinding
 		// attack. Public-hostname Dex deployments are unaffected.
 		AllowPrivateIPJWKS: cfg.Dex.AllowPrivateIPOIDC,
+		// Per-client audience allowlist for brokered RFC 8693 token exchange.
+		// Only consulted when an Exchanger is registered (see
+		// buildOAuthServerOptions); a miss returns invalid_target.
+		TokenExchangeClientAudiences: cfg.TokenExchangeBroker.ClientAudiences,
 	}
 	if cfg.EnableJWTMode {
 		result.AccessTokenFormat = oauthserver.AccessTokenFormatJWT
@@ -88,6 +93,20 @@ func buildOAuthServerOptions(cfg config.OAuthServerConfig, logger *slog.Logger) 
 			issuers[i] = toTrustedIssuer(iss)
 		}
 		opts = append(opts, oauthserver.WithTrustedIssuers(issuers))
+	}
+
+	if cfg.TokenExchangeBroker.Enabled() {
+		if len(cfg.TrustedIssuers) == 0 {
+			return nil, fmt.Errorf("tokenExchangeBroker requires at least one trustedIssuers entry to validate subject tokens")
+		}
+		opts = append(opts, oauthserver.WithExchanger(musteroauth.NewBrokerExchanger(cfg.TokenExchangeBroker)))
+		brokerLogger := logger
+		if brokerLogger == nil {
+			brokerLogger = slog.Default()
+		}
+		brokerLogger.Info("Brokered RFC 8693 token exchange enabled",
+			"targets", len(cfg.TokenExchangeBroker.Targets),
+			"brokerClients", len(cfg.TokenExchangeBroker.ClientAudiences))
 	}
 
 	if len(cfg.TrustedProxyCIDRs) > 0 {

--- a/internal/server/oauth_server_config_test.go
+++ b/internal/server/oauth_server_config_test.go
@@ -141,6 +141,52 @@ func TestToTrustedIssuer_MapsAllFields(t *testing.T) {
 	require.True(t, got.AllowPrivateIPJWKS)
 }
 
+func TestNewOAuthServerConfig_MapsTokenExchangeClientAudiences(t *testing.T) {
+	t.Parallel()
+
+	allowlist := map[string][]string{
+		"portal-backend": {"cluster-a", "cluster-b"},
+	}
+	cfg := config.OAuthServerConfig{
+		BaseURL: "https://muster.example.com",
+		TokenExchangeBroker: config.TokenExchangeBrokerConfig{
+			ClientAudiences: allowlist,
+		},
+	}
+	got := newOAuthServerConfig(cfg, time.Hour)
+	require.Equal(t, allowlist, got.TokenExchangeClientAudiences)
+}
+
+func TestBuildOAuthServerOptions_BrokerRequiresTrustedIssuers(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.OAuthServerConfig{
+		BaseURL: "https://muster.example.com",
+		TokenExchangeBroker: config.TokenExchangeBrokerConfig{
+			Targets: map[string]config.BrokerTargetConfig{
+				"cluster-a": {
+					DexTokenEndpoint: "https://dex.cluster-a.example.com/token",
+					ConnectorID:      "main-dex",
+				},
+			},
+		},
+	}
+	_, err := buildOAuthServerOptions(cfg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "trustedIssuers")
+
+	cfg.TrustedIssuers = []config.TrustedIssuerConfig{
+		{
+			Issuer:           "https://dex.main.example.com",
+			JwksURL:          "https://dex.main.example.com/keys",
+			AllowedAudiences: []string{"portal-frontend"},
+		},
+	}
+	opts, err := buildOAuthServerOptions(cfg, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, opts)
+}
+
 func TestBuildOAuthServerOptions_InvalidCIDRReturnsError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Closes #831. Part of the Backstage SSO via muster token broker epic (giantswarm/giantswarm#36840); the mcp-oauth side shipped in giantswarm/mcp-oauth#447 (v0.3.0).

- Bump mcp-oauth to **v0.3.0** and register a `server.Exchanger` (via `server.WithExchanger`) when the new `oauth.server.tokenExchangeBroker` config block is set. External **confidential** clients can now POST an RFC 8693 token-exchange request with an `audience` parameter to `/oauth/token` and receive a token minted by the audience's downstream Dex (instead of a muster-issued JWT).
- **Config surface**: `tokenExchangeBroker.clientAudiences` (per-client audience allowlist, mapped to mcp-oauth's `Config.TokenExchangeClientAudiences`) and `tokenExchangeBroker.targets` (audience name → downstream Dex token endpoint, connector, per-target scopes, credential secret ref). Secret refs resolve through the existing `SecretCredentialsHandler` — the same per-MC credential secrets the per-MCPServer `tokenExchange` config uses, no duplication. Startup fails fast if the broker is configured without any `trustedIssuers` (needed to validate subject tokens).
- **Scopes are operator-controlled per target** and the client-supplied RFC 8693 `scope` parameter is intentionally ignored: Kubernetes-bound audiences must include the Dex cross-client scope (`audience:server:client_id:dex-k8s-authenticator`) and clients must not be able to drop or extend it.
- `BrokerExchanger` wraps a **dedicated** `TokenExchanger` instance (not the OAuth manager's): broker targets carry their own scope sets, so sharing the per-(endpoint, connector, user) cache with the internal SSO exchange path could serve tokens minted with different scopes for the same cache key.
- `ExchangeResult` now carries `ExpiresAt` (from `expires_in`, falling back to the token's `exp` claim) so the broker grant's `expires_in` is bounded by the downstream token expiry. No refresh tokens are issued; clients re-exchange.
- Helm: values, values.schema.json, configmap rendering (`tokenExchangeBroker` block), chart unit tests; docs in `docs/reference/configuration.md`.

## Test plan

- [x] `go test ./...` green (new unit tests: BrokerExchanger audience mapping/invalid_target, downstream form contents incl. scope pinning and basic auth from secret-resolved creds, cache behavior, expiry propagation, credential error paths; config mapping tests for `TokenExchangeClientAudiences` and the trustedIssuers guard)
- [x] `golangci-lint run -E gosec -E goconst` clean (CI-pinned 2.12.2)
- [x] `helm unittest helm/muster` (83 tests) and `helm template` render with broker values
- [ ] Deployed integration test: POST RFC 8693 request with a main-Dex ID token → short-lived MC token (post-release, via GitOps rollout)

Made with [Cursor](https://cursor.com)