### PR TITLE
feat(observability): service-state OTel metrics, PrometheusRule, Grafana dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- OTel service-lifecycle metrics emitted from the orchestrator: `muster.service.state_transitions_total` counter (labels: `service_name`, `service_type`, `from_state`, `to_state`) and `muster.service.up` observable gauge (1 = running/connected, 0 = otherwise). Both use the same meter scope as existing tool-call metrics. Closes #401.
+- Helm: `prometheusRule.enabled` (under `muster.observability.metrics.prometheus`) renders a `PrometheusRule` with three alerting rules: `MusterServiceDown` (5 min), `MusterServiceFlapping` (>4 transitions in 10 min), `MusterHighToolErrorRate` (>10% error ratio for 5 min). Supports `observability.giantswarm.io/tenant` for multi-tenant Mimir.
+- Helm: `grafanaDashboard.enabled` (under `muster.observability.metrics`) renders a ConfigMap containing a Grafana dashboard with service-status, state-transition, tool-call rate, latency, and error-rate panels. Picked up automatically by the grafana-sidecar.
+
 ### Fixed
 
 - `ssoPoolMissNeedingInit` now detects pool misses for token-forwarding servers in addition to token-exchange servers, so warm sessions (authAlive=true after pod restart) trigger `initSSOForSession` for forwarding servers with empty connection pools. Previously, forwarding servers registered during a restart were inaccessible until the user manually re-authenticated to muster.

--- a/helm/muster/templates/grafana-dashboard.yaml
+++ b/helm/muster/templates/grafana-dashboard.yaml
@@ -69,19 +69,19 @@ data:
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+            "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" },
             "overrides": []
           },
-          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 7 },
+          "gridPos": { "h": 7, "w": 24, "x": 0, "y": 7 },
           "id": 2,
           "options": {
-            "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom" },
+            "legend": { "calcs": ["mean"], "displayMode": "list", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "none" }
           },
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "$datasource" },
-              "expr": "sum by (service_name, to_state) (increase(muster_service_state_transitions_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum by (service_name, to_state) (rate(muster_service_state_transitions_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
               "legendFormat": "{{ "{{" }}service_name{{ "}}" }} → {{ "{{" }}to_state{{ "}}" }}",
               "refId": "A"
             }
@@ -153,25 +153,22 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
+              "custom": { "lineWidth": 2, "fillOpacity": 10 },
               "mappings": [],
               "thresholds": { "mode": "absolute", "steps": [
-                { "color": "green", "value": null },
+                { "color": "green",  "value": null },
                 { "color": "yellow", "value": 0.05 },
-                { "color": "red",   "value": 0.1  }
+                { "color": "red",    "value": 0.1  }
               ]},
               "unit": "percentunit"
             },
             "overrides": []
           },
-          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 22 },
+          "gridPos": { "h": 7, "w": 24, "x": 0, "y": 22 },
           "id": 5,
           "options": {
-            "colorMode": "background",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-            "textMode": "auto"
+            "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
           },
           "targets": [
             {
@@ -182,7 +179,7 @@ data:
             }
           ],
           "title": "Tool Error Rate by Tool",
-          "type": "stat"
+          "type": "timeseries"
         }
       ],
       "refresh": "30s",
@@ -234,7 +231,7 @@ data:
       "timepicker": {},
       "timezone": "browser",
       "title": "Muster",
-      "uid": "muster-overview",
+      "uid": "{{ include "muster.fullname" . | trunc 40 | trimSuffix "-" }}",
       "version": 1
     }
 {{- end }}

