### PR TITLE
feat(oauth): per-issuer acceptedTypHeaders for trustedIssuers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Update mcp-oauth to v0.4.0.
 - Update mcp-oauth to v0.3.1: forwarded ID tokens (`trustedAudiences`) are no longer hard-rejected by the trusted-issuer Bearer branch when the same issuer is also configured in `trustedIssuers` — fixes Backstage AI-chat SSO token forwarding returning 401 (`typ header is "", expected "at+jwt"`) on deployments with the token-exchange broker enabled.
 - Update mcp-oauth to v0.3.0 (server-side RFC 8693 token-exchange grant with pluggable `Exchanger`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `oauth.server.trustedIssuers[].acceptedTypHeaders`: accepted JWT `typ` header values for Bearer tokens from a trusted issuer. Empty keeps the RFC 9068 default (`at+jwt`). Kubernetes ServiceAccount tokens carry no `typ` header; use `[""]` to accept them.
+
 - Brokered RFC 8693 token exchange ([#831](https://github.com/giantswarm/muster/issues/831)): external confidential clients can POST a token-exchange request with an `audience` parameter to `/oauth/token` and receive a token minted by the audience's downstream Dex. New `oauth.server.tokenExchangeBroker` config block (per-client audience allowlist, audience → downstream Dex target mapping with per-target scopes and credential secret refs). Requires mcp-oauth >= v0.3.0; subject tokens are validated against `trustedIssuers`.
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.3.1
+	github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e
+	github.com/giantswarm/mcp-oauth v0.4.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e h1:S0ytBbB2OyNYaHFeMLf5IKdglTFPjN1JeJxYelZUcW0=
 github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
+github.com/giantswarm/mcp-oauth v0.4.0 h1:XQISPBS5fDjPvch97Cnn6nuE3J7aO5FjfYeBQTpTYbI=
+github.com/giantswarm/mcp-oauth v0.4.0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e h1:S0ytBbB2OyNYaHFeMLf5IKdglTFPjN1JeJxYelZUcW0=
-github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-oauth v0.4.0 h1:XQISPBS5fDjPvch97Cnn6nuE3J7aO5FjfYeBQTpTYbI=
 github.com/giantswarm/mcp-oauth v0.4.0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.3.1 h1:v7TSNt2eTnY5I6frSirDsYc9iqSWDnAERzdanLGS7rI=
-github.com/giantswarm/mcp-oauth v0.3.1/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
+github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e h1:S0ytBbB2OyNYaHFeMLf5IKdglTFPjN1JeJxYelZUcW0=
+github.com/giantswarm/mcp-oauth v0.3.3-0.20260612073728-d761b794655e/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -559,7 +559,8 @@
                   "allowedAudiences": {"type": "array", "items": {"type": "string"}},
                   "allowedScopes": {"type": "array", "items": {"type": "string"}},
                   "allowedClaims": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Required JWT claim name→pattern pairs. Values are exact strings or globs ('*' any chars incl. '/', '?' one char). Absent or non-string claims are rejected. Empty means no restriction."},
-                  "allowPrivateIPJWKS": {"type": "boolean", "description": "Allow jwksUrl to resolve to a private/loopback IP. Required for in-cluster Kubernetes SA trust (https://kubernetes.default.svc/openid/v1/jwks). Emits a startup warning when set."}
+                  "allowPrivateIPJWKS": {"type": "boolean", "description": "Allow jwksUrl to resolve to a private/loopback IP. Required for in-cluster Kubernetes SA trust (https://kubernetes.default.svc/openid/v1/jwks). Emits a startup warning when set."},
+                  "acceptedTypHeaders": {"type": "array", "items": {"type": "string"}, "description": "Accepted JWT typ header values for Bearer tokens from this issuer. Empty keeps the RFC 9068 default (at+jwt). Kubernetes ServiceAccount tokens carry no typ header; use [\"\"] to accept them."}
                 }
               }
             },

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -437,6 +437,11 @@ type TrustedIssuerConfig struct {
 	// is https://kubernetes.default.svc/openid/v1/jwks. Emits a startup warning
 	// when set (mcp-oauth dev-override flag). Default: false.
 	AllowPrivateIPJWKS bool `yaml:"allowPrivateIPJWKS,omitempty"`
+	// AcceptedTypHeaders lists the JWT typ header values accepted for Bearer
+	// tokens from this issuer. Empty keeps the RFC 9068 default ("at+jwt").
+	// Kubernetes ServiceAccount tokens carry no typ header; use [""] to
+	// accept them.
+	AcceptedTypHeaders []string `yaml:"acceptedTypHeaders,omitempty"`
 }
 
 // DexConfig holds configuration for the Dex OIDC provider.

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -128,6 +128,7 @@ func toTrustedIssuer(iss config.TrustedIssuerConfig) oauthserver.TrustedIssuer {
 		AllowedScopes:      iss.AllowedScopes,
 		AllowedClaims:      iss.AllowedClaims,
 		AllowPrivateIPJWKS: iss.AllowPrivateIPJWKS,
+		AcceptedTypHeaders: iss.AcceptedTypHeaders,
 	}
 }
 


### PR DESCRIPTION
## What

Adds `oauth.server.trustedIssuers[].acceptedTypHeaders` (config, chart schema, plumbing to mcp-oauth's new `TrustedIssuer.AcceptedTypHeaders`). Bumps mcp-oauth to a pre-release of giantswarm/mcp-oauth#449.

## Why

Kubernetes ServiceAccount tokens carry no `typ` header. mcp-oauth's trusted-issuer Bearer path enforced RFC 9068 `typ: at+jwt` unconditionally, so every SA token configured via `trustedIssuers` was rejected with `trusted_issuer_typ_invalid` after passing signature/issuer/audience/claims — observed live on glean with the kagent SA-token bridge (agentic-platform#82). Setting `acceptedTypHeaders: [""]` on the cluster issuer entry accepts them; all other checks unchanged, defaults stay strict.

Depends on giantswarm/mcp-oauth#449 (needs a tagged release before this merges).