### PR TITLE
fix: health endpoint on OAuth mux, drop dead status fields, promote lifecycle logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - `GET /health` now responds 200 on the aggregator port regardless of OAuth configuration, so Kubernetes liveness/readiness probes work without patching the chart.
 - `RegisterServer` and `DeregisterServer` aggregator events and MCPServer reconcile entry are now logged at Info level, making freshly-restarted pod lifecycle visible without `--debug`.
+- `oauth.server.allowedOrigins` (comma-separated) is now wired into the mcp-oauth CORS `AllowedOrigins` list. Previously declared but never read; empty value keeps CORS disabled (default).
 
 ### Removed
 
 - `MCPServer.status.consecutiveFailures`, `.lastAttempt`, and `.nextRetryAfter` are no longer updated by the reconciler; the retry state machine that drove them was removed in a prior release. The fields remain on the CRD for forward compatibility.
+- `oauth.server.enableHSTS`, `oauth.server.tlsCertFile`, and `oauth.server.tlsKeyFile` config fields removed; they were declared and YAML-parsed but never read anywhere in the codebase.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `GET /health` now responds 200 on the aggregator port regardless of OAuth configuration, so Kubernetes liveness/readiness probes work without patching the chart.
+- `RegisterServer` and `DeregisterServer` aggregator events and MCPServer reconcile entry are now logged at Info level, making freshly-restarted pod lifecycle visible without `--debug`.
+
+### Removed
+
+- `MCPServer.status.consecutiveFailures`, `.lastAttempt`, and `.nextRetryAfter` are no longer updated by the reconciler; the retry state machine that drove them was removed in a prior release. The fields remain on the CRD for forward compatibility.
+
+### Added
+
 - Brokered RFC 8693 token exchange ([#831](https://github.com/giantswarm/muster/issues/831)): external confidential clients can POST a token-exchange request with an `audience` parameter to `/oauth/token` and receive a token minted by the audience's downstream Dex. New `oauth.server.tokenExchangeBroker` config block (per-client audience allowlist, audience → downstream Dex target mapping with per-target scopes and credential secret refs). Requires mcp-oauth >= v0.3.0; subject tokens are validated against `trustedIssuers`.
 
 ### Changed

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1094,8 +1094,8 @@ func (a *AggregatorServer) Stop(ctx context.Context) error {
 // Returns an error if registration fails due to naming conflicts, client issues,
 // or communication problems with the backend server.
 func (a *AggregatorServer) RegisterServer(ctx context.Context, registration ServerRegistration, client MCPClient) error {
-	logging.DebugWithAttrs("Aggregator", "RegisterServer called",
-		slog.String("server", registration.Name), slog.String("time", time.Now().Format("15:04:05.000")))
+	logging.InfoWithAttrs("Aggregator", "RegisterServer called",
+		slog.String("server", registration.Name))
 
 	// Wire the notification handler before registration so Initialize()
 	// (called inside Register) forwards it to the underlying mcp-go client.
@@ -1140,8 +1140,8 @@ func (a *AggregatorServer) wirePoolNotificationCallback(serverName string) {
 //
 // Returns an error if the server is not found or deregistration fails.
 func (a *AggregatorServer) DeregisterServer(name string) error {
-	logging.DebugWithAttrs("Aggregator", "DeregisterServer called",
-		slog.String("server", name), slog.String("time", time.Now().Format("15:04:05.000")))
+	logging.InfoWithAttrs("Aggregator", "DeregisterServer called",
+		slog.String("server", name))
 
 	// Remove auth state and capabilities for this server across all sessions.
 	if a.authStore != nil {
@@ -1548,6 +1548,14 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 
 	// Authenticated logout endpoints (behind ValidateToken middleware).
 	// These require a valid Bearer token and extract the user's subject from context.
+	// Unauthenticated health check so Kubernetes liveness/readiness probes work
+	// regardless of OAuth configuration.
+	outerMux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
 	outerMux.Handle("DELETE /user-tokens", oauthHTTPServer.ValidateTokenWithSubject(
 		http.HandlerFunc(a.handleUserTokensDeletion)))
 	outerMux.Handle("DELETE /auth/{server}", oauthHTTPServer.ValidateTokenWithSubject(

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -279,18 +279,9 @@ type OAuthServerConfig struct {
 	// Format: Go duration string (e.g., "720h", "30d" is NOT valid, use hours).
 	SessionDuration string `yaml:"sessionDuration,omitempty"`
 
-	// AllowedOrigins is a comma-separated list of allowed CORS origins.
+	// AllowedOrigins is a comma-separated list of allowed CORS origins for
+	// browser-based MCP clients. Empty disables CORS (default, secure).
 	AllowedOrigins string `yaml:"allowedOrigins,omitempty"`
-
-	// EnableHSTS enables HSTS header (for reverse proxy scenarios).
-	EnableHSTS bool `yaml:"enableHSTS,omitempty"`
-
-	// TLSCertFile is the path to the TLS certificate file (PEM format).
-	// If both TLSCertFile and TLSKeyFile are provided, the server will use HTTPS.
-	TLSCertFile string `yaml:"tlsCertFile,omitempty"`
-
-	// TLSKeyFile is the path to the TLS private key file (PEM format).
-	TLSKeyFile string `yaml:"tlsKeyFile,omitempty"`
 
 	// TrustedAudiences lists additional OAuth client IDs (audiences) whose
 	// JWT ID tokens are accepted directly as bearer tokens, without requiring

--- a/internal/reconciler/mcpserver_reconciler.go
+++ b/internal/reconciler/mcpserver_reconciler.go
@@ -78,7 +78,7 @@ func (r *MCPServerReconciler) GetResourceType() ResourceType {
 // check failures, etc.) are eventually reflected in the CRD status even if
 // state change events are missed.
 func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ReconcileRequest) ReconcileResult {
-	logging.Debug("MCPServerReconciler", "Reconciling MCPServer: %s", req.Name)
+	logging.Info("MCPServerReconciler", "Reconciling MCPServer: %s", req.Name)
 
 	// Fetch the desired state from the definition source
 	mcpServerInfo, err := r.mcpServerManager.GetMCPServer(req.Name)
@@ -203,21 +203,6 @@ func (r *MCPServerReconciler) applyStatusFromService(server *musterv1alpha1.MCPS
 			server.Status.LastConnected = &now
 		}
 
-		// Sync failure tracking fields for unreachable server detection
-		serviceData := service.GetServiceData()
-		if serviceData != nil {
-			if failures, ok := serviceData["consecutiveFailures"].(int); ok {
-				server.Status.ConsecutiveFailures = failures
-			}
-			if lastAttempt, ok := serviceData["lastAttempt"].(time.Time); ok {
-				t := metav1.NewTime(lastAttempt)
-				server.Status.LastAttempt = &t
-			}
-			if nextRetry, ok := serviceData["nextRetryAfter"].(time.Time); ok {
-				t := metav1.NewTime(nextRetry)
-				server.Status.NextRetryAfter = &t
-			}
-		}
 	} else {
 		// Service doesn't exist - use appropriate initial state based on server type
 		isRemote := server.Spec.Type == "streamable-http" || server.Spec.Type == "sse"

--- a/internal/server/new_oauth_server_config_test.go
+++ b/internal/server/new_oauth_server_config_test.go
@@ -89,6 +89,36 @@ func TestNewOAuthServerConfig_PreservesAdjacentFields(t *testing.T) {
 	require.Equal(t, int64(time.Hour/time.Second), got.RefreshTokenTTL)
 }
 
+func TestNewOAuthServerConfig_AllowedOriginsSplitAndTrimmed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty disables CORS", in: "", want: nil},
+		{name: "single origin", in: "https://app.example.com", want: []string{"https://app.example.com"}},
+		{name: "multiple origins split on comma", in: "https://a.example.com,https://b.example.com", want: []string{"https://a.example.com", "https://b.example.com"}},
+		{name: "spaces around commas trimmed", in: "https://a.example.com, https://b.example.com", want: []string{"https://a.example.com", "https://b.example.com"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.OAuthServerConfig{
+				BaseURL:        "https://muster.example.com",
+				AllowedOrigins: tc.in,
+			}
+
+			got := newOAuthServerConfig(cfg, time.Hour)
+
+			require.Equal(t, tc.want, got.CORS.AllowedOrigins)
+		})
+	}
+}
+
 func TestNewOAuthServerConfig_AllowPrivateIPJWKSMirrorsDexFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"time"
 
 	oauth "github.com/giantswarm/mcp-oauth"
@@ -51,6 +52,12 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		// Only consulted when an Exchanger is registered (see
 		// buildOAuthServerOptions); a miss returns invalid_target.
 		TokenExchangeClientAudiences: cfg.TokenExchangeBroker.ClientAudiences,
+	}
+	if cfg.AllowedOrigins != "" {
+		result.CORS.AllowedOrigins = strings.Split(cfg.AllowedOrigins, ",")
+		for i, o := range result.CORS.AllowedOrigins {
+			result.CORS.AllowedOrigins[i] = strings.TrimSpace(o)
+		}
 	}
 	if cfg.EnableJWTMode {
 		result.AccessTokenFormat = oauthserver.AccessTokenFormatJWT


### PR DESCRIPTION
Closes #677, #726, #728, #729.

## What changed

**#677 — Wire `AllowedOrigins` into mcp-oauth CORS config**

`oauth.server.allowedOrigins` was parsed from config but never passed to mcp-oauth, so CORS was always disabled regardless of what operators set. `AllowedOrigins` is now split on comma, trimmed, and wired into `oauthserver.Config.CORS.AllowedOrigins`.

Three dead config fields removed from `OAuthServerConfig`: `EnableHSTS`, `TLSCertFile`, `TLSKeyFile` — declared and YAML-parsed but never read anywhere.

**#726 — `GET /health` on the OAuth-protected mux**

`/health` existed only in `createStandardMux`. When OAuth is enabled, `createOAuthProtectedMux` is used instead and Kubernetes HTTP probes returned connection refused, causing pods to cycle. The endpoint is now registered on `outerMux` before the OAuth catchall, unauthenticated.

**#729 — Remove dead status field writers**

`consecutiveFailures`, `lastAttempt`, and `nextRetryAfter` were still written in `applyStatusFromService` via `service.GetServiceData()`, but the retry state machine that populated those keys was removed in a prior release. The map lookups silently produced nothing; the block is now gone. Fields remain on the CRD schema for forward compatibility.

**#728 — Promote key lifecycle logs to Info**

`RegisterServer`, `DeregisterServer`, and `Reconcile` entry were at Debug level. On a freshly-restarted pod these are the first signs of life; they are now Info so normal `kubectl logs` output shows them without `--debug`.