### PR TITLE
fix: update mcp-oauth to v0.3.1 (forwarded ID token fall-through)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Update mcp-oauth to v0.3.1: forwarded ID tokens (`trustedAudiences`) are no longer hard-rejected by the trusted-issuer Bearer branch when the same issuer is also configured in `trustedIssuers` — fixes Backstage AI-chat SSO token forwarding returning 401 (`typ header is "", expected "at+jwt"`) on deployments with the token-exchange broker enabled.
 - Update mcp-oauth to v0.3.0 (server-side RFC 8693 token-exchange grant with pluggable `Exchanger`).
 
 ## [0.3.12] - 2026-06-10

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.3.0
+	github.com/giantswarm/mcp-oauth v0.3.1
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.3.0 h1:nH0OI7TPgW+G/A5Xocoq0x1FSV0bEEg28nQGBl39Fk8=
-github.com/giantswarm/mcp-oauth v0.3.0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
+github.com/giantswarm/mcp-oauth v0.3.1 h1:v7TSNt2eTnY5I6frSirDsYc9iqSWDnAERzdanLGS7rI=
+github.com/giantswarm/mcp-oauth v0.3.1/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=


### PR DESCRIPTION
## Summary

Bumps mcp-oauth v0.3.0 → v0.3.1 ([mcp-oauth#450](https://github.com/giantswarm/mcp-oauth/pull/450)): when the main Dex issuer is also configured in `trustedIssuers` (required for the RFC 8693 token-exchange broker), forwarded ID tokens with a `trustedAudiences` match were hard-rejected by the trusted-issuer Bearer branch (`typ header is "", expected "at+jwt"`) before the forwarded-ID-token branch could validate them. This broke Backstage AI-chat SSO token forwarding on deployments with the broker enabled (observed on the gazelle devportal). v0.3.1 defers such tokens to the forwarded-ID-token validation path.

## Test plan

- [x] `go build ./...`, `go test ./internal/server/...` green
- [ ] After release + deploy: AI-chat muster requests on the devportal validate (no 401 from muster behind the agentgateway)

Made with [Cursor](https://cursor.com)