--- a/helm/muster/templates/grafana-dashboard.yaml
+++ b/helm/muster/templates/grafana-dashboard.yaml
@@ -1,0 +1,240 @@
+{{- if .Values.muster.observability.metrics.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "muster.fullname" . }}-dashboard
+  namespace: {{ .Values.muster.observability.metrics.grafanaDashboard.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    {{ .Values.muster.observability.metrics.grafanaDashboard.label }}: {{ .Values.muster.observability.metrics.grafanaDashboard.labelValue | quote }}
+data:
+  muster.json: |
+    {
+      "__inputs": [],
+      "__requires": [],
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "id": 100,
+          "title": "Services",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                { "options": { "0": { "color": "red",   "index": 0, "text": "Down" },
+                               "1": { "color": "green", "index": 1, "text": "Up"   } },
+                  "type": "value" }
+              ],
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "red",   "value": null },
+                { "color": "green", "value": 1    }
+              ]},
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 1 },
+          "id": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "muster_service_up{namespace=\"$namespace\",pod=~\"$pod\"}",
+              "instant": true,
+              "legendFormat": "{{ "{{" }}service_name{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Service Status",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "fieldConfig": {
+            "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 7 },
+          "id": 2,
+          "options": {
+            "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "none" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "sum by (service_name, to_state) (increase(muster_service_state_transitions_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+              "legendFormat": "{{ "{{" }}service_name{{ "}}" }} → {{ "{{" }}to_state{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Service State Transitions",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+          "id": 101,
+          "title": "Tool Calls",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "fieldConfig": {
+            "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 15 },
+          "id": 3,
+          "options": {
+            "legend": { "calcs": ["mean"], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "sum by (tool, outcome) (rate(muster_tool_calls_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+              "legendFormat": "{{ "{{" }}tool{{ "}}" }} / {{ "{{" }}outcome{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tool Call Rate by Tool and Outcome",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "fieldConfig": {
+            "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 15 },
+          "id": 4,
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "histogram_quantile(0.99, sum by (tool, le) (rate(muster_tool_call_duration_seconds_bucket{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval])))",
+              "legendFormat": "p99 {{ "{{" }}tool{{ "}}" }}",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "histogram_quantile(0.50, sum by (tool, le) (rate(muster_tool_call_duration_seconds_bucket{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval])))",
+              "legendFormat": "p50 {{ "{{" }}tool{{ "}}" }}",
+              "refId": "B"
+            }
+          ],
+          "title": "Tool Call Latency (p50 / p99)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.05 },
+                { "color": "red",   "value": 0.1  }
+              ]},
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 22 },
+          "id": 5,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "$datasource" },
+              "expr": "sum by (tool) (rate(muster_tool_calls_total{namespace=\"$namespace\",pod=~\"$pod\",outcome=~\"error|error_result\"}[$__rate_interval])) / sum by (tool) (rate(muster_tool_calls_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+              "legendFormat": "{{ "{{" }}tool{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tool Error Rate by Tool",
+          "type": "stat"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 37,
+      "tags": ["muster", "mcp"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "type": "datasource"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "$datasource" },
+            "definition": "label_values(muster_service_up, namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "query": { "query": "label_values(muster_service_up, namespace)", "refId": "A" },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "$datasource" },
+            "definition": "label_values(muster_service_up{namespace=\"$namespace\"}, pod)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Pod",
+            "multi": true,
+            "name": "pod",
+            "query": { "query": "label_values(muster_service_up{namespace=\"$namespace\"}, pod)", "refId": "A" },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": { "from": "now-1h", "to": "now" },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Muster",
+      "uid": "muster-overview",
+      "version": 1
+    }
+{{- end }}

--- a/helm/muster/templates/prometheusrule.yaml
+++ b/helm/muster/templates/prometheusrule.yaml
@@ -16,12 +16,26 @@ spec:
   groups:
     - name: muster.service
       rules:
+        - alert: MusterDown
+          expr: |
+            absent(muster_service_up)
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            runbook_url: "https://github.com/giantswarm/muster/blob/main/docs/runbooks/MusterDown.md"
+            summary: "Muster is not reporting metrics"
+            description: >
+              No muster_service_up series found for 2 minutes. The muster process is likely
+              down or the scrape target is unreachable. Also fires if muster has no services
+              configured.
+
         - alert: MusterServiceDown
           expr: |
             muster_service_up == 0
           for: 5m
           labels:
-            severity: warning
+            severity: critical
           annotations:
             runbook_url: "https://github.com/giantswarm/muster/blob/main/docs/runbooks/MusterServiceDown.md"
             summary: "Muster MCP service {{ "{{" }} $labels.service_name {{ "}}" }} is down"
@@ -31,7 +45,7 @@ spec:
 
         - alert: MusterServiceFlapping
           expr: |
-            increase(muster_service_state_transitions_total[10m]) > 4
+            increase(muster_service_state_transitions_total[10m]) > 8
           for: 1m
           labels:
             severity: warning
@@ -40,7 +54,7 @@ spec:
             summary: "Muster MCP service {{ "{{" }} $labels.service_name {{ "}}" }} is flapping"
             description: >
               MCP service {{ "{{" }} $labels.service_name {{ "}}" }} has transitioned state more than
-              4 times in the last 10 minutes, indicating instability.
+              8 times in the last 10 minutes, indicating instability.
 
     - name: muster.tools
       rules:
@@ -51,6 +65,8 @@ spec:
               /
               sum by (tool) (rate(muster_tool_calls_total[5m]))
             ) > 0.1
+            and
+            sum by (tool) (rate(muster_tool_calls_total[5m])) > 0.05
           for: 5m
           labels:
             severity: warning

--- a/helm/muster/templates/prometheusrule.yaml
+++ b/helm/muster/templates/prometheusrule.yaml
@@ -23,6 +23,7 @@ spec:
           labels:
             severity: warning
           annotations:
+            runbook_url: "https://github.com/giantswarm/muster/blob/main/docs/runbooks/MusterServiceDown.md"
             summary: "Muster MCP service {{ "{{" }} $labels.service_name {{ "}}" }} is down"
             description: >
               MCP service {{ "{{" }} $labels.service_name {{ "}}" }} (type: {{ "{{" }} $labels.service_type {{ "}}" }})
@@ -31,10 +32,11 @@ spec:
         - alert: MusterServiceFlapping
           expr: |
             increase(muster_service_state_transitions_total[10m]) > 4
-          for: 0m
+          for: 1m
           labels:
             severity: warning
           annotations:
+            runbook_url: "https://github.com/giantswarm/muster/blob/main/docs/runbooks/MusterServiceFlapping.md"
             summary: "Muster MCP service {{ "{{" }} $labels.service_name {{ "}}" }} is flapping"
             description: >
               MCP service {{ "{{" }} $labels.service_name {{ "}}" }} has transitioned state more than
@@ -53,6 +55,7 @@ spec:
           labels:
             severity: warning
           annotations:
+            runbook_url: "https://github.com/giantswarm/muster/blob/main/docs/runbooks/MusterHighToolErrorRate.md"
             summary: "High error rate for MCP tool {{ "{{" }} $labels.tool {{ "}}" }}"
             description: >
               MCP tool {{ "{{" }} $labels.tool {{ "}}" }} has an error rate above 10%

--- a/helm/muster/templates/prometheusrule.yaml
+++ b/helm/muster/templates/prometheusrule.yaml
@@ -1,0 +1,60 @@
+{{- if and (eq (include "muster.prometheusExporterEnabled" .) "true") .Values.muster.observability.metrics.prometheus.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "muster.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    {{- with .Values.muster.observability.metrics.prometheus.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.muster.observability.metrics.prometheus.prometheusRule.tenant }}
+    observability.giantswarm.io/tenant: {{ . | quote }}
+    {{- end }}
+spec:
+  groups:
+    - name: muster.service
+      rules:
+        - alert: MusterServiceDown
+          expr: |
+            muster_service_up == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Muster MCP service {{ "{{" }} $labels.service_name {{ "}}" }} is down"
+            description: >
+              MCP service {{ "{{" }} $labels.service_name {{ "}}" }} (type: {{ "{{" }} $labels.service_type {{ "}}" }})
+              has not been in a running/connected state for 5 minutes.
+
+        - alert: MusterServiceFlapping
+          expr: |
+            increase(muster_service_state_transitions_total[10m]) > 4
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Muster MCP service {{ "{{" }} $labels.service_name {{ "}}" }} is flapping"
+            description: >
+              MCP service {{ "{{" }} $labels.service_name {{ "}}" }} has transitioned state more than
+              4 times in the last 10 minutes, indicating instability.
+
+    - name: muster.tools
+      rules:
+        - alert: MusterHighToolErrorRate
+          expr: |
+            (
+              sum by (tool) (rate(muster_tool_calls_total{outcome=~"error|error_result"}[5m]))
+              /
+              sum by (tool) (rate(muster_tool_calls_total[5m]))
+            ) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High error rate for MCP tool {{ "{{" }} $labels.tool {{ "}}" }}"
+            description: >
+              MCP tool {{ "{{" }} $labels.tool {{ "}}" }} has an error rate above 10%
+              ({{ "{{" }} $value | humanizePercentage {{ "}}" }}) over the last 5 minutes.
+{{- end }}

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -597,6 +597,31 @@ muster:
           # selecting the right Prometheus instance in a multi-tenant
           # cluster.
           labels: {}
+        # PrometheusRule for Prometheus-Operator clusters. Renders a
+        # PrometheusRule with alerting rules for muster service health and
+        # tool call error rates. Requires ServiceMonitor to be enabled so
+        # the rules have data to evaluate.
+        prometheusRule:
+          enabled: false
+          # Extra labels applied to the PrometheusRule — use to target the
+          # right Prometheus instance (e.g. "prometheus: kube-prometheus").
+          labels: {}
+          # observability.giantswarm.io/tenant label value for multi-tenant
+          # Mimir deployments. Empty disables the label.
+          tenant: ""
+      # Grafana dashboard ConfigMap. When enabled, a ConfigMap containing a
+      # pre-built Grafana dashboard is rendered. The grafana-sidecar picks it
+      # up automatically when the ConfigMap carries the correct label.
+      grafanaDashboard:
+        enabled: false
+        # Namespace to deploy the ConfigMap into. Defaults to the release
+        # namespace when empty.
+        namespace: ""
+        # Label selector used by the Grafana sidecar to discover dashboards.
+        # The default matches the standard grafana-operator/grafana-sidecar
+        # convention. Override if your Grafana uses a different label.
+        label: grafana_dashboard
+        labelValue: "1"
 
 # DEPRECATED. The muster application chart no longer ships the CRDs — they now
 # live in the standalone `muster-crds` chart (helm/muster-crds), so the CRD

--- a/internal/orchestrator/metrics.go
+++ b/internal/orchestrator/metrics.go
@@ -1,0 +1,80 @@
+package orchestrator
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/giantswarm/muster/internal/services"
+	"github.com/giantswarm/muster/pkg/logging"
+	"github.com/giantswarm/muster/pkg/observability"
+)
+
+// serviceMetrics holds OTel instruments for service lifecycle observability.
+type serviceMetrics struct {
+	transitions metric.Int64Counter
+	up          metric.Int64ObservableGauge
+}
+
+// newServiceMetrics initialises the OTel instruments against the global
+// MeterProvider. Failures are non-fatal: each instrument falls back to a
+// no-op so the orchestrator continues operating without metrics.
+func newServiceMetrics(registry services.ServiceRegistry) *serviceMetrics {
+	m := otel.Meter(observability.TracerName)
+
+	transitions, err := m.Int64Counter(
+		"muster.service.state_transitions_total",
+		metric.WithDescription("Total number of MCP service state transitions."),
+		metric.WithUnit("{transition}"),
+	)
+	if err != nil {
+		logging.Warn("Orchestrator", "create muster.service.state_transitions_total counter: %v", err)
+	}
+
+	up, err := m.Int64ObservableGauge(
+		"muster.service.up",
+		metric.WithDescription("1 if the MCP service is in a running/connected state, 0 otherwise."),
+		metric.WithUnit("{service}"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			for _, svc := range registry.GetAll() {
+				state := svc.GetState()
+				var value int64
+				if state == services.StateRunning || state == services.StateConnected {
+					value = 1
+				}
+				o.Observe(value,
+					metric.WithAttributes(
+						attribute.String("service_name", svc.GetName()),
+						attribute.String("service_type", string(svc.GetType())),
+					),
+				)
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		logging.Warn("Orchestrator", "create muster.service.up gauge: %v", err)
+	}
+
+	return &serviceMetrics{
+		transitions: transitions,
+		up:          up,
+	}
+}
+
+// recordTransition emits one observation on the transitions counter.
+func (m *serviceMetrics) recordTransition(ctx context.Context, serviceName, serviceType, fromState, toState string) {
+	if m.transitions == nil {
+		return
+	}
+	m.transitions.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("service_name", serviceName),
+			attribute.String("service_type", serviceType),
+			attribute.String("from_state", fromState),
+			attribute.String("to_state", toState),
+		),
+	)
+}

--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -1,0 +1,22 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/services"
+)
+
+func TestNewServiceMetrics_NoOp(t *testing.T) {
+	// No MeterProvider configured — instruments should fall back to no-ops
+	// and not panic.
+	registry := services.NewRegistry()
+	m := newServiceMetrics(registry)
+	require.NotNil(t, m)
+
+	// recordTransition must not panic.
+	m.recordTransition(context.Background(), "svc", "mcpserver", "starting", "running")
+	m.recordTransition(context.Background(), "svc", "mcpserver", "running", "failed")
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -35,6 +35,7 @@ const MaxConcurrentRetries = 5
 // service registry (MCPServer services and the aggregator service).
 type Orchestrator struct {
 	registry services.ServiceRegistry
+	metrics  *serviceMetrics
 
 	// Configuration
 	aggregator config.AggregatorConfig
@@ -68,6 +69,7 @@ func New(cfg Config) *Orchestrator {
 
 	return &Orchestrator{
 		registry:               registry,
+		metrics:                newServiceMetrics(registry),
 		aggregator:             cfg.Aggregator,
 		yolo:                   cfg.Yolo,
 		stopReasons:            make(map[string]StopReason),
@@ -242,6 +244,8 @@ func (o *Orchestrator) publishStateChangeEvent(name string, oldState, newState s
 	}
 
 	logging.Debug("Orchestrator", "Service %s state changed: %s -> %s (health: %s)", name, oldState, newState, health)
+
+	o.metrics.recordTransition(o.ctx, name, string(service.GetType()), string(oldState), string(newState))
 
 	event := ServiceStateChangedEvent{
 		Name:        name,


### PR DESCRIPTION
Closes #401

## What changed

### Go: service lifecycle metrics (`internal/orchestrator/metrics.go`)

Two new OTel instruments emitted from the orchestrator's state-change hook:

| Metric | Type | Labels |
|---|---|---|
| `muster.service.state_transitions_total` | Counter | `service_name`, `service_type`, `from_state`, `to_state` |
| `muster.service.up` | Observable Gauge | `service_name`, `service_type` |

`muster.service.up` is 1 when a service is in `running` or `connected` state, 0 otherwise — the standard "is it up?" signal for alerting.

Both use `otel.Meter(observability.TracerName)`, the same scope as the existing `muster.tool_calls` counter in `internal/aggregator/metrics.go`. The global MeterProvider is already initialised in `cmd/serve.go` via `mcp-toolkit`, so no additional bootstrap is needed.

### Helm: PrometheusRule (`helm/muster/templates/prometheusrule.yaml`)

Three alerting rules (guarded by `prometheusExporterEnabled`, same as ServiceMonitor):

- **MusterServiceDown** — fires after 5 min with `muster_service_up == 0`
- **MusterServiceFlapping** — fires immediately on > 4 transitions in 10 min
- **MusterHighToolErrorRate** — fires after 5 min when tool error ratio > 10 %

Supports `observability.giantswarm.io/tenant` label for multi-tenant Mimir.

Enable with:
```yaml
muster:
  observability:
    metrics:
      exporter: prometheus
      prometheus:
        prometheusRule:
          enabled: true
          tenant: giantswarm   # optional
```

### Helm: Grafana dashboard (`helm/muster/templates/grafana-dashboard.yaml`)

ConfigMap carrying a ready-to-use dashboard, picked up by the standard grafana-sidecar. Panels:

- Service status stat (up/down per service)
- State transitions timeseries
- Tool call rate by tool + outcome
- Tool call latency p50/p99
- Tool error rate per tool

Enable with:
```yaml
muster:
  observability:
    metrics:
      grafanaDashboard:
        enabled: true
```

## What was already present (not changed)

- `muster.tool_calls` counter + `muster.tool_call.duration` histogram in `internal/aggregator/metrics.go`
- mcp-go OTel tracing hooks (`internal/aggregator/server_options.go`)
- `cmd/serve.go` tracing + metrics init via mcp-toolkit
- ServiceMonitor Helm template and deployment OTel env vars
- `values.yaml` observability section