### PR TITLE
fix(aggregator): detect forwarding-server pool misses on warm reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `ssoPoolMissNeedingInit` now detects pool misses for token-forwarding servers in addition to token-exchange servers, so warm sessions (authAlive=true after pod restart) trigger `initSSOForSession` for forwarding servers with empty connection pools. Previously, forwarding servers registered during a restart were inaccessible until the user manually re-authenticated to muster.
+- `establishSSOConnection` now treats a pool miss as stale state for token-forwarding servers (clearing the Valkey auth entry and re-establishing the connection), matching the existing behaviour for token-exchange servers.
+
 ### Added
 
 - Brokered RFC 8693 token exchange ([#831](https://github.com/giantswarm/muster/issues/831)): external confidential clients can POST a token-exchange request with an `audience` parameter to `/oauth/token` and receive a token minted by the audience's downstream Dex. New `oauth.server.tokenExchangeBroker` config block (per-client audience allowlist, audience → downstream Dex target mapping with per-target scopes and credential secret refs). Requires mcp-oauth >= v0.3.0; subject tokens are validated against `trustedIssuers`.

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -418,14 +418,15 @@ func (a *AggregatorServer) initSSOForSession(ctx context.Context, userID, sessio
 	}
 }
 
-// ssoPoolMissNeedingInit reports whether any token-exchange server has a pool
-// miss for sessionID that is not already covered by an in-flight exchange or
-// an unexpired failure backoff window. For each qualifying server it atomically
-// claims the pending slot via MarkSSOPendingIfNotPending, so concurrent
-// onAuthenticated calls for the same session do not spawn redundant
-// initSSOForSession goroutines. Servers whose last exchange failed are skipped
-// until their backoff expires, so a persistently failing exchange retries on
-// the tracker's backoff schedule instead of on every request.
+// ssoPoolMissNeedingInit reports whether any SSO server (token-exchange or
+// token-forwarding) has a pool miss for sessionID that is not already covered
+// by an in-flight exchange or an unexpired failure backoff window. For each
+// qualifying server it atomically claims the pending slot via
+// MarkSSOPendingIfNotPending, so concurrent onAuthenticated calls for the same
+// session do not spawn redundant initSSOForSession goroutines. Servers whose
+// last exchange failed are skipped until their backoff expires, so a
+// persistently failing exchange retries on the tracker's backoff schedule
+// instead of on every request.
 //
 // Pending slots are keyed by user subject while the connection pool is keyed
 // by session: when two sessions of the same user both have a pool miss, the
@@ -440,7 +441,7 @@ func (a *AggregatorServer) ssoPoolMissNeedingInit(userID, sessionID string) bool
 		if !info.RequiresSessionAuth() {
 			continue
 		}
-		if !ShouldUseTokenExchange(info) {
+		if !ShouldUseTokenExchange(info) && !ShouldUseTokenForwarding(info) {
 			continue
 		}
 		if _, ok := a.connPool.Get(sessionID, info.Name); ok {
@@ -482,12 +483,12 @@ func (a *AggregatorServer) establishSSOConnection(
 	if a.authStore != nil {
 		authenticated, _ := a.authStore.IsAuthenticated(ctx, sessionID, serverInfo.Name)
 		if authenticated {
-			// For token-exchange servers, also verify the conn pool has a live client.
+			// For SSO servers, verify the conn pool has a live client.
 			// After a pod restart the auth store persists "authenticated" in Valkey while
 			// the in-memory pool is empty. In that case, clear the stale auth entry so
-			// the exchange proceeds and the pool is repopulated.
+			// the connection is re-established and the pool is repopulated.
 			stalePoolMiss := false
-			if ShouldUseTokenExchange(serverInfo) && a.connPool != nil {
+			if (ShouldUseTokenExchange(serverInfo) || ShouldUseTokenForwarding(serverInfo)) && a.connPool != nil {
 				_, poolHit := a.connPool.Get(sessionID, serverInfo.Name)
 				stalePoolMiss = !poolHit
 			}

--- a/internal/aggregator/sso_reconnect_test.go
+++ b/internal/aggregator/sso_reconnect_test.go
@@ -740,9 +740,10 @@ func TestSSOPoolMissNeedingInit_ReturnsFalseWithLivePoolEntry(t *testing.T) {
 		"should not detect pool miss when conn pool has a live entry")
 }
 
-func TestSSOPoolMissNeedingInit_IgnoresForwardTokenServers(t *testing.T) {
-	// ssoPoolMissNeedingInit only checks token-exchange servers; forward-token
-	// servers recreate their clients on demand and don't need this trigger.
+func TestSSOPoolMissNeedingInit_ForwardTokenServerWithEmptyPool(t *testing.T) {
+	// After a pod restart the auth store persists "authenticated" but the pool
+	// is empty. ssoPoolMissNeedingInit must also detect pool misses for
+	// forward-token servers so onAuthenticated triggers SSO re-init for them.
 	pool := NewSessionConnectionPool(1 * time.Hour)
 	defer pool.Stop()
 	defer pool.DrainAll()
@@ -762,7 +763,6 @@ func TestSSOPoolMissNeedingInit_IgnoresForwardTokenServers(t *testing.T) {
 	ctx := t.Context()
 	sessionID := "fwd-session"
 
-	// Auth store says authenticated, pool is empty — but it's a forward-token server.
 	require.NoError(t, authStore.MarkAuthenticated(ctx, sessionID, "gazelle-mcp-kubernetes"))
 
 	aggServer := &AggregatorServer{
@@ -771,8 +771,62 @@ func TestSSOPoolMissNeedingInit_IgnoresForwardTokenServers(t *testing.T) {
 		authStore: authStore,
 	}
 
+	assert.True(t, aggServer.ssoPoolMissNeedingInit("user1", sessionID),
+		"forward-token server with empty pool should trigger ssoPoolMissNeedingInit")
+}
+
+func TestSSOPoolMissNeedingInit_ForwardTokenServerNeverAuthenticated(t *testing.T) {
+	// A new forward-token server registered after a pod restart. The session
+	// (authAlive=true via Valkey) has never authenticated to this server so
+	// auth store has no entry and pool is empty. Must trigger re-init so
+	// initSSOForSession connects the session to the new server.
+	pool := NewSessionConnectionPool(1 * time.Hour)
+	defer pool.Stop()
+	defer pool.DrainAll()
+
+	registry := NewServerRegistry("x")
+	err := registry.RegisterPendingAuth(PendingAuthRegistration{
+		ServerRegistration: ServerRegistration{Name: "new-fwd-server", ToolPrefix: "new"},
+		URL:                "https://mcp.new.example.com",
+		AuthInfo:           &AuthInfo{Issuer: "https://dex.new.example.com"},
+		AuthConfig:         &api.MCPServerAuth{ForwardToken: true},
+	})
+	require.NoError(t, err)
+
+	aggServer := &AggregatorServer{
+		registry: registry,
+		connPool: pool,
+	}
+
+	assert.True(t, aggServer.ssoPoolMissNeedingInit("user1", "session-never-seen"),
+		"new forward-token server should trigger ssoPoolMissNeedingInit when session has no auth entry")
+}
+
+func TestSSOPoolMissNeedingInit_ForwardTokenServerWithLivePoolEntry(t *testing.T) {
+	// When the pool already has a live entry, no re-init is needed.
+	pool := NewSessionConnectionPool(1 * time.Hour)
+	defer pool.Stop()
+	defer pool.DrainAll()
+
+	registry := NewServerRegistry("x")
+	err := registry.RegisterPendingAuth(PendingAuthRegistration{
+		ServerRegistration: ServerRegistration{Name: "gazelle-mcp-kubernetes", ToolPrefix: "gazelle"},
+		URL:                "https://mcp.gazelle.example.com",
+		AuthInfo:           &AuthInfo{Issuer: "https://dex.gazelle.example.com"},
+		AuthConfig:         &api.MCPServerAuth{ForwardToken: true},
+	})
+	require.NoError(t, err)
+
+	sessionID := "live-fwd-session"
+	pool.Put(sessionID, "gazelle-mcp-kubernetes", &noopMCPClient{})
+
+	aggServer := &AggregatorServer{
+		registry: registry,
+		connPool: pool,
+	}
+
 	assert.False(t, aggServer.ssoPoolMissNeedingInit("user1", sessionID),
-		"forward-token server with empty pool should not trigger ssoPoolMissNeedingInit")
+		"forward-token server with live pool entry should not trigger ssoPoolMissNeedingInit")
 }
 
 func TestSSOPoolMissNeedingInit_DeduplicatesConcurrentCalls(t *testing.T) {

--- a/internal/testing/scenarios/oauth-sso-forwarding-warm-reconnect.yaml
+++ b/internal/testing/scenarios/oauth-sso-forwarding-warm-reconnect.yaml
@@ -1,0 +1,105 @@
+name: "oauth-sso-forwarding-warm-reconnect"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  Regression test for issue #682: forwarding-server tools accessible after warm reconnect.
+
+  When a session reconnects with authAlive=true (same token family, Valkey auth state
+  survives), ssoPoolMissNeedingInit must detect pool misses for forward-token servers
+  and trigger initSSOForSession — not just for token-exchange servers.
+
+  This scenario exercises the onAuthenticated → authAlive=true path by using
+  test_simulate_muster_reauth (refresh-grant, same token family) and verifying that
+  a forward-token server's tools remain accessible. A regression in the fix would cause
+  the forwarding server to appear inaccessible after the warm reconnect.
+tags: ["oauth", "sso", "token-forwarding", "reconnect", "warm-session", "issue-682", "regression"]
+timeout: "2m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "warm-reconnect-idp"
+      scopes: ["openid", "profile", "mcp:admin"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "warm-reconnect-client"
+      client_secret: "warm-reconnect-secret"
+      use_as_muster_oauth_server: true
+
+  mcp_servers:
+    - name: "warm-fwd-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "warm-reconnect-idp"
+          forward_token: true
+        tools:
+          - name: "fwd_op"
+            description: "Operation on a forward-token SSO server"
+            responses:
+              - response:
+                  status: "ok"
+                  source: "warm-fwd-server"
+
+steps:
+  - id: muster-auth-login
+    description: "Initial login — creates session, fires SessionCreationHandler + initSSOForSession"
+    tool: "test_muster_auth_login"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "success"
+        - "ID token stored"
+
+  - id: verify-server-connected
+    description: "Verify the forwarding server is connected after initial login"
+    tool: "test_read_auth_status"
+    args:
+      server: "warm-fwd-server"
+    expected:
+      success: true
+      contains:
+        - "warm-fwd-server"
+        - "connected"
+
+  - id: call-tool-before-reconnect
+    description: "Forwarding server tool works on the initial session"
+    tool: "x_warm-fwd-server_fwd_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "ok"
+        - "warm-fwd-server"
+
+  - id: warm-reconnect
+    description: "Simulate warm reconnect (refresh grant, same token family — authAlive=true on next request)"
+    tool: "test_simulate_muster_reauth"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: call-tool-after-reconnect
+    description: "Forwarding server tool must still be accessible after warm reconnect"
+    tool: "x_warm-fwd-server_fwd_op"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "ok"
+        - "warm-fwd-server"
+
+  - id: verify-auth-status-after-reconnect
+    description: "Auth status shows connected after warm reconnect"
+    tool: "test_read_auth_status"
+    args:
+      server: "warm-fwd-server"
+    expected:
+      success: true
+      contains:
+        - "warm-fwd-server"
+        - "connected"


### PR DESCRIPTION
## What

Closes #682 (remaining gap after #811).

PR #811 fixed the pool-miss detection for token-exchange servers. Forwarding servers were explicitly excluded because `ssoPoolMissNeedingInit` only checked `ShouldUseTokenExchange`. Sessions reconnecting with `authAlive=true` after a pod restart never triggered `initSSOForSession` for forwarding servers.

## Root cause

`ssoPoolMissNeedingInit` iterated the registry and skipped any server that wasn't `ShouldUseTokenExchange`. Token-forwarding servers with empty pools (after a restart cleared the in-memory conn pool while Valkey kept auth state) were never detected. `initSSOForSession` was never called for those servers on warm reconnect.

A second, lower-impact gap: `establishSSOConnection` only treated `auth-store-hit + pool-miss` as stale state for exchange servers. For forwarding servers in the same state it returned early, leaving the pool empty (the tool-call path creates clients on-demand when Valkey says authenticated, so this only affects the proactive re-establishment).

## Changes

- `internal/aggregator/auth_resource.go`
  - `ssoPoolMissNeedingInit`: include `ShouldUseTokenForwarding` alongside `ShouldUseTokenExchange` in pool-miss scan
  - `establishSSOConnection`: extend stale-pool-miss check to forwarding servers (revoke Valkey entry + re-establish, matching exchange behaviour)

- `internal/aggregator/sso_reconnect_test.go`
  - Rename `TestSSOPoolMissNeedingInit_IgnoresForwardTokenServers` (the assertion was wrong) to `TestSSOPoolMissNeedingInit_ForwardTokenServerWithEmptyPool`, flipping the assertion to `true`
  - Add `TestSSOPoolMissNeedingInit_ForwardTokenServerNeverAuthenticated` — new forwarding server, no auth-store entry, pool miss → triggers init
  - Add `TestSSOPoolMissNeedingInit_ForwardTokenServerWithLivePoolEntry` — live pool entry → no re-init

- `internal/testing/scenarios/oauth-sso-forwarding-warm-reconnect.yaml`
  - BDD scenario exercising the `onAuthenticated` / `authAlive=true` path with a forwarding server (warm-session reconnect via refresh grant, same token family)