### PR TITLE
fix(deps): bump mcp-oauth to v0.4.1 for token-exchange basic auth encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Bump `mcp-oauth` to v0.4.1, which RFC 6749 §2.3.1-encodes client credentials in token-exchange Basic auth. Cross-cluster SSO token exchange previously failed with `invalid_client` for downstream clusters whose `muster-token-exchange-*` Dex client secret contained `+` (decoded to a space on the wire); base64-std secrets with only `/` and `=` were unaffected, which is why some clusters worked and others did not.
 - `ssoPoolMissNeedingInit` now detects pool misses for token-forwarding servers in addition to token-exchange servers, so warm sessions (authAlive=true after pod restart) trigger `initSSOForSession` for forwarding servers with empty connection pools. Previously, forwarding servers registered during a restart were inaccessible until the user manually re-authenticated to muster.
 - `establishSSOConnection` now treats a pool miss as stale state for token-forwarding servers (clearing the Valkey auth entry and re-establishing the connection), matching the existing behaviour for token-exchange servers.
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.4.0
+	github.com/giantswarm/mcp-oauth v0.4.1
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.4.0 h1:XQISPBS5fDjPvch97Cnn6nuE3J7aO5FjfYeBQTpTYbI=
-github.com/giantswarm/mcp-oauth v0.4.0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
+github.com/giantswarm/mcp-oauth v0.4.1 h1:sM+gb5vOAuJGzNXQTW96e+l/UkepqQSgQpeViXLgaEs=
+github.com/giantswarm/mcp-oauth v0.4.1/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=


### PR DESCRIPTION
## Summary

Bumps `github.com/giantswarm/mcp-oauth` from v0.4.0 to v0.4.1.

v0.4.1 fixes RFC 6749 §2.3.1 client-credential encoding in the token-exchange client (`providers/oidc`). Previously `TokenExchangeClient.Exchange` used `http.Request.SetBasicAuth` with the raw client id/secret; a downstream Dex client secret containing `+` was mangled by `application/x-www-form-urlencoded` (decoded to a space on the server side) and rejected with `invalid_client`. This broke cross-cluster SSO token exchange for clusters whose `muster-token-exchange-*` secret happened to contain a `+`; secrets with only `/` and `=` were unaffected.

Upstream fix: giantswarm/mcp-oauth#451 (released as v0.4.1).

## Test plan

- [x] `go build ./...` and `go mod tidy` clean
- [ ] CI green

Made with [Cursor](https://cursor.com)