### PR TITLE
feat(oauth): github-app broker target type for GitHub App installation tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 
 - `oauth.server.tokenExchangeBroker.workloadAudiences`: per-workload allowlist for workload-authenticated RFC 8693 token exchange (no confidential-client credentials). Keys are workload subjects (`system:serviceaccount:<ns>:<name>`; globs supported), values are the audiences each workload may request. Delegation uses the actor subject; impersonation uses the subject token's sub claim. Enforcement is performed by mcp-oauth before the credential provider is invoked.
 - `oauth.server.tokenExchangeBroker.targets[].type`: credential provider discriminator for broker targets. Defaults to `oidc-exchange` (downstream Dex RFC 8693 exchange) when omitted; additional provider types will be added in future releases.
+- `oauth.server.tokenExchangeBroker.targets[].type: github-app` mints GitHub App installation tokens. Configure via `githubApp.appId`, `githubApp.installationId` (or `githubApp.owner` + `githubApp.repo` for auto-discovery), `githubApp.privateKeyRef` (RSA PEM in a Kubernetes Secret), and optional `githubApp.repositories` / `githubApp.permissions` scope restriction.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,14 @@ All notable changes to this project will be documented in this file.
 
 - Brokered RFC 8693 token exchange ([#831](https://github.com/giantswarm/muster/issues/831)): external confidential clients can POST a token-exchange request with an `audience` parameter to `/oauth/token` and receive a token minted by the audience's downstream Dex. New `oauth.server.tokenExchangeBroker` config block (per-client audience allowlist, audience → downstream Dex target mapping with per-target scopes and credential secret refs). Requires mcp-oauth >= v0.3.0; subject tokens are validated against `trustedIssuers`.
 
+### Added
+
+- `oauth.server.tokenExchangeBroker.workloadAudiences`: per-workload allowlist for workload-authenticated RFC 8693 token exchange (no confidential-client credentials). Keys are workload subjects (`system:serviceaccount:<ns>:<name>`; globs supported), values are the audiences each workload may request. Delegation uses the actor subject; impersonation uses the subject token's sub claim. Enforcement is performed by mcp-oauth before the credential provider is invoked.
+- `oauth.server.tokenExchangeBroker.targets[].type`: credential provider discriminator for broker targets. Defaults to `oidc-exchange` (downstream Dex RFC 8693 exchange) when omitted; additional provider types will be added in future releases.
+
 ### Changed
 
+- Broker credential minting extracted behind a `CredentialProvider` interface and an `oidc-exchange` provider dispatched through a registry (`internal/oauth`). No behaviour change; the oidc-exchange provider preserves per-(endpoint, connector, user) token caching.
 - Update mcp-oauth to v0.4.0.
 - Update mcp-oauth to v0.3.1: forwarded ID tokens (`trustedAudiences`) are no longer hard-rejected by the trusted-issuer Bearer branch when the same issuer is also configured in `trustedIssuers` — fixes Backstage AI-chat SSO token forwarding returning 401 (`typ header is "", expected "at+jwt"`) on deployments with the token-exchange broker enabled.
 - Update mcp-oauth to v0.3.0 (server-side RFC 8693 token-exchange grant with pluggable `Exchanger`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,36 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-
-- Bump `mcp-oauth` to v0.4.2, which makes the trusted-issuer JWKS cache rotation-safe: a subject token presenting a `kid` absent from the cached JWKS now triggers a single bounded refetch (rate-limited per JWKS URI) and retries verification before rejecting. Previously, a Dex signing-key rotation made the token-exchange broker reject **every** current user token with `subject_token_validation_failed` until the muster pod was restarted (the shared broker took down all downstream audiences at once). Closes #847.
-- Bump `mcp-oauth` to v0.4.1, which RFC 6749 §2.3.1-encodes client credentials in token-exchange Basic auth. Cross-cluster SSO token exchange previously failed with `invalid_client` for downstream clusters whose `muster-token-exchange-*` Dex client secret contained `+` (decoded to a space on the wire); base64-std secrets with only `/` and `=` were unaffected, which is why some clusters worked and others did not.
-- `ssoPoolMissNeedingInit` now detects pool misses for token-forwarding servers in addition to token-exchange servers, so warm sessions (authAlive=true after pod restart) trigger `initSSOForSession` for forwarding servers with empty connection pools. Previously, forwarding servers registered during a restart were inaccessible until the user manually re-authenticated to muster.
-- `establishSSOConnection` now treats a pool miss as stale state for token-forwarding servers (clearing the Valkey auth entry and re-establishing the connection), matching the existing behaviour for token-exchange servers.
-
-### Fixed
-
-- After an idle period, `getIDTokenForForwarding` now attempts an in-process upstream provider refresh (`Server.RefreshSession`) when the proxy store has no valid ID token. On success the store is repopulated by `TokenRefreshHandler` and the fresh token is forwarded, avoiding `401 Unauthorized` errors without requiring re-authentication. Closes #549.
-
 ### Added
 
 - `GET /health` now responds 200 on the aggregator port regardless of OAuth configuration, so Kubernetes liveness/readiness probes work without patching the chart.
 - `RegisterServer` and `DeregisterServer` aggregator events and MCPServer reconcile entry are now logged at Info level, making freshly-restarted pod lifecycle visible without `--debug`.
 - `oauth.server.allowedOrigins` (comma-separated) is now wired into the mcp-oauth CORS `AllowedOrigins` list. Previously declared but never read; empty value keeps CORS disabled (default).
-
-### Removed
-
-- `MCPServer.status.consecutiveFailures`, `.lastAttempt`, and `.nextRetryAfter` are no longer updated by the reconciler; the retry state machine that drove them was removed in a prior release. The fields remain on the CRD for forward compatibility.
-- `oauth.server.enableHSTS`, `oauth.server.tlsCertFile`, and `oauth.server.tlsKeyFile` config fields removed; they were declared and YAML-parsed but never read anywhere in the codebase.
-
-### Added
-
 - `oauth.server.trustedIssuers[].acceptedTypHeaders`: accepted JWT `typ` header values for Bearer tokens from a trusted issuer. Empty keeps the RFC 9068 default (`at+jwt`). Kubernetes ServiceAccount tokens carry no `typ` header; use `[""]` to accept them.
-
 - Brokered RFC 8693 token exchange ([#831](https://github.com/giantswarm/muster/issues/831)): external confidential clients can POST a token-exchange request with an `audience` parameter to `/oauth/token` and receive a token minted by the audience's downstream Dex. New `oauth.server.tokenExchangeBroker` config block (per-client audience allowlist, audience → downstream Dex target mapping with per-target scopes and credential secret refs). Requires mcp-oauth >= v0.3.0; subject tokens are validated against `trustedIssuers`.
-
-### Added
-
 - `oauth.server.tokenExchangeBroker.workloadAudiences`: per-workload allowlist for workload-authenticated RFC 8693 token exchange (no confidential-client credentials). Keys are workload subjects (`system:serviceaccount:<ns>:<name>`; globs supported), values are the audiences each workload may request. Delegation uses the actor subject; impersonation uses the subject token's sub claim. Enforcement is performed by mcp-oauth before the credential provider is invoked.
 - `oauth.server.tokenExchangeBroker.targets[].type`: credential provider discriminator for broker targets. Defaults to `oidc-exchange` (downstream Dex RFC 8693 exchange) when omitted; additional provider types will be added in future releases.
 - `oauth.server.tokenExchangeBroker.targets[].type: github-app` mints GitHub App installation tokens. Configure via `githubApp.appId`, `githubApp.installationId` (or `githubApp.owner` + `githubApp.repo` for auto-discovery), `githubApp.privateKeyRef` (RSA PEM in a Kubernetes Secret), and optional `githubApp.repositories` / `githubApp.permissions` scope restriction.
@@ -44,6 +21,19 @@ All notable changes to this project will be documented in this file.
 - Update mcp-oauth to v0.4.0.
 - Update mcp-oauth to v0.3.1: forwarded ID tokens (`trustedAudiences`) are no longer hard-rejected by the trusted-issuer Bearer branch when the same issuer is also configured in `trustedIssuers` — fixes Backstage AI-chat SSO token forwarding returning 401 (`typ header is "", expected "at+jwt"`) on deployments with the token-exchange broker enabled.
 - Update mcp-oauth to v0.3.0 (server-side RFC 8693 token-exchange grant with pluggable `Exchanger`).
+
+### Removed
+
+- `MCPServer.status.consecutiveFailures`, `.lastAttempt`, and `.nextRetryAfter` are no longer updated by the reconciler; the retry state machine that drove them was removed in a prior release. The fields remain on the CRD for forward compatibility.
+- `oauth.server.enableHSTS`, `oauth.server.tlsCertFile`, and `oauth.server.tlsKeyFile` config fields removed; they were declared and YAML-parsed but never read anywhere in the codebase.
+
+### Fixed
+
+- Bump `mcp-oauth` to v0.4.2, which makes the trusted-issuer JWKS cache rotation-safe: a subject token presenting a `kid` absent from the cached JWKS now triggers a single bounded refetch (rate-limited per JWKS URI) and retries verification before rejecting. Previously, a Dex signing-key rotation made the token-exchange broker reject **every** current user token with `subject_token_validation_failed` until the muster pod was restarted (the shared broker took down all downstream audiences at once). Closes #847.
+- Bump `mcp-oauth` to v0.4.1, which RFC 6749 §2.3.1-encodes client credentials in token-exchange Basic auth. Cross-cluster SSO token exchange previously failed with `invalid_client` for downstream clusters whose `muster-token-exchange-*` Dex client secret contained `+` (decoded to a space on the wire); base64-std secrets with only `/` and `=` were unaffected, which is why some clusters worked and others did not.
+- `ssoPoolMissNeedingInit` now detects pool misses for token-forwarding servers in addition to token-exchange servers, so warm sessions (authAlive=true after pod restart) trigger `initSSOForSession` for forwarding servers with empty connection pools. Previously, forwarding servers registered during a restart were inaccessible until the user manually re-authenticated to muster.
+- `establishSSOConnection` now treats a pool miss as stale state for token-forwarding servers (clearing the Valkey auth entry and re-establishing the connection), matching the existing behaviour for token-exchange servers.
+- After an idle period, `getIDTokenForForwarding` now attempts an in-process upstream provider refresh (`Server.RefreshSession`) when the proxy store has no valid ID token. On success the store is repopulated by `TokenRefreshHandler` and the fresh token is forwarded, avoiding `401 Unauthorized` errors without requiring re-authentication. Closes #549.
 
 ## [0.3.12] - 2026-06-10
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0
+	github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220542-fdad89b01df0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.26.0
 
 toolchain go1.26.4
 
-replace github.com/giantswarm/mcp-oauth => /home/quentin/dev/mcp-oauth
-
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/briandowns/spinner v1.23.2
@@ -13,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.4.2
+	github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.26.0
 
 toolchain go1.26.4
 
+replace github.com/giantswarm/mcp-oauth => /home/quentin/dev/mcp-oauth
+
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/briandowns/spinner v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,6 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0 h1:WnnHV8/wE4q2XcTDf71JD3JI0V3OLgNorT6fOHke/8s=
-github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
-github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220020-fee9f51abd96 h1:bcpbWZotz7ifVFL/giicFYqfIu/4h4u4b62vmpIl5pk=
-github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220020-fee9f51abd96/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220542-fdad89b01df0 h1:gNPyVSsTM5xFYxspiYk9DPwjTs7i4RY+IKSnUoqu1HU=
 github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220542-fdad89b01df0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0 h1:WnnHV8/wE4q2XcTDf71JD3JI0V3OLgNorT6fOHke/8s=
+github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.4.2 h1:FV1tYs+xHRPkdGeisvxisvs2ag5byWLXyUk8DQiKZzY=
-github.com/giantswarm/mcp-oauth v0.4.2/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,10 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0 h1:WnnHV8/wE4q2XcTDf71JD3JI0V3OLgNorT6fOHke/8s=
 github.com/giantswarm/mcp-oauth v0.4.3-0.20260616194026-753e5d4497f0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
+github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220020-fee9f51abd96 h1:bcpbWZotz7ifVFL/giicFYqfIu/4h4u4b62vmpIl5pk=
+github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220020-fee9f51abd96/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
+github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220542-fdad89b01df0 h1:gNPyVSsTM5xFYxspiYk9DPwjTs7i4RY+IKSnUoqu1HU=
+github.com/giantswarm/mcp-oauth v0.4.3-0.20260616220542-fdad89b01df0/go.mod h1:CryfQrOaMap00pxuzjlcrf3thY2Lmt2lk05wjzbx5LY=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/helm/muster/templates/rbac.yaml
+++ b/helm/muster/templates/rbac.yaml
@@ -6,6 +6,11 @@ Muster needs access to:
   - CRD discovery
   - Events (for core_events tool)
   - Secrets (for reading credentials: token exchange, OAuth)
+
+Secrets access is intentionally scoped to namespaced Roles, not a ClusterRole,
+to limit blast radius. By default a Role is created in the release namespace.
+Broker target secrets or githubApp.privateKeyRef secrets in other namespaces
+require listing those namespaces in rbac.additionalSecretNamespaces.
 */}}
 
 {{- if and .Values.serviceAccount.create .Values.rbac.create -}}
@@ -36,11 +41,6 @@ rules:
     resources: ["events"]
     verbs: ["get", "list", "watch", "create"]
 
-  # Secrets - required for reading credentials (token exchange, OAuth)
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -56,4 +56,66 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "muster.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "muster.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "muster.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "muster.fullname" . }}-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "muster.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+
+{{- range .Values.rbac.additionalSecretNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "muster.fullname" $ }}-secrets
+  namespace: {{ . }}
+  labels:
+    {{- include "muster.labels" $ | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "muster.fullname" $ }}-secrets
+  namespace: {{ . }}
+  labels:
+    {{- include "muster.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "muster.fullname" $ }}-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "muster.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/helm/muster/tests/configmap_test.yaml
+++ b/helm/muster/tests/configmap_test.yaml
@@ -112,3 +112,42 @@ tests:
       - notMatchRegex:
           path: data["config.yaml"]
           pattern: "tokenExchangeBroker:"
+
+  - it: renders github-app typed broker target into config.yaml
+    set:
+      muster.oauth.server.enabled: true
+      muster.oauth.server.baseUrl: "https://muster.example.com"
+      muster.oauth.server.existingSecret: "muster-oauth"
+      muster.oauth.server.dex.issuerUrl: "https://dex.example.com"
+      muster.oauth.server.dex.clientId: "muster"
+      muster.oauth.server.tokenExchangeBroker:
+        workloadAudiences:
+          "system:serviceaccount:ai-platform:kagent": ["github-infra"]
+        targets:
+          github-infra:
+            type: github-app
+            githubApp:
+              appId: "123456"
+              installationId: "78901234"
+              privateKeyRef:
+                name: github-app-pem
+              repositories:
+                - infra
+              permissions:
+                contents: read
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "tokenExchangeBroker:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "github-app"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "appId: \"123456\""
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "github-app-pem"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "workloadAudiences:"

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -72,7 +72,12 @@
       "properties": {
         "create": {
           "type": "boolean",
-          "description": "Create RBAC resources (ClusterRole and ClusterRoleBinding)"
+          "description": "Create RBAC resources (ClusterRole, ClusterRoleBinding, and per-namespace Roles for secrets)."
+        },
+        "additionalSecretNamespaces": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Additional namespaces where broker target secrets or githubApp.privateKeyRef secrets reside. A Role/RoleBinding granting get on secrets is created in each."
         }
       }
     },
@@ -604,7 +609,7 @@
                         "type": "object",
                         "required": ["appId", "privateKeyRef"],
                         "properties": {
-                          "appId": {"type": "string", "description": "GitHub App numeric ID (iss claim in the App JWT)."},
+                          "appId": {"type": "string", "pattern": "^[0-9]+$", "description": "GitHub App numeric ID (iss claim in the App JWT)."},
                           "installationId": {"type": "string", "description": "Installation ID. Omit to auto-discover via owner+repo."},
                           "owner": {"type": "string", "description": "GitHub org or user for installation auto-discovery. Required when installationId is empty."},
                           "repo": {"type": "string", "description": "Repository name for installation auto-discovery. Required when installationId is empty."},
@@ -614,15 +619,22 @@
                             "properties": {
                               "name": {"type": "string", "description": "Kubernetes Secret name holding the RSA private key PEM."},
                               "namespace": {"type": "string", "description": "Defaults to the muster namespace."},
-                              "clientIdKey": {"type": "string", "description": "Key within the Secret. Defaults to private-key."}
+                              "key": {"type": "string", "description": "Key within the Secret data map. Defaults to private-key."}
                             }
                           },
                           "repositories": {"type": "array", "items": {"type": "string"}, "description": "Restrict the installation token to these repositories. Empty means all repositories the installation can access."},
                           "permissions": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Restrict the installation token to these permissions, e.g. {contents: read, pull_requests: write}."},
-                          "baseUrl": {"type": "string", "description": "Override the GitHub API base URL. Defaults to https://api.github.com. For GitHub Enterprise or test overrides."}
+                          "baseUrl": {"type": "string", "pattern": "^https://", "description": "Override the GitHub API base URL (HTTPS only). Defaults to https://api.github.com. Set for GitHub Enterprise Server."}
                         },
                         "description": "github-app: GitHub App installation token config."
                       }
+                    },
+                    "if": {
+                      "properties": {"type": {"const": "github-app"}},
+                      "required": ["type"]
+                    },
+                    "then": {
+                      "required": ["githubApp"]
                     }
                   }
                 },

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -580,15 +580,15 @@
                 },
                 "targets": {
                   "type": "object",
-                  "description": "Audience name → downstream Dex exchange target.",
+                  "description": "Audience name → credential provider target. Set type to select the provider (default: oidc-exchange).",
                   "additionalProperties": {
                     "type": "object",
-                    "required": ["dexTokenEndpoint", "connectorId"],
                     "properties": {
-                      "dexTokenEndpoint": {"type": "string", "pattern": "^https://", "description": "Downstream Dex token endpoint URL (HTTPS)."},
-                      "expectedIssuer": {"type": "string", "description": "Expected iss claim of the exchanged token. Derived from dexTokenEndpoint when empty."},
-                      "connectorId": {"type": "string", "description": "Downstream Dex OIDC connector that trusts the subject token's issuer."},
-                      "scopes": {"type": "string", "description": "Space-separated downstream scopes (default: openid profile email groups). Kubernetes-bound audiences must include the Dex cross-client scope, e.g. audience:server:client_id:dex-k8s-authenticator."},
+                      "type": {"type": "string", "enum": ["oidc-exchange", "github-app"], "description": "Credential provider type. Defaults to oidc-exchange when omitted."},
+                      "dexTokenEndpoint": {"type": "string", "pattern": "^https://", "description": "oidc-exchange: downstream Dex token endpoint URL (HTTPS)."},
+                      "expectedIssuer": {"type": "string", "description": "oidc-exchange: expected iss claim of the exchanged token. Derived from dexTokenEndpoint when empty."},
+                      "connectorId": {"type": "string", "description": "oidc-exchange: downstream Dex OIDC connector that trusts the subject token's issuer."},
+                      "scopes": {"type": "string", "description": "oidc-exchange: space-separated downstream scopes (default: openid profile email groups). Kubernetes-bound audiences must include the Dex cross-client scope, e.g. audience:server:client_id:dex-k8s-authenticator."},
                       "clientCredentialsSecretRef": {
                         "type": "object",
                         "required": ["name"],
@@ -598,10 +598,42 @@
                           "clientIdKey": {"type": "string", "description": "Defaults to client-id."},
                           "clientSecretKey": {"type": "string", "description": "Defaults to client-secret."}
                         },
-                        "description": "Kubernetes Secret holding the downstream exchange client credentials (same secrets the per-MCPServer tokenExchange config uses)."
+                        "description": "oidc-exchange: Kubernetes Secret holding the downstream exchange client credentials."
+                      },
+                      "githubApp": {
+                        "type": "object",
+                        "required": ["appId", "privateKeyRef"],
+                        "properties": {
+                          "appId": {"type": "string", "description": "GitHub App numeric ID (iss claim in the App JWT)."},
+                          "installationId": {"type": "string", "description": "Installation ID. Omit to auto-discover via owner+repo."},
+                          "owner": {"type": "string", "description": "GitHub org or user for installation auto-discovery. Required when installationId is empty."},
+                          "repo": {"type": "string", "description": "Repository name for installation auto-discovery. Required when installationId is empty."},
+                          "privateKeyRef": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                              "name": {"type": "string", "description": "Kubernetes Secret name holding the RSA private key PEM."},
+                              "namespace": {"type": "string", "description": "Defaults to the muster namespace."},
+                              "clientIdKey": {"type": "string", "description": "Key within the Secret. Defaults to private-key."}
+                            }
+                          },
+                          "repositories": {"type": "array", "items": {"type": "string"}, "description": "Restrict the installation token to these repositories. Empty means all repositories the installation can access."},
+                          "permissions": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Restrict the installation token to these permissions, e.g. {contents: read, pull_requests: write}."},
+                          "baseUrl": {"type": "string", "description": "Override the GitHub API base URL. Defaults to https://api.github.com. For GitHub Enterprise or test overrides."}
+                        },
+                        "description": "github-app: GitHub App installation token config."
                       }
                     }
                   }
+                },
+                "workloadAudiences": {
+                  "type": "object",
+                  "description": "Per-workload audience allowlist for workload-authenticated RFC 8693 token exchange (no confidential-client credentials). Keys are workload subjects (system:serviceaccount:<ns>:<name>; globs supported), values are the audiences the workload may request.",
+                  "additionalProperties": {"type": "array", "items": {"type": "string"}}
+                },
+                "defaultSecretNamespace": {
+                  "type": "string",
+                  "description": "Default namespace for clientCredentialsSecretRef and githubApp.privateKeyRef lookups when namespace is omitted. Defaults to the muster pod's namespace."
                 },
                 "allowPrivateIP": {
                   "type": "boolean",

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -501,13 +501,14 @@ muster:
       # Brokered RFC 8693 token exchange: muster as a shared token broker.
       # An external confidential client POSTs a token-exchange request with an
       # `audience` parameter to /oauth/token and receives a token minted by the
-      # audience's downstream Dex (instead of a muster-issued JWT). Subject
-      # tokens are validated against trustedIssuers, so at least one issuer
-      # entry covering the broker client's tokens is required.
+      # audience's downstream credential provider (Dex exchange or GitHub App
+      # installation token). Subject tokens are validated against trustedIssuers,
+      # so at least one issuer entry covering the broker client's tokens is required.
       # Policy enforced by mcp-oauth: confidential clients only, per-client
       # audience allowlist, no refresh tokens, expires_in bounded by the
       # downstream token's expiry, DPoP rejected.
-      # Example:
+      #
+      # oidc-exchange target (default): downstream Dex RFC 8693 exchange
       #   clientAudiences:
       #     portal-backend: ["cluster-a", "cluster-b"]
       #   targets:
@@ -520,6 +521,27 @@ muster:
       #       scopes: "openid profile email groups audience:server:client_id:dex-k8s-authenticator"
       #       clientCredentialsSecretRef:
       #         name: muster-token-exchange-cluster-a
+      #
+      # github-app target: mints GitHub App installation tokens
+      #   targets:
+      #     github-infra:
+      #       type: github-app
+      #       githubApp:
+      #         appId: "123456"
+      #         # Either a static installationId:
+      #         installationId: "78901234"
+      #         # Or auto-discover via the repository installation:
+      #         # owner: my-org
+      #         # repo: infra
+      #         privateKeyRef:
+      #           name: github-app-pem       # Kubernetes Secret, key defaults to "private-key"
+      #         repositories: ["infra"]      # optional: restrict to specific repos
+      #         permissions:                 # optional: restrict granted permissions
+      #           contents: read
+      #
+      # workload-authenticated exchange (no confidential-client credentials):
+      #   workloadAudiences:
+      #     "system:serviceaccount:ai-platform:*": ["github-infra", "cluster-a"]
       tokenExchangeBroker: {}
 
       # CIDRs from which X-Forwarded-Proto and X-Forwarded-Host headers are

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -35,8 +35,12 @@ serviceAccount:
 #   - Events (for core_events tool)
 #   - Secrets (for reading credentials: token exchange, OAuth)
 rbac:
-  # Create RBAC resources (ClusterRole and ClusterRoleBinding)
+  # Create RBAC resources (ClusterRole, ClusterRoleBinding, and per-namespace Roles for secrets).
   create: true
+  # additionalSecretNamespaces lists namespaces beyond the release namespace where
+  # broker target secrets or githubApp.privateKeyRef secrets may reside.
+  # A Role/RoleBinding granting `get` on secrets is created in each listed namespace.
+  additionalSecretNamespaces: []
 
 podAnnotations: {}
 podLabels: {}

--- a/internal/aggregator/connection_helper_test.go
+++ b/internal/aggregator/connection_helper_test.go
@@ -399,6 +399,10 @@ func (m *mockSecretCredentialsHandler) LoadClientCredentials(
 	return m.credentials, nil
 }
 
+func (m *mockSecretCredentialsHandler) LoadSecretKey(_ context.Context, _ *api.ClientCredentialsSecretRef, _ string, _ string) ([]byte, error) {
+	return nil, fmt.Errorf("LoadSecretKey not implemented in mockSecretCredentialsHandler")
+}
+
 func TestLoadTokenExchangeCredentials(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/api/secret_credentials.go
+++ b/internal/api/secret_credentials.go
@@ -41,6 +41,20 @@ type SecretCredentialsHandler interface {
 	//   - *ClientCredentials: The loaded credentials
 	//   - error: Error if the secret cannot be found or is missing required keys
 	LoadClientCredentials(ctx context.Context, secretRef *ClientCredentialsSecretRef, defaultNamespace string) (*ClientCredentials, error)
+
+	// LoadSecretKey loads raw bytes for a single named key from a Kubernetes secret.
+	// Callers are responsible for not logging the returned value.
+	//
+	// Args:
+	//   - ctx: Context for Kubernetes API calls
+	//   - secretRef: Secret name and namespace (ClientIDKey/ClientSecretKey are ignored)
+	//   - key: Key name within the secret's data map
+	//   - defaultNamespace: Namespace to use if not specified in secretRef
+	//
+	// Returns:
+	//   - []byte: The raw secret data for the key
+	//   - error: Error if the secret cannot be found or is missing the key
+	LoadSecretKey(ctx context.Context, secretRef *ClientCredentialsSecretRef, key, defaultNamespace string) ([]byte, error)
 }
 
 // secretCredentialsHandler stores the registered handler implementation.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -334,9 +334,19 @@ type OAuthServerConfig struct {
 	TokenExchangeBroker TokenExchangeBrokerConfig `yaml:"tokenExchangeBroker,omitempty"`
 }
 
-// TargetTypeOIDCExchange is the target type for downstream Dex/OIDC RFC 8693
-// exchange. It is the default when BrokerTargetConfig.Type is empty.
-const TargetTypeOIDCExchange = "oidc-exchange"
+// BrokerTargetType identifies the credential provider for a broker target.
+type BrokerTargetType string
+
+const (
+	// TargetTypeOIDCExchange selects the downstream Dex/OIDC RFC 8693 exchange
+	// provider. It is the default when BrokerTargetConfig.Type is empty.
+	TargetTypeOIDCExchange BrokerTargetType = "oidc-exchange"
+
+	// TargetTypeGithubApp selects the GitHub App installation token provider.
+	// The provider builds an RS256 App JWT and exchanges it for a short-lived
+	// installation token scoped to the configured repositories and permissions.
+	TargetTypeGithubApp BrokerTargetType = "github-app"
+)
 
 // TokenExchangeBrokerConfig configures brokered RFC 8693 token exchange
 // (muster as a shared token broker for external clients).
@@ -373,14 +383,14 @@ type TokenExchangeBrokerConfig struct {
 
 // Enabled reports whether brokered token exchange is configured.
 func (c TokenExchangeBrokerConfig) Enabled() bool {
-	return len(c.Targets) > 0
+	return len(c.Targets) > 0 || len(c.WorkloadAudiences) > 0
 }
 
 // BrokerTargetConfig describes one downstream target of the token broker.
 type BrokerTargetConfig struct {
 	// Type selects the credential provider. Defaults to TargetTypeOIDCExchange
-	// ("oidc-exchange") when empty.
-	Type string `yaml:"type,omitempty"`
+	// when empty.
+	Type BrokerTargetType `yaml:"type,omitempty"`
 
 	// DexTokenEndpoint is the downstream Dex token endpoint URL (HTTPS).
 	// Example: https://dex.cluster-b.example.com/token
@@ -406,6 +416,49 @@ type BrokerTargetConfig struct {
 	// downstream exchange client credentials (same secrets the per-MCPServer
 	// tokenExchange config uses; no duplication).
 	ClientCredentialsSecretRef *BrokerSecretRefConfig `yaml:"clientCredentialsSecretRef,omitempty"`
+
+	// GithubApp contains configuration for the github-app provider type.
+	// Required when Type is "github-app"; ignored otherwise.
+	GithubApp *GithubAppTargetConfig `yaml:"githubApp,omitempty"`
+}
+
+// GithubAppTargetConfig configures the github-app credential provider.
+// The provider mints short-lived GitHub App installation tokens by building an
+// RS256 App JWT and exchanging it at the GitHub API.
+type GithubAppTargetConfig struct {
+	// AppID is the numeric GitHub App ID, used as the JWT iss claim.
+	AppID string `yaml:"appId"`
+
+	// InstallationID is the numeric installation ID. When empty, it is
+	// auto-discovered via GET /repos/{Owner}/{Repo}/installation using the App JWT.
+	// Either InstallationID or both Owner and Repo must be set.
+	InstallationID string `yaml:"installationId,omitempty"`
+
+	// Owner is the GitHub organization or user that installed the App.
+	// Required for auto-discovery when InstallationID is empty.
+	Owner string `yaml:"owner,omitempty"`
+
+	// Repo is the repository name (without owner) used for auto-discovery.
+	// Required for auto-discovery when InstallationID is empty.
+	Repo string `yaml:"repo,omitempty"`
+
+	// PrivateKeyRef references the Kubernetes Secret containing the RSA private
+	// key PEM. The key within the secret defaults to "private-key".
+	// Name and Namespace follow the same semantics as BrokerSecretRefConfig.
+	PrivateKeyRef *BrokerSecretRefConfig `yaml:"privateKeyRef"`
+
+	// Repositories limits the installation token to specific repositories.
+	// When empty, the token covers all repositories the installation can access.
+	Repositories []string `yaml:"repositories,omitempty"`
+
+	// Permissions further restricts the installation token permissions.
+	// Keys are permission names (e.g. "contents", "issues"); values are
+	// "read" or "write". When empty, the installation's full permissions apply.
+	Permissions map[string]string `yaml:"permissions,omitempty"`
+
+	// BaseURL overrides the GitHub API base URL. Defaults to
+	// https://api.github.com. Set for GitHub Enterprise Server or test stubs.
+	BaseURL string `yaml:"baseUrl,omitempty"`
 }
 
 // BrokerSecretRefConfig references a Kubernetes Secret with OAuth client

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -443,9 +443,8 @@ type GithubAppTargetConfig struct {
 	Repo string `yaml:"repo,omitempty"`
 
 	// PrivateKeyRef references the Kubernetes Secret containing the RSA private
-	// key PEM. The key within the secret defaults to "private-key".
-	// Name and Namespace follow the same semantics as BrokerSecretRefConfig.
-	PrivateKeyRef *BrokerSecretRefConfig `yaml:"privateKeyRef"`
+	// key PEM. Key defaults to "private-key" when empty.
+	PrivateKeyRef *GithubAppSecretKeyRef `yaml:"privateKeyRef"`
 
 	// Repositories limits the installation token to specific repositories.
 	// When empty, the token covers all repositories the installation can access.
@@ -456,9 +455,20 @@ type GithubAppTargetConfig struct {
 	// "read" or "write". When empty, the installation's full permissions apply.
 	Permissions map[string]string `yaml:"permissions,omitempty"`
 
-	// BaseURL overrides the GitHub API base URL. Defaults to
+	// BaseURL overrides the GitHub API base URL. Must use HTTPS. Defaults to
 	// https://api.github.com. Set for GitHub Enterprise Server or test stubs.
 	BaseURL string `yaml:"baseUrl,omitempty"`
+}
+
+// GithubAppSecretKeyRef references a Kubernetes Secret by name, namespace, and
+// key within the secret data map. Used for the GitHub App RSA private key PEM.
+type GithubAppSecretKeyRef struct {
+	// Name is the Kubernetes Secret name. Required.
+	Name string `yaml:"name"`
+	// Namespace defaults to the broker's DefaultSecretNamespace when empty.
+	Namespace string `yaml:"namespace,omitempty"`
+	// Key is the data key within the Secret. Defaults to "private-key".
+	Key string `yaml:"key,omitempty"`
 }
 
 // BrokerSecretRefConfig references a Kubernetes Secret with OAuth client

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -334,6 +334,10 @@ type OAuthServerConfig struct {
 	TokenExchangeBroker TokenExchangeBrokerConfig `yaml:"tokenExchangeBroker,omitempty"`
 }
 
+// TargetTypeOIDCExchange is the target type for downstream Dex/OIDC RFC 8693
+// exchange. It is the default when BrokerTargetConfig.Type is empty.
+const TargetTypeOIDCExchange = "oidc-exchange"
+
 // TokenExchangeBrokerConfig configures brokered RFC 8693 token exchange
 // (muster as a shared token broker for external clients).
 type TokenExchangeBrokerConfig struct {
@@ -344,8 +348,16 @@ type TokenExchangeBrokerConfig struct {
 	ClientAudiences map[string][]string `yaml:"clientAudiences,omitempty"`
 
 	// Targets maps an RFC 8693 audience name (e.g. a management cluster name)
-	// to the downstream Dex exchange target.
+	// to the downstream credential provider target.
 	Targets map[string]BrokerTargetConfig `yaml:"targets,omitempty"`
+
+	// WorkloadAudiences maps a workload subject (the sub claim of a validated
+	// SA token, e.g. system:serviceaccount:<ns>:<name>; globs supported) to
+	// the audiences it may request. Enables workload-authenticated token
+	// exchange (no confidential-client credentials required). Maps to
+	// mcp-oauth's Config.WorkloadAudiences; enforcement is performed upstream
+	// by mcp-oauth before the provider is invoked.
+	WorkloadAudiences map[string][]string `yaml:"workloadAudiences,omitempty"`
 
 	// AllowPrivateIP allows downstream token endpoints to resolve to private
 	// or loopback IP addresses. WARNING: reduces SSRF protection; only enable
@@ -364,8 +376,12 @@ func (c TokenExchangeBrokerConfig) Enabled() bool {
 	return len(c.Targets) > 0
 }
 
-// BrokerTargetConfig describes one downstream Dex target of the token broker.
+// BrokerTargetConfig describes one downstream target of the token broker.
 type BrokerTargetConfig struct {
+	// Type selects the credential provider. Defaults to TargetTypeOIDCExchange
+	// ("oidc-exchange") when empty.
+	Type string `yaml:"type,omitempty"`
+
 	// DexTokenEndpoint is the downstream Dex token endpoint URL (HTTPS).
 	// Example: https://dex.cluster-b.example.com/token
 	DexTokenEndpoint string `yaml:"dexTokenEndpoint"`

--- a/internal/mcpserver/credentials_adapter.go
+++ b/internal/mcpserver/credentials_adapter.go
@@ -134,3 +134,52 @@ func (a *CredentialsAdapter) LoadClientCredentials(
 		ClientSecret: clientSecret,
 	}, nil
 }
+
+// LoadSecretKey loads raw bytes for a single named key from a Kubernetes secret.
+func (a *CredentialsAdapter) LoadSecretKey(
+	ctx context.Context,
+	secretRef *api.ClientCredentialsSecretRef,
+	key string,
+	defaultNamespace string,
+) ([]byte, error) {
+	if secretRef == nil {
+		return nil, fmt.Errorf("secret reference is nil")
+	}
+	if secretRef.Name == "" {
+		return nil, fmt.Errorf("secret name is required")
+	}
+
+	namespace := secretRef.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	logging.Debug("SecretCredentials", "Loading secret key %q from secret %s/%s", key, namespace, secretRef.Name)
+
+	if secretRef.Namespace != "" && secretRef.Namespace != defaultNamespace {
+		logging.Warn("SecretCredentials", "Cross-namespace secret access: reading secret %s/%s from namespace %s. "+
+			"Ensure RBAC policies permit this access and review security implications.",
+			namespace, secretRef.Name, defaultNamespace)
+	}
+
+	secret := &corev1.Secret{}
+	if err := a.client.Get(ctx, client.ObjectKey{
+		Name:      secretRef.Name,
+		Namespace: namespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretRef.Name, err)
+	}
+
+	data, ok := secret.Data[key]
+	if !ok {
+		return nil, fmt.Errorf("secret %s/%s missing required key %q", namespace, secretRef.Name, key)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("secret %s/%s has empty value for key %q", namespace, secretRef.Name, key)
+	}
+
+	return data, nil
+}

--- a/internal/oauth/broker.go
+++ b/internal/oauth/broker.go
@@ -8,7 +8,6 @@ import (
 
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 
-	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/config"
 	"github.com/giantswarm/muster/pkg/logging"
 )
@@ -17,13 +16,13 @@ import (
 // TokenExchanger, turning muster into a shared RFC 8693 token broker: an
 // external confidential client (e.g. a developer-portal backend) presents a
 // subject token plus an audience name and receives a token minted by the
-// audience's downstream Dex.
+// audience's downstream credential provider.
 //
 // mcp-oauth owns subject-token validation (TrustedIssuers), client
 // authentication, the per-client audience allowlist
-// (Config.TokenExchangeClientAudiences), and audit. BrokerExchanger owns the
-// audience -> downstream-Dex mapping and the actual downstream exchange,
-// reusing the per-(endpoint, connector, user) token cache of TokenExchanger.
+// (Config.TokenExchangeClientAudiences), workload-audience authorization
+// (Config.WorkloadAudiences), and audit. BrokerExchanger owns the audience →
+// provider dispatch and delegates minting to the registered CredentialProvider.
 //
 // The exchanger instance is deliberately separate from the OAuth manager's
 // internal SSO exchanger: broker targets carry their own scope sets (e.g. the
@@ -33,8 +32,10 @@ import (
 //
 // Thread-safe: Yes.
 type BrokerExchanger struct {
-	cfg       config.TokenExchangeBrokerConfig
+	cfg      config.TokenExchangeBrokerConfig
 	exchanger *TokenExchanger
+	// registry overrides the default provider registry. Nil uses defaultProviderRegistry.
+	registry *providerRegistry
 }
 
 // NewBrokerExchanger creates a BrokerExchanger for the configured targets.
@@ -59,9 +60,20 @@ func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig) *BrokerExchanger {
 	}
 }
 
-// Exchange maps the requested audience to a downstream Dex target and performs
-// the downstream RFC 8693 exchange, forwarding the (already validated) subject
-// token verbatim. Unknown audiences return an error wrapping
+// effectiveRegistry returns the configured registry, falling back to the default
+// when none is set. Callers constructed via struct literal (e.g. in tests) that
+// do not set registry receive the default oidc-exchange registry built from
+// b.exchanger.
+func (b *BrokerExchanger) effectiveRegistry() *providerRegistry {
+	if b.registry != nil {
+		return b.registry
+	}
+	return defaultProviderRegistry()
+}
+
+// Exchange maps the requested audience to a downstream credential provider and
+// mints a token, forwarding the (already validated) subject token verbatim.
+// Unknown audiences or unsupported target types return errors wrapping
 // server.ErrInvalidTarget so the client receives invalid_target.
 func (b *BrokerExchanger) Exchange(ctx context.Context, req *oauthserver.ExchangerRequest) (*oauthserver.ExchangerResult, error) {
 	target, ok := b.cfg.Targets[req.Audience]
@@ -69,33 +81,16 @@ func (b *BrokerExchanger) Exchange(ctx context.Context, req *oauthserver.Exchang
 		return nil, fmt.Errorf("%w: no broker target configured for audience %q", oauthserver.ErrInvalidTarget, req.Audience)
 	}
 
-	exchangeConfig := &api.TokenExchangeConfig{
-		Enabled:          true,
-		DexTokenEndpoint: target.DexTokenEndpoint,
-		ExpectedIssuer:   target.ExpectedIssuer,
-		ConnectorID:      target.ConnectorID,
-		// Scopes are operator-controlled per target (the RFC 8693 scope
-		// parameter from the client is intentionally ignored): k8s-bound
-		// audiences need the Dex cross-client scope and clients must not be
-		// able to drop or extend it.
-		Scopes: target.Scopes,
+	provider, err := b.effectiveRegistry().forTarget(req.Audience, target, b.exchanger, b.cfg.DefaultSecretNamespace)
+	if err != nil {
+		return nil, err
 	}
 
-	if target.ClientCredentialsSecretRef != nil {
-		creds, err := b.loadCredentials(ctx, target.ClientCredentialsSecretRef)
-		if err != nil {
-			logging.Warn("TokenBroker", "Failed to load credentials for audience=%s: %v", req.Audience, err)
-			return nil, fmt.Errorf("load broker credentials for audience %q: %w", req.Audience, err)
-		}
-		exchangeConfig.ClientID = creds.ClientID
-		exchangeConfig.ClientSecret = creds.ClientSecret
-	}
-
-	result, err := b.exchanger.Exchange(ctx, &ExchangeRequest{
-		Config:           exchangeConfig,
+	result, err := provider.Mint(ctx, MintRequest{
+		Subject:          req.Subject.Subject,
 		SubjectToken:     req.SubjectToken,
 		SubjectTokenType: req.SubjectTokenType,
-		UserID:           req.Subject.Subject,
+		Target:           req.Audience,
 	})
 	if err != nil {
 		return nil, err
@@ -109,20 +104,4 @@ func (b *BrokerExchanger) Exchange(ctx context.Context, req *oauthserver.Exchang
 		IssuedTokenType: result.IssuedTokenType,
 		ExpiresAt:       result.ExpiresAt,
 	}, nil
-}
-
-// loadCredentials resolves the downstream exchange client credentials from the
-// referenced Kubernetes Secret via the registered SecretCredentialsHandler
-// (the same mechanism the per-MCPServer tokenExchange config uses).
-func (b *BrokerExchanger) loadCredentials(ctx context.Context, ref *config.BrokerSecretRefConfig) (*api.ClientCredentials, error) {
-	handler := api.GetSecretCredentialsHandler()
-	if handler == nil {
-		return nil, fmt.Errorf("no secret credentials handler registered (broker secret refs require Kubernetes mode)")
-	}
-	return handler.LoadClientCredentials(ctx, &api.ClientCredentialsSecretRef{
-		Name:            ref.Name,
-		Namespace:       ref.Namespace,
-		ClientIDKey:     ref.ClientIDKey,
-		ClientSecretKey: ref.ClientSecretKey,
-	}, b.cfg.DefaultSecretNamespace)
 }

--- a/internal/oauth/broker.go
+++ b/internal/oauth/broker.go
@@ -45,13 +45,11 @@ func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig) *BrokerExchanger {
 	// Mirror the OAuth manager's internal-deployment handling: mcp-oauth's
 	// private-IP-allowed client bypasses the process-wide augmented transport
 	// (--extra-ca-file), so hand the exchanger an explicit client backed by
-	// http.DefaultTransport when private IPs are allowed.
-	var httpClient *http.Client
+	// http.DefaultTransport when private IPs are allowed. The timeout is
+	// unconditional: downstream API calls must not block indefinitely.
+	httpClient := &http.Client{Timeout: 30 * time.Second}
 	if cfg.AllowPrivateIP {
-		httpClient = &http.Client{
-			Transport: http.DefaultTransport,
-			Timeout:   30 * time.Second,
-		}
+		httpClient.Transport = http.DefaultTransport
 	}
 	return &BrokerExchanger{
 		cfg: cfg,

--- a/internal/oauth/broker.go
+++ b/internal/oauth/broker.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/providers/tokencache"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 
 	"github.com/giantswarm/muster/internal/config"
@@ -35,7 +35,7 @@ import (
 type BrokerExchanger struct {
 	cfg         config.TokenExchangeBrokerConfig
 	exchanger   *TokenExchanger
-	githubCache *oidcpkg.TokenExchangeCache
+	githubCache *tokencache.Cache
 	httpClient  *http.Client // shared HTTP client for downstream calls
 	registry    *providerRegistry
 }
@@ -59,7 +59,7 @@ func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig) *BrokerExchanger {
 			AllowPrivateIP: cfg.AllowPrivateIP,
 			HTTPClient:     httpClient,
 		}),
-		githubCache: oidcpkg.NewTokenExchangeCache(),
+		githubCache: tokencache.New(),
 		httpClient:  httpClient,
 		registry:    defaultProviderRegistry(),
 	}

--- a/internal/oauth/broker.go
+++ b/internal/oauth/broker.go
@@ -32,7 +32,7 @@ import (
 //
 // Thread-safe: Yes.
 type BrokerExchanger struct {
-	cfg      config.TokenExchangeBrokerConfig
+	cfg       config.TokenExchangeBrokerConfig
 	exchanger *TokenExchanger
 	// registry overrides the default provider registry. Nil uses defaultProviderRegistry.
 	registry *providerRegistry

--- a/internal/oauth/broker.go
+++ b/internal/oauth/broker.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 
 	"github.com/giantswarm/muster/internal/config"
@@ -32,10 +33,11 @@ import (
 //
 // Thread-safe: Yes.
 type BrokerExchanger struct {
-	cfg       config.TokenExchangeBrokerConfig
-	exchanger *TokenExchanger
-	// registry overrides the default provider registry. Nil uses defaultProviderRegistry.
-	registry *providerRegistry
+	cfg         config.TokenExchangeBrokerConfig
+	exchanger   *TokenExchanger
+	githubCache *oidcpkg.TokenExchangeCache
+	httpClient  *http.Client // shared HTTP client for downstream calls
+	registry    *providerRegistry
 }
 
 // NewBrokerExchanger creates a BrokerExchanger for the configured targets.
@@ -57,18 +59,10 @@ func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig) *BrokerExchanger {
 			AllowPrivateIP: cfg.AllowPrivateIP,
 			HTTPClient:     httpClient,
 		}),
+		githubCache: oidcpkg.NewTokenExchangeCache(),
+		httpClient:  httpClient,
+		registry:    defaultProviderRegistry(),
 	}
-}
-
-// effectiveRegistry returns the configured registry, falling back to the default
-// when none is set. Callers constructed via struct literal (e.g. in tests) that
-// do not set registry receive the default oidc-exchange registry built from
-// b.exchanger.
-func (b *BrokerExchanger) effectiveRegistry() *providerRegistry {
-	if b.registry != nil {
-		return b.registry
-	}
-	return defaultProviderRegistry()
 }
 
 // Exchange maps the requested audience to a downstream credential provider and
@@ -81,7 +75,13 @@ func (b *BrokerExchanger) Exchange(ctx context.Context, req *oauthserver.Exchang
 		return nil, fmt.Errorf("%w: no broker target configured for audience %q", oauthserver.ErrInvalidTarget, req.Audience)
 	}
 
-	provider, err := b.effectiveRegistry().forTarget(req.Audience, target, b.exchanger, b.cfg.DefaultSecretNamespace)
+	deps := providerDeps{
+		exchanger:   b.exchanger,
+		githubCache: b.githubCache,
+		httpClient:  b.httpClient,
+		defaultNS:   b.cfg.DefaultSecretNamespace,
+	}
+	provider, err := b.registry.forTarget(req.Audience, target, deps)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oauth/broker_test.go
+++ b/internal/oauth/broker_test.go
@@ -37,6 +37,10 @@ func (s *stubCredentialsHandler) LoadClientCredentials(_ context.Context, ref *a
 	return s.creds, nil
 }
 
+func (s *stubCredentialsHandler) LoadSecretKey(_ context.Context, _ *api.ClientCredentialsSecretRef, _ string, _ string) ([]byte, error) {
+	return nil, fmt.Errorf("LoadSecretKey not implemented in stubCredentialsHandler")
+}
+
 // withCredentialsHandler registers h for the duration of the test and restores
 // the previous handler afterwards (the registry is a package-level global).
 func withCredentialsHandler(t *testing.T, h api.SecretCredentialsHandler) {
@@ -47,13 +51,14 @@ func withCredentialsHandler(t *testing.T, h api.SecretCredentialsHandler) {
 }
 
 func newTestBroker(cfg config.TokenExchangeBrokerConfig, httpClient *http.Client) *BrokerExchanger {
-	return &BrokerExchanger{
-		cfg: cfg,
-		exchanger: NewTokenExchangerWithOptions(TokenExchangerOptions{
-			AllowPrivateIP: true, // httptest servers listen on 127.0.0.1
+	b := NewBrokerExchanger(cfg)
+	if httpClient != nil {
+		b.exchanger = NewTokenExchangerWithOptions(TokenExchangerOptions{
+			AllowPrivateIP: true,
 			HTTPClient:     httpClient,
-		}),
+		})
 	}
+	return b
 }
 
 func subjectIdentity(sub string) *oauthserver.SubjectIdentity {

--- a/internal/oauth/broker_test.go
+++ b/internal/oauth/broker_test.go
@@ -70,7 +70,7 @@ func TestBrokerExchanger_UnknownAudience(t *testing.T) {
 		Targets: map[string]config.BrokerTargetConfig{},
 	}, nil)
 
-	_, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+	_, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{
 		Audience:     "unmapped",
 		Subject:      subjectIdentity("user-1"),
 		SubjectToken: "subject-token",
@@ -121,7 +121,7 @@ func TestBrokerExchanger_Exchange(t *testing.T) {
 		DefaultSecretNamespace: "muster-system",
 	}, downstream.Client())
 
-	result, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+	result, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{
 		Audience:         "cluster-a",
 		ClientID:         "portal-backend",
 		Subject:          subjectIdentity("user-1"),
@@ -155,7 +155,7 @@ func TestBrokerExchanger_Exchange(t *testing.T) {
 
 	// Second exchange for the same user is served from the per-(endpoint,
 	// connector, user) cache and keeps a usable expiry.
-	cached, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+	cached, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{
 		Audience:         "cluster-a",
 		ClientID:         "portal-backend",
 		Subject:          subjectIdentity("user-1"),
@@ -188,7 +188,7 @@ func TestBrokerExchanger_CredentialsErrors(t *testing.T) {
 
 	t.Run("no handler registered", func(t *testing.T) {
 		withCredentialsHandler(t, nil)
-		_, err := newTestBroker(cfg, nil).Exchange(context.Background(), req)
+		_, err := newTestBroker(cfg, nil).Exchange(t.Context(), req)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no secret credentials handler registered")
 		assert.False(t, errors.Is(err, oauthserver.ErrInvalidTarget))
@@ -196,7 +196,7 @@ func TestBrokerExchanger_CredentialsErrors(t *testing.T) {
 
 	t.Run("secret load failure", func(t *testing.T) {
 		withCredentialsHandler(t, &stubCredentialsHandler{err: fmt.Errorf("secret not found")})
-		_, err := newTestBroker(cfg, nil).Exchange(context.Background(), req)
+		_, err := newTestBroker(cfg, nil).Exchange(t.Context(), req)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secret not found")
 		assert.False(t, errors.Is(err, oauthserver.ErrInvalidTarget))
@@ -220,7 +220,7 @@ func TestBrokerExchanger_DownstreamError(t *testing.T) {
 		},
 	}, downstream.Client())
 
-	_, err := broker.Exchange(context.Background(), &oauthserver.ExchangerRequest{
+	_, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{
 		Audience:     "cluster-a",
 		Subject:      subjectIdentity("user-1"),
 		SubjectToken: "subject-token",

--- a/internal/oauth/credential_provider.go
+++ b/internal/oauth/credential_provider.go
@@ -3,8 +3,10 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
+	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 
 	"github.com/giantswarm/muster/internal/api"
@@ -49,21 +51,39 @@ type MintResult struct {
 	FromCache bool
 }
 
+// providerDeps holds the long-lived dependencies shared across provider instances
+// constructed per Exchange call. The broker builds this once in NewBrokerExchanger
+// and threads it through the factory so caches survive individual Mint calls.
+type providerDeps struct {
+	exchanger   *TokenExchanger
+	githubCache *oidcpkg.TokenExchangeCache
+	// httpClient is the broker's shared HTTP client; nil falls back to http.DefaultClient.
+	httpClient *http.Client
+	defaultNS  string
+}
+
 // providerFactory constructs a CredentialProvider for a single broker target.
-type providerFactory func(target config.BrokerTargetConfig, exchanger *TokenExchanger, defaultNS string) CredentialProvider
+type providerFactory func(target config.BrokerTargetConfig, deps providerDeps) CredentialProvider
 
 // providerRegistry dispatches to CredentialProvider implementations by target type.
-// Factories are keyed on the target Type string (BrokerTargetConfig.Type); an
-// empty type defaults to config.TargetTypeOIDCExchange.
+// Factories are keyed on BrokerTargetType; an empty type defaults to
+// config.TargetTypeOIDCExchange.
 type providerRegistry struct {
-	factories map[string]providerFactory
+	factories map[config.BrokerTargetType]providerFactory
 }
 
 // defaultProviderRegistry returns a registry pre-loaded with the built-in providers.
 func defaultProviderRegistry() *providerRegistry {
-	r := &providerRegistry{factories: make(map[string]providerFactory)}
-	r.factories[config.TargetTypeOIDCExchange] = func(target config.BrokerTargetConfig, exchanger *TokenExchanger, defaultNS string) CredentialProvider {
-		return &oidcExchangeProvider{target: target, exchanger: exchanger, defaultNS: defaultNS}
+	r := &providerRegistry{factories: make(map[config.BrokerTargetType]providerFactory)}
+	r.factories[config.TargetTypeOIDCExchange] = func(target config.BrokerTargetConfig, deps providerDeps) CredentialProvider {
+		return &oidcExchangeProvider{target: target, exchanger: deps.exchanger, defaultNS: deps.defaultNS}
+	}
+	r.factories[config.TargetTypeGithubApp] = func(target config.BrokerTargetConfig, deps providerDeps) CredentialProvider {
+		httpClient := deps.httpClient
+		if httpClient == nil {
+			httpClient = http.DefaultClient
+		}
+		return &githubAppProvider{target: target, cache: deps.githubCache, defaultNS: deps.defaultNS, httpClient: httpClient}
 	}
 	return r
 }
@@ -71,7 +91,7 @@ func defaultProviderRegistry() *providerRegistry {
 // forTarget resolves the CredentialProvider for the given target.
 // An empty target Type defaults to config.TargetTypeOIDCExchange.
 // An unregistered type returns an error wrapping oauthserver.ErrInvalidTarget.
-func (r *providerRegistry) forTarget(audience string, target config.BrokerTargetConfig, exchanger *TokenExchanger, defaultNS string) (CredentialProvider, error) {
+func (r *providerRegistry) forTarget(audience string, target config.BrokerTargetConfig, deps providerDeps) (CredentialProvider, error) {
 	targetType := target.Type
 	if targetType == "" {
 		targetType = config.TargetTypeOIDCExchange
@@ -80,7 +100,7 @@ func (r *providerRegistry) forTarget(audience string, target config.BrokerTarget
 	if !ok {
 		return nil, fmt.Errorf("%w: unsupported target type %q for audience %q", oauthserver.ErrInvalidTarget, targetType, audience)
 	}
-	return factory(target, exchanger, defaultNS), nil
+	return factory(target, deps), nil
 }
 
 // oidcExchangeProvider implements CredentialProvider via downstream RFC 8693

--- a/internal/oauth/credential_provider.go
+++ b/internal/oauth/credential_provider.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/providers/tokencache"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 
 	"github.com/giantswarm/muster/internal/api"
@@ -56,7 +56,7 @@ type MintResult struct {
 // and threads it through the factory so caches survive individual Mint calls.
 type providerDeps struct {
 	exchanger   *TokenExchanger
-	githubCache *oidcpkg.TokenExchangeCache
+	githubCache *tokencache.Cache
 	// httpClient is the broker's shared HTTP client; nil falls back to http.DefaultClient.
 	httpClient *http.Client
 	defaultNS  string

--- a/internal/oauth/credential_provider.go
+++ b/internal/oauth/credential_provider.go
@@ -1,0 +1,153 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	oauthserver "github.com/giantswarm/mcp-oauth/server"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// CredentialProvider mints credentials for one broker target.
+//
+// Each implementation encapsulates the downstream token-exchange protocol for a
+// specific target type (e.g. OIDC/Dex exchange, GitHub App installation token).
+// The broker calls Mint after mcp-oauth has already validated and authorized the
+// request: the provider only needs to perform the downstream exchange.
+type CredentialProvider interface {
+	Mint(ctx context.Context, req MintRequest) (*MintResult, error)
+}
+
+// MintRequest carries the parameters for a downstream credential exchange.
+type MintRequest struct {
+	// Subject is the authz principal: req.Subject.Subject (the impersonated
+	// identity). Used as the cache key by the oidc-exchange provider. Do NOT
+	// replace this with the actor subject — see comment on oidcExchangeProvider.
+	Subject string
+
+	// SubjectToken is the raw RFC 8693 subject_token, forwarded verbatim to
+	// the downstream token endpoint.
+	SubjectToken string
+
+	// SubjectTokenType is the RFC 8693 token-type URN of SubjectToken.
+	SubjectTokenType string
+
+	// Target is the audience / target name, used for logging and error messages.
+	Target string
+}
+
+// MintResult is the result of a successful credential exchange.
+type MintResult struct {
+	AccessToken     string
+	IssuedTokenType string
+	ExpiresAt       time.Time
+	// FromCache is true when the oidc-exchange provider returned a cached token.
+	FromCache bool
+}
+
+// providerFactory constructs a CredentialProvider for a single broker target.
+type providerFactory func(target config.BrokerTargetConfig, exchanger *TokenExchanger, defaultNS string) CredentialProvider
+
+// providerRegistry dispatches to CredentialProvider implementations by target type.
+// Factories are keyed on the target Type string (BrokerTargetConfig.Type); an
+// empty type defaults to config.TargetTypeOIDCExchange.
+type providerRegistry struct {
+	factories map[string]providerFactory
+}
+
+// defaultProviderRegistry returns a registry pre-loaded with the built-in providers.
+func defaultProviderRegistry() *providerRegistry {
+	r := &providerRegistry{factories: make(map[string]providerFactory)}
+	r.factories[config.TargetTypeOIDCExchange] = func(target config.BrokerTargetConfig, exchanger *TokenExchanger, defaultNS string) CredentialProvider {
+		return &oidcExchangeProvider{target: target, exchanger: exchanger, defaultNS: defaultNS}
+	}
+	return r
+}
+
+// forTarget resolves the CredentialProvider for the given target.
+// An empty target Type defaults to config.TargetTypeOIDCExchange.
+// An unregistered type returns an error wrapping oauthserver.ErrInvalidTarget.
+func (r *providerRegistry) forTarget(audience string, target config.BrokerTargetConfig, exchanger *TokenExchanger, defaultNS string) (CredentialProvider, error) {
+	targetType := target.Type
+	if targetType == "" {
+		targetType = config.TargetTypeOIDCExchange
+	}
+	factory, ok := r.factories[targetType]
+	if !ok {
+		return nil, fmt.Errorf("%w: unsupported target type %q for audience %q", oauthserver.ErrInvalidTarget, targetType, audience)
+	}
+	return factory(target, exchanger, defaultNS), nil
+}
+
+// oidcExchangeProvider implements CredentialProvider via downstream RFC 8693
+// OIDC/Dex token exchange. It wraps TokenExchanger and preserves the per-
+// (endpoint, connector, user) token cache.
+//
+// Cache keying: MintRequest.Subject (= req.Subject.Subject, the impersonated
+// identity) is used as TokenExchanger's UserID. Do NOT substitute the actor
+// subject here: if two different impersonated subjects were keyed on the same
+// actor, the cache would serve the first subject's token to the second caller.
+// Authorization is enforced upstream by mcp-oauth before Mint is called.
+type oidcExchangeProvider struct {
+	target    config.BrokerTargetConfig
+	exchanger *TokenExchanger
+	defaultNS string
+}
+
+func (p *oidcExchangeProvider) Mint(ctx context.Context, req MintRequest) (*MintResult, error) {
+	exchangeConfig := &api.TokenExchangeConfig{
+		Enabled:          true,
+		DexTokenEndpoint: p.target.DexTokenEndpoint,
+		ExpectedIssuer:   p.target.ExpectedIssuer,
+		ConnectorID:      p.target.ConnectorID,
+		// Scopes are operator-controlled per target: the RFC 8693 scope
+		// parameter from the client is intentionally ignored. Kubernetes-bound
+		// audiences require the Dex cross-client scope, which clients must not
+		// be able to drop or extend.
+		Scopes: p.target.Scopes,
+	}
+
+	if p.target.ClientCredentialsSecretRef != nil {
+		creds, err := p.loadCredentials(ctx, p.target.ClientCredentialsSecretRef)
+		if err != nil {
+			logging.Warn("TokenBroker", "Failed to load credentials for audience=%s: %v", req.Target, err)
+			return nil, fmt.Errorf("load broker credentials for audience %q: %w", req.Target, err)
+		}
+		exchangeConfig.ClientID = creds.ClientID
+		exchangeConfig.ClientSecret = creds.ClientSecret
+	}
+
+	result, err := p.exchanger.Exchange(ctx, &ExchangeRequest{
+		Config:           exchangeConfig,
+		SubjectToken:     req.SubjectToken,
+		SubjectTokenType: req.SubjectTokenType,
+		UserID:           req.Subject,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &MintResult{
+		AccessToken:     result.AccessToken,
+		IssuedTokenType: result.IssuedTokenType,
+		ExpiresAt:       result.ExpiresAt,
+		FromCache:       result.FromCache,
+	}, nil
+}
+
+func (p *oidcExchangeProvider) loadCredentials(ctx context.Context, ref *config.BrokerSecretRefConfig) (*api.ClientCredentials, error) {
+	handler := api.GetSecretCredentialsHandler()
+	if handler == nil {
+		return nil, fmt.Errorf("no secret credentials handler registered (broker secret refs require Kubernetes mode)")
+	}
+	return handler.LoadClientCredentials(ctx, &api.ClientCredentialsSecretRef{
+		Name:            ref.Name,
+		Namespace:       ref.Namespace,
+		ClientIDKey:     ref.ClientIDKey,
+		ClientSecretKey: ref.ClientSecretKey,
+	}, p.defaultNS)
+}

--- a/internal/oauth/credential_provider_test.go
+++ b/internal/oauth/credential_provider_test.go
@@ -14,10 +14,10 @@ import (
 
 // stubCredentialProvider is a CredentialProvider test double that records calls.
 type stubCredentialProvider struct {
-	result       *MintResult
-	err          error
-	mintCalled   bool
-	lastMintReq  MintRequest
+	result      *MintResult
+	err         error
+	mintCalled  bool
+	lastMintReq MintRequest
 }
 
 func (s *stubCredentialProvider) Mint(_ context.Context, req MintRequest) (*MintResult, error) {
@@ -90,4 +90,3 @@ func TestProviderRegistry_UnknownType(t *testing.T) {
 	assert.True(t, errors.Is(err, oauthserver.ErrInvalidTarget),
 		"unknown provider type must wrap ErrInvalidTarget, got: %v", err)
 }
-

--- a/internal/oauth/credential_provider_test.go
+++ b/internal/oauth/credential_provider_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/providers/tokencache"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,7 +81,7 @@ func TestProviderRegistry_UnknownType(t *testing.T) {
 			},
 		},
 		registry:    defaultProviderRegistry(),
-		githubCache: oidcpkg.NewTokenExchangeCache(),
+		githubCache: tokencache.New(),
 	}
 
 	_, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{

--- a/internal/oauth/credential_provider_test.go
+++ b/internal/oauth/credential_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,8 +35,8 @@ func TestProviderRegistry_Dispatch(t *testing.T) {
 	}
 
 	reg := &providerRegistry{
-		factories: map[string]providerFactory{
-			"stub-provider": func(_ config.BrokerTargetConfig, _ *TokenExchanger, _ string) CredentialProvider {
+		factories: map[config.BrokerTargetType]providerFactory{
+			"stub-provider": func(_ config.BrokerTargetConfig, _ providerDeps) CredentialProvider {
 				return stub
 			},
 		},
@@ -79,6 +80,8 @@ func TestProviderRegistry_UnknownType(t *testing.T) {
 				"cluster-a": {Type: "mystery-provider"},
 			},
 		},
+		registry:    defaultProviderRegistry(),
+		githubCache: oidcpkg.NewTokenExchangeCache(),
 	}
 
 	_, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{

--- a/internal/oauth/credential_provider_test.go
+++ b/internal/oauth/credential_provider_test.go
@@ -1,0 +1,93 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	oauthserver "github.com/giantswarm/mcp-oauth/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/config"
+)
+
+// stubCredentialProvider is a CredentialProvider test double that records calls.
+type stubCredentialProvider struct {
+	result       *MintResult
+	err          error
+	mintCalled   bool
+	lastMintReq  MintRequest
+}
+
+func (s *stubCredentialProvider) Mint(_ context.Context, req MintRequest) (*MintResult, error) {
+	s.mintCalled = true
+	s.lastMintReq = req
+	return s.result, s.err
+}
+
+// TestProviderRegistry_Dispatch verifies that Exchange selects the registered
+// provider and threads the correct MintRequest fields.
+func TestProviderRegistry_Dispatch(t *testing.T) {
+	stub := &stubCredentialProvider{
+		result: &MintResult{AccessToken: "minted-token", IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token"},
+	}
+
+	reg := &providerRegistry{
+		factories: map[string]providerFactory{
+			"stub-provider": func(_ config.BrokerTargetConfig, _ *TokenExchanger, _ string) CredentialProvider {
+				return stub
+			},
+		},
+	}
+
+	broker := &BrokerExchanger{
+		cfg: config.TokenExchangeBrokerConfig{
+			Targets: map[string]config.BrokerTargetConfig{
+				"cluster-a": {Type: "stub-provider"},
+			},
+		},
+		registry: reg,
+	}
+
+	result, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{
+		Audience:         "cluster-a",
+		Subject:          &oauthserver.SubjectIdentity{Subject: "user-1"},
+		SubjectToken:     "subject-token",
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
+	})
+	require.NoError(t, err)
+
+	// Stub was invoked with the correctly threaded MintRequest.
+	require.True(t, stub.mintCalled)
+	assert.Equal(t, "user-1", stub.lastMintReq.Subject)
+	assert.Equal(t, "subject-token", stub.lastMintReq.SubjectToken)
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:id_token", stub.lastMintReq.SubjectTokenType)
+	assert.Equal(t, "cluster-a", stub.lastMintReq.Target)
+
+	// Result is mapped through to the ExchangerResult.
+	assert.Equal(t, "minted-token", result.AccessToken)
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", result.IssuedTokenType)
+}
+
+// TestProviderRegistry_UnknownType verifies that a target with an unregistered
+// type returns an error wrapping ErrInvalidTarget.
+func TestProviderRegistry_UnknownType(t *testing.T) {
+	broker := &BrokerExchanger{
+		cfg: config.TokenExchangeBrokerConfig{
+			Targets: map[string]config.BrokerTargetConfig{
+				"cluster-a": {Type: "mystery-provider"},
+			},
+		},
+	}
+
+	_, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{
+		Audience:     "cluster-a",
+		Subject:      &oauthserver.SubjectIdentity{Subject: "user-1"},
+		SubjectToken: "subject-token",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, oauthserver.ErrInvalidTarget),
+		"unknown provider type must wrap ErrInvalidTarget, got: %v", err)
+}
+

--- a/internal/oauth/github_app_provider.go
+++ b/internal/oauth/github_app_provider.go
@@ -1,0 +1,339 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+const (
+	// githubAPIBaseURL is the default GitHub API base URL.
+	githubAPIBaseURL = "https://api.github.com"
+
+	// githubAppPrivateKeyDefault is the default key name within the secret.
+	githubAppPrivateKeyDefault = "private-key"
+
+	// appJWTExpiry is the lifetime of the App JWT sent to the GitHub API.
+	// GitHub requires exp - iat <= 10 minutes.
+	appJWTExpiry = 9 * time.Minute
+
+	// appJWTBackdate is applied to iat to tolerate minor clock skew.
+	appJWTBackdate = 60 * time.Second
+
+	// issuedTokenType is the RFC 8693 token-type URN for GitHub installation tokens.
+	issuedTokenType = "urn:ietf:params:oauth:token-type:access_token" //nolint:gosec // G101: RFC 8693 token-type URN, not a credential
+)
+
+// githubAppProvider implements CredentialProvider for GitHub App installation tokens.
+//
+// Minting flow: build an RS256 App JWT (iss=AppID), POST it to the GitHub
+// installations API to obtain a short-lived installation token, return the
+// token as the brokered credential.
+//
+// Authorization is enforced upstream by mcp-oauth before Mint is called.
+// The subject token and subject identity are not forwarded to GitHub —
+// installation tokens are app-scoped, not user-delegated.
+type githubAppProvider struct {
+	target config.BrokerTargetConfig
+	// cache holds minted installation tokens, keyed on (installationID, permissions-hash).
+	// Shared across Mint calls via the BrokerExchanger lifetime — providers are
+	// reconstructed per request so a provider-local cache would never hit.
+	cache      *oidc.TokenExchangeCache
+	defaultNS  string
+	httpClient *http.Client
+}
+
+// githubInstallationTokenRequest is the JSON body for POST .../access_tokens.
+type githubInstallationTokenRequest struct {
+	Repositories []string          `json:"repositories,omitempty"`
+	Permissions  map[string]string `json:"permissions,omitempty"`
+}
+
+// githubInstallationTokenResponse is the relevant subset of the GitHub API response.
+type githubInstallationTokenResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// githubInstallationResponse is used when auto-discovering an installation ID.
+type githubInstallationResponse struct {
+	ID int64 `json:"id"`
+}
+
+func (p *githubAppProvider) Mint(ctx context.Context, req MintRequest) (*MintResult, error) {
+	cfg := p.target.GithubApp
+	if cfg == nil {
+		return nil, fmt.Errorf("target %q has type github-app but no githubApp config", req.Target)
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = githubAPIBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	// Cache key encodes the installation scope so separate permission sets get
+	// separate entries.
+	cacheKey, err := githubAppCacheKey(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("computing cache key for target %q: %w", req.Target, err)
+	}
+	if hit := p.cache.Get(cacheKey); hit != nil {
+		logging.Debug("GitHubApp", "cache hit for target=%s", req.Target)
+		return &MintResult{
+			AccessToken:     hit.AccessToken,
+			IssuedTokenType: hit.IssuedTokenType,
+			ExpiresAt:       hit.ExpiresAt,
+			FromCache:       true,
+		}, nil
+	}
+
+	rsaKey, err := p.loadPrivateKey(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("load private key for target %q: %w", req.Target, err)
+	}
+
+	appJWT, err := buildAppJWT(cfg.AppID, rsaKey)
+	if err != nil {
+		return nil, fmt.Errorf("build App JWT for target %q: %w", req.Target, err)
+	}
+
+	installationID, err := p.resolveInstallationID(ctx, cfg, baseURL, appJWT)
+	if err != nil {
+		return nil, fmt.Errorf("resolve installation ID for target %q: %w", req.Target, err)
+	}
+
+	token, expiresAt, err := p.mintInstallationToken(ctx, cfg, baseURL, appJWT, installationID)
+	if err != nil {
+		return nil, fmt.Errorf("mint installation token for target %q: %w", req.Target, err)
+	}
+
+	if expiresIn := int(time.Until(expiresAt).Seconds()); expiresIn > 0 {
+		p.cache.Set(cacheKey, token, issuedTokenType, expiresIn)
+	}
+
+	return &MintResult{
+		AccessToken:     token,
+		IssuedTokenType: issuedTokenType,
+		ExpiresAt:       expiresAt,
+		FromCache:       false,
+	}, nil
+}
+
+// loadPrivateKey fetches the RSA private key PEM from the configured secret.
+func (p *githubAppProvider) loadPrivateKey(ctx context.Context, cfg *config.GithubAppTargetConfig) (*rsa.PrivateKey, error) {
+	if cfg.PrivateKeyRef == nil {
+		return nil, fmt.Errorf("privateKeyRef is required")
+	}
+	handler := api.GetSecretCredentialsHandler()
+	if handler == nil {
+		return nil, fmt.Errorf("no secret credentials handler registered (github-app private key requires Kubernetes mode)")
+	}
+
+	keyName := cfg.PrivateKeyRef.ClientIDKey
+	if keyName == "" {
+		keyName = githubAppPrivateKeyDefault
+	}
+
+	pemBytes, err := handler.LoadSecretKey(ctx, &api.ClientCredentialsSecretRef{
+		Name:      cfg.PrivateKeyRef.Name,
+		Namespace: cfg.PrivateKeyRef.Namespace,
+	}, keyName, p.defaultNS)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseRSAPrivateKey(pemBytes)
+}
+
+// parseRSAPrivateKey decodes the first PEM block and parses an RSA private key.
+// Accepts PKCS#1 (RSA PRIVATE KEY) and PKCS#8 (PRIVATE KEY) formats.
+func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no valid PEM block found in private key")
+	}
+
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing RSA PKCS#1 private key: %w", err)
+		}
+		return key, nil
+	case "PRIVATE KEY":
+		raw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing PKCS#8 private key: %w", err)
+		}
+		rsaKey, ok := raw.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("PKCS#8 private key is %T, expected *rsa.PrivateKey", raw)
+		}
+		return rsaKey, nil
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type %q; expected RSA PRIVATE KEY or PRIVATE KEY", block.Type)
+	}
+}
+
+// buildAppJWT creates an RS256-signed GitHub App JWT.
+// iss=appID, iat=now-backdate (clock skew), exp=now+appJWTExpiry.
+func buildAppJWT(appID string, key *rsa.PrivateKey) (string, error) {
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		return "", fmt.Errorf("creating RS256 signer: %w", err)
+	}
+
+	now := time.Now()
+	claims := josejwt.Claims{
+		Issuer:   appID,
+		IssuedAt: josejwt.NewNumericDate(now.Add(-appJWTBackdate)),
+		Expiry:   josejwt.NewNumericDate(now.Add(appJWTExpiry)),
+	}
+
+	token, err := josejwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		return "", fmt.Errorf("signing App JWT: %w", err)
+	}
+	return token, nil
+}
+
+// resolveInstallationID returns the installation ID from config or discovers it
+// via GET /repos/{owner}/{repo}/installation.
+func (p *githubAppProvider) resolveInstallationID(ctx context.Context, cfg *config.GithubAppTargetConfig, baseURL, appJWT string) (string, error) {
+	if cfg.InstallationID != "" {
+		return cfg.InstallationID, nil
+	}
+	if cfg.Owner == "" || cfg.Repo == "" {
+		return "", fmt.Errorf("either installationId or both owner and repo must be set")
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/%s/installation", baseURL, cfg.Owner, cfg.Repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("building installation discovery request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("GET %s returned %d: %s", url, resp.StatusCode, body)
+	}
+
+	var installation githubInstallationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&installation); err != nil {
+		return "", fmt.Errorf("decoding installation response: %w", err)
+	}
+	if installation.ID == 0 {
+		return "", fmt.Errorf("installation discovery returned empty ID")
+	}
+	return fmt.Sprintf("%d", installation.ID), nil
+}
+
+// mintInstallationToken POSTs to the GitHub installations API and returns the
+// token and its expiry.
+func (p *githubAppProvider) mintInstallationToken(
+	ctx context.Context,
+	cfg *config.GithubAppTargetConfig,
+	baseURL, appJWT, installationID string,
+) (string, time.Time, error) {
+	url := fmt.Sprintf("%s/app/installations/%s/access_tokens", baseURL, installationID)
+
+	body := githubInstallationTokenRequest{
+		Repositories: cfg.Repositories,
+		Permissions:  cfg.Permissions,
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("marshaling token request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("building token request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("POST %s: %w", url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", time.Time{}, fmt.Errorf("POST %s returned %d: %s", url, resp.StatusCode, body)
+	}
+
+	var tokenResp githubInstallationTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", time.Time{}, fmt.Errorf("decoding token response: %w", err)
+	}
+	if tokenResp.Token == "" {
+		return "", time.Time{}, fmt.Errorf("GitHub API returned empty token")
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, tokenResp.ExpiresAt)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("parsing expires_at %q: %w", tokenResp.ExpiresAt, err)
+	}
+
+	return tokenResp.Token, expiresAt, nil
+}
+
+// githubAppCacheKey returns a stable cache key for the given GitHub App config.
+// Keyed on installationID (or owner/repo for auto-discovery) plus a hash of
+// the requested repositories and permissions so distinct scope sets get
+// independent cache entries.
+func githubAppCacheKey(cfg *config.GithubAppTargetConfig) (string, error) {
+	installRef := cfg.InstallationID
+	if installRef == "" {
+		installRef = cfg.Owner + "/" + cfg.Repo
+	}
+
+	// Stable JSON of scope — marshaling map[string]string is deterministic in
+	// Go (sorted keys since 1.12).
+	scope := struct {
+		Repos       []string          `json:"r,omitempty"`
+		Permissions map[string]string `json:"p,omitempty"`
+	}{
+		Repos:       cfg.Repositories,
+		Permissions: cfg.Permissions,
+	}
+	scopeJSON, err := json.Marshal(scope)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(scopeJSON)
+	return fmt.Sprintf("github-app:%s:%x", installRef, h), nil
+}

--- a/internal/oauth/github_app_provider.go
+++ b/internal/oauth/github_app_provider.go
@@ -30,8 +30,9 @@ const (
 	githubAppPrivateKeyDefault = "private-key"
 
 	// appJWTExpiry is the lifetime of the App JWT sent to the GitHub API.
-	// GitHub requires exp - iat <= 10 minutes.
-	appJWTExpiry = 9 * time.Minute
+	// GitHub requires exp - iat <= 10 minutes; 8 minutes leaves headroom for
+	// clock skew between muster and the GitHub API.
+	appJWTExpiry = 8 * time.Minute
 
 	// appJWTBackdate is applied to iat to tolerate minor clock skew.
 	appJWTBackdate = 60 * time.Second
@@ -312,13 +313,19 @@ func (p *githubAppProvider) mintInstallationToken(
 }
 
 // githubAppCacheKey returns a stable cache key for the given GitHub App config.
-// Keyed on installationID (or owner/repo for auto-discovery) plus a hash of
-// the requested repositories and permissions so distinct scope sets get
-// independent cache entries.
+// Keyed on AppID + BaseURL + installationID (or owner/repo for auto-discovery)
+// plus a hash of the requested repositories and permissions. AppID and BaseURL
+// are included so that two distinct GitHub Apps targeting the same owner/repo
+// (or coincidentally sharing an installation ID) never share a cache entry.
 func githubAppCacheKey(cfg *config.GithubAppTargetConfig) (string, error) {
 	installRef := cfg.InstallationID
 	if installRef == "" {
 		installRef = cfg.Owner + "/" + cfg.Repo
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = githubAPIBaseURL
 	}
 
 	// Stable JSON of scope — marshaling map[string]string is deterministic in
@@ -335,5 +342,5 @@ func githubAppCacheKey(cfg *config.GithubAppTargetConfig) (string, error) {
 		return "", err
 	}
 	h := sha256.Sum256(scopeJSON)
-	return fmt.Sprintf("github-app:%s:%x", installRef, h), nil
+	return fmt.Sprintf("github-app:%s:%s:%s:%x", cfg.AppID, baseURL, installRef, h), nil
 }

--- a/internal/oauth/github_app_provider.go
+++ b/internal/oauth/github_app_provider.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"bytes"
 	"context"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -10,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -89,6 +92,16 @@ func (p *githubAppProvider) Mint(ctx context.Context, req MintRequest) (*MintRes
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 
+	// B1: Reject non-HTTPS to prevent plaintext transmission of the App JWT and installation token.
+	if parsedURL, err := url.Parse(baseURL); err != nil || parsedURL.Scheme != "https" {
+		return nil, fmt.Errorf("githubApp.baseUrl must use https scheme, got %q", baseURL)
+	}
+
+	// NB3: A non-numeric AppID produces an invalid JWT iss that GitHub rejects.
+	if _, err := strconv.ParseInt(cfg.AppID, 10, 64); err != nil {
+		return nil, fmt.Errorf("githubApp.appId must be a numeric GitHub App ID, got %q", cfg.AppID)
+	}
+
 	// Cache key encodes the installation scope so separate permission sets get
 	// separate entries.
 	cacheKey, err := githubAppCacheKey(cfg)
@@ -147,7 +160,7 @@ func (p *githubAppProvider) loadPrivateKey(ctx context.Context, cfg *config.Gith
 		return nil, fmt.Errorf("no secret credentials handler registered (github-app private key requires Kubernetes mode)")
 	}
 
-	keyName := cfg.PrivateKeyRef.ClientIDKey
+	keyName := cfg.PrivateKeyRef.Key
 	if keyName == "" {
 		keyName = githubAppPrivateKeyDefault
 	}
@@ -228,8 +241,8 @@ func (p *githubAppProvider) resolveInstallationID(ctx context.Context, cfg *conf
 		return "", fmt.Errorf("either installationId or both owner and repo must be set")
 	}
 
-	url := fmt.Sprintf("%s/repos/%s/%s/installation", baseURL, cfg.Owner, cfg.Repo)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/installation", baseURL, url.PathEscape(cfg.Owner), url.PathEscape(cfg.Repo))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("building installation discovery request: %w", err)
 	}
@@ -239,13 +252,13 @@ func (p *githubAppProvider) resolveInstallationID(ctx context.Context, cfg *conf
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("GET %s: %w", url, err)
+		return "", fmt.Errorf("GET %s: %w", apiURL, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return "", fmt.Errorf("GET %s returned %d: %s", url, resp.StatusCode, body)
+		return "", fmt.Errorf("GET %s returned %d: %s", apiURL, resp.StatusCode, body)
 	}
 
 	var installation githubInstallationResponse
@@ -276,7 +289,7 @@ func (p *githubAppProvider) mintInstallationToken(
 		return "", time.Time{}, fmt.Errorf("marshaling token request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyBytes)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("building token request: %w", err)
 	}

--- a/internal/oauth/github_app_provider.go
+++ b/internal/oauth/github_app_provider.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/providers/tokencache"
 	"github.com/go-jose/go-jose/v4"
 	josejwt "github.com/go-jose/go-jose/v4/jwt"
 
@@ -54,7 +54,7 @@ type githubAppProvider struct {
 	// cache holds minted installation tokens, keyed on (installationID, permissions-hash).
 	// Shared across Mint calls via the BrokerExchanger lifetime — providers are
 	// reconstructed per request so a provider-local cache would never hit.
-	cache      *oidc.TokenExchangeCache
+	cache      *tokencache.Cache
 	defaultNS  string
 	httpClient *http.Client
 }

--- a/internal/oauth/github_app_provider_test.go
+++ b/internal/oauth/github_app_provider_test.go
@@ -1,0 +1,331 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
+	oauthserver "github.com/giantswarm/mcp-oauth/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+)
+
+// testRSAKey generates a throwaway 2048-bit RSA key for use in tests.
+func testRSAKey(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return key, pemBytes
+}
+
+// stubSecretKeyHandler is a SecretCredentialsHandler test double that serves
+// a fixed PEM for LoadSecretKey and stubs out LoadClientCredentials.
+type stubSecretKeyHandler struct {
+	pemBytes []byte
+	err      error
+}
+
+func (s *stubSecretKeyHandler) LoadClientCredentials(_ context.Context, _ *api.ClientCredentialsSecretRef, _ string) (*api.ClientCredentials, error) {
+	return nil, fmt.Errorf("LoadClientCredentials not implemented in stubSecretKeyHandler")
+}
+
+func (s *stubSecretKeyHandler) LoadSecretKey(_ context.Context, _ *api.ClientCredentialsSecretRef, _ string, _ string) ([]byte, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.pemBytes, nil
+}
+
+// jwtPayloadClaims decodes the payload section of a compact JWT without
+// signature verification, returning the raw claims map. Panics on malformed input.
+func jwtPayloadClaims(t *testing.T, compact string) map[string]any {
+	t.Helper()
+	parts := strings.Split(compact, ".")
+	require.Len(t, parts, 3, "expected compact JWT (3 dot-separated parts)")
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err, "decoding JWT payload")
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(payload, &claims), "unmarshaling JWT claims")
+	return claims
+}
+
+// newGithubTestProvider builds a githubAppProvider pointing at the given test
+// server URL.
+func newGithubTestProvider(t *testing.T, cfg *config.GithubAppTargetConfig, serverURL string, pemBytes []byte) *githubAppProvider {
+	t.Helper()
+	cfg.BaseURL = serverURL
+	withCredentialsHandler(t, &stubSecretKeyHandler{pemBytes: pemBytes})
+	return &githubAppProvider{
+		target:     config.BrokerTargetConfig{GithubApp: cfg},
+		cache:      oidcpkg.NewTokenExchangeCache(),
+		defaultNS:  "muster-system",
+		httpClient: &http.Client{},
+	}
+}
+
+// okTokenHandler returns an httptest handler that always serves a 201 token
+// response and records the decoded request body into *body.
+func okTokenHandler(t *testing.T, tokenValue string, body *githubInstallationTokenRequest) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			_ = json.NewDecoder(r.Body).Decode(body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token":      tokenValue,
+				"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			})
+		}
+	}
+}
+
+// TestGithubAppProvider_AppJWTClaims verifies that the App JWT sent to the
+// GitHub API has a correct iss, a backdated iat, and exp-iat ≤ 10 minutes.
+func TestGithubAppProvider_AppJWTClaims(t *testing.T) {
+	_, pemBytes := testRSAKey(t)
+
+	var gotAuthHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 42})
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "ghs_test_token",
+			"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
+		AppID:         "99999",
+		Owner:         "my-org",
+		Repo:          "my-repo",
+		PrivateKeyRef: &config.BrokerSecretRefConfig{Name: "pem"},
+	}, server.URL, pemBytes)
+
+	_, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, gotAuthHeader)
+	require.True(t, strings.HasPrefix(gotAuthHeader, "Bearer "), "Authorization must be Bearer")
+	tokenStr := strings.TrimPrefix(gotAuthHeader, "Bearer ")
+
+	claims := jwtPayloadClaims(t, tokenStr)
+	assert.Equal(t, "99999", claims["iss"], "iss must be AppID")
+
+	iat := time.Unix(int64(claims["iat"].(float64)), 0)
+	exp := time.Unix(int64(claims["exp"].(float64)), 0)
+	now := time.Now()
+
+	assert.True(t, iat.Before(now), "iat must be backdated (iat=%v, now=%v)", iat, now)
+	assert.LessOrEqual(t, exp.Sub(iat), 10*time.Minute, "exp-iat must be ≤ 10 minutes")
+}
+
+// TestGithubAppProvider_RequestBody verifies that repositories and permissions
+// from the config are forwarded in the access_tokens request body.
+func TestGithubAppProvider_RequestBody(t *testing.T) {
+	_, pemBytes := testRSAKey(t)
+	var gotBody githubInstallationTokenRequest
+	server := httptest.NewServer(okTokenHandler(t, "ghs_scoped", &gotBody))
+	t.Cleanup(server.Close)
+
+	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
+		AppID:          "99999",
+		InstallationID: "12345",
+		Repositories:   []string{"infra"},
+		Permissions:    map[string]string{"contents": "read"},
+		PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
+	}, server.URL, pemBytes)
+
+	_, err := provider.Mint(t.Context(), MintRequest{Target: "scoped"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"infra"}, gotBody.Repositories)
+	assert.Equal(t, map[string]string{"contents": "read"}, gotBody.Permissions)
+}
+
+// TestGithubAppProvider_EmptyReposPermissions verifies that nil repositories
+// and permissions are omitted from the request body (omitempty).
+func TestGithubAppProvider_EmptyReposPermissions(t *testing.T) {
+	_, pemBytes := testRSAKey(t)
+	var gotBody githubInstallationTokenRequest
+	server := httptest.NewServer(okTokenHandler(t, "ghs_wide", &gotBody))
+	t.Cleanup(server.Close)
+
+	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
+		AppID:          "99999",
+		InstallationID: "12345",
+		PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
+	}, server.URL, pemBytes)
+
+	_, err := provider.Mint(t.Context(), MintRequest{Target: "wide"})
+	require.NoError(t, err)
+	assert.Nil(t, gotBody.Repositories)
+	assert.Nil(t, gotBody.Permissions)
+}
+
+// TestGithubAppProvider_InstallationDiscovery verifies that when InstallationID
+// is empty the provider performs GET /repos/{owner}/{repo}/installation and
+// uses the returned ID in the token POST path.
+func TestGithubAppProvider_InstallationDiscovery(t *testing.T) {
+	_, pemBytes := testRSAKey(t)
+	var discoveryPath, tokenPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			discoveryPath = r.URL.Path
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 777})
+			return
+		}
+		tokenPath = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "ghs_discovered",
+			"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
+		AppID:         "99999",
+		Owner:         "acme-org",
+		Repo:          "platform",
+		PrivateKeyRef: &config.BrokerSecretRefConfig{Name: "pem"},
+	}, server.URL, pemBytes)
+
+	result, err := provider.Mint(t.Context(), MintRequest{Target: "disc"})
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_discovered", result.AccessToken)
+	assert.Equal(t, "/repos/acme-org/platform/installation", discoveryPath)
+	assert.Equal(t, "/app/installations/777/access_tokens", tokenPath)
+}
+
+// TestGithubAppProvider_Cache verifies that the second Mint for the same
+// (installationID, permissions) is served from cache without a second API call.
+func TestGithubAppProvider_Cache(t *testing.T) {
+	_, pemBytes := testRSAKey(t)
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			callCount.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token":      "ghs_cached",
+				"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
+		AppID:          "99999",
+		InstallationID: "42",
+		PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
+	}, server.URL, pemBytes)
+
+	first, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
+	require.NoError(t, err)
+	assert.False(t, first.FromCache)
+
+	second, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
+	require.NoError(t, err)
+	assert.True(t, second.FromCache, "second Mint must be served from cache")
+	assert.Equal(t, "ghs_cached", second.AccessToken)
+	assert.Equal(t, int32(1), callCount.Load(), "GitHub API must be called only once")
+}
+
+// TestGithubAppProvider_NoSecretHandler verifies that a missing secret handler
+// returns an appropriate error (not ErrInvalidTarget).
+func TestGithubAppProvider_NoSecretHandler(t *testing.T) {
+	withCredentialsHandler(t, nil)
+
+	provider := &githubAppProvider{
+		target: config.BrokerTargetConfig{
+			GithubApp: &config.GithubAppTargetConfig{
+				AppID:          "99999",
+				InstallationID: "42",
+				PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
+				BaseURL:        "https://api.github.com",
+			},
+		},
+		cache:      oidcpkg.NewTokenExchangeCache(),
+		defaultNS:  "muster-system",
+		httpClient: http.DefaultClient,
+	}
+
+	_, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no secret credentials handler registered")
+}
+
+// TestGithubAppProvider_MissingConfig verifies that a target configured with
+// type github-app but no githubApp block returns a clear error.
+func TestGithubAppProvider_MissingConfig(t *testing.T) {
+	provider := &githubAppProvider{
+		target:     config.BrokerTargetConfig{},
+		cache:      oidcpkg.NewTokenExchangeCache(),
+		defaultNS:  "muster-system",
+		httpClient: http.DefaultClient,
+	}
+
+	_, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no githubApp config")
+}
+
+// TestProviderRegistry_GithubAppType verifies that targets with type "github-app"
+// resolve to the github-app provider and do NOT return ErrInvalidTarget.
+func TestProviderRegistry_GithubAppType(t *testing.T) {
+	withCredentialsHandler(t, nil)
+
+	broker := &BrokerExchanger{
+		cfg: config.TokenExchangeBrokerConfig{
+			Targets: map[string]config.BrokerTargetConfig{
+				"github": {
+					Type: config.TargetTypeGithubApp,
+					GithubApp: &config.GithubAppTargetConfig{
+						AppID:          "99999",
+						InstallationID: "42",
+						PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
+						BaseURL:        "https://api.github.com",
+					},
+				},
+			},
+		},
+		registry:    defaultProviderRegistry(),
+		githubCache: oidcpkg.NewTokenExchangeCache(),
+		httpClient:  http.DefaultClient,
+	}
+
+	_, err := broker.Exchange(t.Context(), &oauthserver.ExchangerRequest{
+		Audience:     "github",
+		Subject:      &oauthserver.SubjectIdentity{Subject: "user-1"},
+		SubjectToken: "subject-token",
+	})
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, oauthserver.ErrInvalidTarget),
+		"github-app type must resolve to a provider, not ErrInvalidTarget, got: %v", err)
+}

--- a/internal/oauth/github_app_provider_test.go
+++ b/internal/oauth/github_app_provider_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	oidcpkg "github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/providers/tokencache"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,7 +77,7 @@ func newGithubTestProvider(t *testing.T, cfg *config.GithubAppTargetConfig, serv
 	withCredentialsHandler(t, &stubSecretKeyHandler{pemBytes: pemBytes})
 	return &githubAppProvider{
 		target:     config.BrokerTargetConfig{GithubApp: cfg},
-		cache:      oidcpkg.NewTokenExchangeCache(),
+		cache:      tokencache.New(),
 		defaultNS:  "muster-system",
 		httpClient: &http.Client{},
 	}
@@ -271,7 +271,7 @@ func TestGithubAppProvider_NoSecretHandler(t *testing.T) {
 				BaseURL:        "https://api.github.com",
 			},
 		},
-		cache:      oidcpkg.NewTokenExchangeCache(),
+		cache:      tokencache.New(),
 		defaultNS:  "muster-system",
 		httpClient: http.DefaultClient,
 	}
@@ -286,7 +286,7 @@ func TestGithubAppProvider_NoSecretHandler(t *testing.T) {
 func TestGithubAppProvider_MissingConfig(t *testing.T) {
 	provider := &githubAppProvider{
 		target:     config.BrokerTargetConfig{},
-		cache:      oidcpkg.NewTokenExchangeCache(),
+		cache:      tokencache.New(),
 		defaultNS:  "muster-system",
 		httpClient: http.DefaultClient,
 	}
@@ -316,7 +316,7 @@ func TestProviderRegistry_GithubAppType(t *testing.T) {
 			},
 		},
 		registry:    defaultProviderRegistry(),
-		githubCache: oidcpkg.NewTokenExchangeCache(),
+		githubCache: tokencache.New(),
 		httpClient:  http.DefaultClient,
 	}
 

--- a/internal/oauth/github_app_provider_test.go
+++ b/internal/oauth/github_app_provider_test.go
@@ -70,16 +70,19 @@ func jwtPayloadClaims(t *testing.T, compact string) map[string]any {
 }
 
 // newGithubTestProvider builds a githubAppProvider pointing at the given test
-// server URL.
-func newGithubTestProvider(t *testing.T, cfg *config.GithubAppTargetConfig, serverURL string, pemBytes []byte) *githubAppProvider {
+// server URL. httpClient must be the TLS-aware client from a TLS test server.
+func newGithubTestProvider(t *testing.T, cfg *config.GithubAppTargetConfig, serverURL string, pemBytes []byte, httpClient *http.Client) *githubAppProvider {
 	t.Helper()
 	cfg.BaseURL = serverURL
 	withCredentialsHandler(t, &stubSecretKeyHandler{pemBytes: pemBytes})
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
 	return &githubAppProvider{
 		target:     config.BrokerTargetConfig{GithubApp: cfg},
 		cache:      tokencache.New(),
 		defaultNS:  "muster-system",
-		httpClient: &http.Client{},
+		httpClient: httpClient,
 	}
 }
 
@@ -105,7 +108,7 @@ func TestGithubAppProvider_AppJWTClaims(t *testing.T) {
 	_, pemBytes := testRSAKey(t)
 
 	var gotAuthHeader string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuthHeader = r.Header.Get("Authorization")
 		if r.Method == http.MethodGet {
 			_ = json.NewEncoder(w).Encode(map[string]any{"id": 42})
@@ -123,8 +126,8 @@ func TestGithubAppProvider_AppJWTClaims(t *testing.T) {
 		AppID:         "99999",
 		Owner:         "my-org",
 		Repo:          "my-repo",
-		PrivateKeyRef: &config.BrokerSecretRefConfig{Name: "pem"},
-	}, server.URL, pemBytes)
+		PrivateKeyRef: &config.GithubAppSecretKeyRef{Name: "pem"},
+	}, server.URL, pemBytes, server.Client())
 
 	_, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
 	require.NoError(t, err)
@@ -149,7 +152,7 @@ func TestGithubAppProvider_AppJWTClaims(t *testing.T) {
 func TestGithubAppProvider_RequestBody(t *testing.T) {
 	_, pemBytes := testRSAKey(t)
 	var gotBody githubInstallationTokenRequest
-	server := httptest.NewServer(okTokenHandler(t, "ghs_scoped", &gotBody))
+	server := httptest.NewTLSServer(okTokenHandler(t, "ghs_scoped", &gotBody))
 	t.Cleanup(server.Close)
 
 	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
@@ -157,8 +160,8 @@ func TestGithubAppProvider_RequestBody(t *testing.T) {
 		InstallationID: "12345",
 		Repositories:   []string{"infra"},
 		Permissions:    map[string]string{"contents": "read"},
-		PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
-	}, server.URL, pemBytes)
+		PrivateKeyRef:  &config.GithubAppSecretKeyRef{Name: "pem"},
+	}, server.URL, pemBytes, server.Client())
 
 	_, err := provider.Mint(t.Context(), MintRequest{Target: "scoped"})
 	require.NoError(t, err)
@@ -171,14 +174,14 @@ func TestGithubAppProvider_RequestBody(t *testing.T) {
 func TestGithubAppProvider_EmptyReposPermissions(t *testing.T) {
 	_, pemBytes := testRSAKey(t)
 	var gotBody githubInstallationTokenRequest
-	server := httptest.NewServer(okTokenHandler(t, "ghs_wide", &gotBody))
+	server := httptest.NewTLSServer(okTokenHandler(t, "ghs_wide", &gotBody))
 	t.Cleanup(server.Close)
 
 	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
 		AppID:          "99999",
 		InstallationID: "12345",
-		PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
-	}, server.URL, pemBytes)
+		PrivateKeyRef:  &config.GithubAppSecretKeyRef{Name: "pem"},
+	}, server.URL, pemBytes, server.Client())
 
 	_, err := provider.Mint(t.Context(), MintRequest{Target: "wide"})
 	require.NoError(t, err)
@@ -193,7 +196,7 @@ func TestGithubAppProvider_InstallationDiscovery(t *testing.T) {
 	_, pemBytes := testRSAKey(t)
 	var discoveryPath, tokenPath string
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			discoveryPath = r.URL.Path
 			_ = json.NewEncoder(w).Encode(map[string]any{"id": 777})
@@ -212,8 +215,8 @@ func TestGithubAppProvider_InstallationDiscovery(t *testing.T) {
 		AppID:         "99999",
 		Owner:         "acme-org",
 		Repo:          "platform",
-		PrivateKeyRef: &config.BrokerSecretRefConfig{Name: "pem"},
-	}, server.URL, pemBytes)
+		PrivateKeyRef: &config.GithubAppSecretKeyRef{Name: "pem"},
+	}, server.URL, pemBytes, server.Client())
 
 	result, err := provider.Mint(t.Context(), MintRequest{Target: "disc"})
 	require.NoError(t, err)
@@ -228,7 +231,7 @@ func TestGithubAppProvider_Cache(t *testing.T) {
 	_, pemBytes := testRSAKey(t)
 	var callCount atomic.Int32
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			callCount.Add(1)
 			w.WriteHeader(http.StatusCreated)
@@ -243,8 +246,8 @@ func TestGithubAppProvider_Cache(t *testing.T) {
 	provider := newGithubTestProvider(t, &config.GithubAppTargetConfig{
 		AppID:          "99999",
 		InstallationID: "42",
-		PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
-	}, server.URL, pemBytes)
+		PrivateKeyRef:  &config.GithubAppSecretKeyRef{Name: "pem"},
+	}, server.URL, pemBytes, server.Client())
 
 	first, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
 	require.NoError(t, err)
@@ -267,7 +270,7 @@ func TestGithubAppProvider_NoSecretHandler(t *testing.T) {
 			GithubApp: &config.GithubAppTargetConfig{
 				AppID:          "99999",
 				InstallationID: "42",
-				PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
+				PrivateKeyRef:  &config.GithubAppSecretKeyRef{Name: "pem"},
 				BaseURL:        "https://api.github.com",
 			},
 		},
@@ -309,7 +312,7 @@ func TestProviderRegistry_GithubAppType(t *testing.T) {
 					GithubApp: &config.GithubAppTargetConfig{
 						AppID:          "99999",
 						InstallationID: "42",
-						PrivateKeyRef:  &config.BrokerSecretRefConfig{Name: "pem"},
+						PrivateKeyRef:  &config.GithubAppSecretKeyRef{Name: "pem"},
 						BaseURL:        "https://api.github.com",
 					},
 				},
@@ -328,4 +331,83 @@ func TestProviderRegistry_GithubAppType(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, oauthserver.ErrInvalidTarget),
 		"github-app type must resolve to a provider, not ErrInvalidTarget, got: %v", err)
+}
+
+// testRSAKeyPKCS8 generates a throwaway 2048-bit RSA key encoded as PKCS#8 PEM.
+func testRSAKeyPKCS8(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	})
+	return key, pemBytes
+}
+
+// TestParseRSAPrivateKey_PKCS8 verifies that parseRSAPrivateKey accepts PKCS#8
+// PEM blocks in addition to the PKCS#1 form used by github.com key downloads.
+func TestParseRSAPrivateKey_PKCS8(t *testing.T) {
+	_, pemBytes := testRSAKeyPKCS8(t)
+	got, err := parseRSAPrivateKey(pemBytes)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+// TestGithubAppProvider_HTTPSEnforcement verifies that a non-HTTPS baseUrl is
+// rejected with a clear error before any network call is made.
+func TestGithubAppProvider_HTTPSEnforcement(t *testing.T) {
+	_, pemBytes := testRSAKey(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("provider must not reach the network when baseUrl is http://")
+	}))
+	t.Cleanup(srv.Close)
+
+	withCredentialsHandler(t, &stubSecretKeyHandler{pemBytes: pemBytes})
+	provider := &githubAppProvider{
+		target: config.BrokerTargetConfig{GithubApp: &config.GithubAppTargetConfig{
+			AppID:          "99999",
+			InstallationID: "42",
+			PrivateKeyRef:  &config.GithubAppSecretKeyRef{Name: "pem"},
+			BaseURL:        srv.URL, // http://
+		}},
+		cache:      tokencache.New(),
+		defaultNS:  "muster-system",
+		httpClient: srv.Client(),
+	}
+
+	_, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https scheme")
+}
+
+// TestGithubAppProvider_NonNumericAppID verifies that a non-numeric appId is
+// rejected before a JWT is built (GitHub rejects non-numeric iss at runtime).
+func TestGithubAppProvider_NonNumericAppID(t *testing.T) {
+	_, pemBytes := testRSAKey(t)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("provider must not reach the network when appId is non-numeric")
+	}))
+	t.Cleanup(srv.Close)
+
+	withCredentialsHandler(t, &stubSecretKeyHandler{pemBytes: pemBytes})
+	provider := &githubAppProvider{
+		target: config.BrokerTargetConfig{GithubApp: &config.GithubAppTargetConfig{
+			AppID:          "not-a-number",
+			InstallationID: "42",
+			PrivateKeyRef:  &config.GithubAppSecretKeyRef{Name: "pem"},
+			BaseURL:        srv.URL, // https://
+		}},
+		cache:      tokencache.New(),
+		defaultNS:  "muster-system",
+		httpClient: srv.Client(),
+	}
+
+	_, err := provider.Mint(t.Context(), MintRequest{Target: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "numeric")
 }

--- a/internal/oauth/token_exchange.go
+++ b/internal/oauth/token_exchange.go
@@ -15,6 +15,7 @@ import (
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 
 	"github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/providers/tokencache"
 )
 
 // TokenExchanger performs RFC 8693 OAuth 2.0 Token Exchange for cross-cluster SSO.
@@ -31,7 +32,7 @@ import (
 // Thread-safe: Yes, the underlying TokenExchangeClient is thread-safe.
 type TokenExchanger struct {
 	client *oidc.TokenExchangeClient
-	cache  *oidc.TokenExchangeCache
+	cache  *tokencache.Cache
 	logger *slog.Logger
 
 	// allowPrivateIP allows token endpoints on private IP addresses.
@@ -77,9 +78,9 @@ func NewTokenExchangerWithOptions(opts TokenExchangerOptions) *TokenExchanger {
 
 	maxEntries := opts.CacheMaxEntries
 	if maxEntries <= 0 {
-		maxEntries = oidc.DefaultCacheMaxEntries
+		maxEntries = tokencache.DefaultMaxEntries
 	}
-	cache := oidc.NewTokenExchangeCacheWithMaxEntries(maxEntries)
+	cache := tokencache.NewWithMaxEntries(maxEntries)
 
 	if opts.AllowPrivateIP {
 		logging.Warn("TokenExchange", "Token exchanger created with AllowPrivateIP=true, SSRF protection is reduced")
@@ -199,7 +200,7 @@ func (e *TokenExchanger) Exchange(ctx context.Context, req *ExchangeRequest) (*E
 	tokenType, scopes := getExchangeDefaults(req)
 
 	// Check cache first
-	cacheKey := oidc.GenerateCacheKey(req.Config.DexTokenEndpoint, req.Config.ConnectorID, req.UserID)
+	cacheKey := tokencache.GenerateCacheKey(req.Config.DexTokenEndpoint, req.Config.ConnectorID, req.UserID)
 	if cached := e.cache.Get(cacheKey); cached != nil {
 		logging.Debug("TokenExchange", "Cache hit for user=%s endpoint=%s",
 			logging.TruncateIdentifier(req.UserID), req.Config.DexTokenEndpoint)
@@ -280,7 +281,7 @@ func (e *TokenExchanger) Exchange(ctx context.Context, req *ExchangeRequest) (*E
 // ClearCache removes a cached token for the given parameters.
 // This is useful when a cached token is rejected by the remote server.
 func (e *TokenExchanger) ClearCache(tokenEndpoint, connectorID, userID string) {
-	cacheKey := oidc.GenerateCacheKey(tokenEndpoint, connectorID, userID)
+	cacheKey := tokencache.GenerateCacheKey(tokenEndpoint, connectorID, userID)
 	e.cache.Delete(cacheKey)
 	logging.Debug("TokenExchange", "Cleared cache for user=%s endpoint=%s",
 		logging.TruncateIdentifier(userID), tokenEndpoint)
@@ -293,7 +294,7 @@ func (e *TokenExchanger) ClearAllCache() {
 }
 
 // GetCacheStats returns statistics about the token exchange cache.
-func (e *TokenExchanger) GetCacheStats() oidc.TokenExchangeCacheStats {
+func (e *TokenExchanger) GetCacheStats() tokencache.Stats {
 	return e.cache.GetStats()
 }
 

--- a/internal/server/new_oauth_server_config_test.go
+++ b/internal/server/new_oauth_server_config_test.go
@@ -165,7 +165,14 @@ func TestNewOAuthServerConfig_WorkloadAudiences(t *testing.T) {
 
 			require.Equal(t, tc.wantEnableWorkload, got.EnableWorkloadTokenExchange)
 			if tc.wantWorkloadAudienceSubject != "" {
-				require.Equal(t, tc.wantWorkloadAudienceAuds, got.WorkloadAudiences[tc.wantWorkloadAudienceSubject])
+				var found []string
+				for _, g := range got.WorkloadAudiences {
+					if g.Subject == tc.wantWorkloadAudienceSubject {
+						found = g.Audiences
+						break
+					}
+				}
+				require.Equal(t, tc.wantWorkloadAudienceAuds, found)
 			}
 		})
 	}

--- a/internal/server/new_oauth_server_config_test.go
+++ b/internal/server/new_oauth_server_config_test.go
@@ -119,6 +119,58 @@ func TestNewOAuthServerConfig_AllowedOriginsSplitAndTrimmed(t *testing.T) {
 	}
 }
 
+func TestNewOAuthServerConfig_WorkloadAudiences(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                        string
+		workloadAudiences           map[string][]string
+		wantEnableWorkload          bool
+		wantWorkloadAudienceSubject string
+		wantWorkloadAudienceAuds    []string
+	}{
+		{
+			name:               "nil workloadAudiences disables workload exchange",
+			workloadAudiences:  nil,
+			wantEnableWorkload: false,
+		},
+		{
+			name:               "empty workloadAudiences disables workload exchange",
+			workloadAudiences:  map[string][]string{},
+			wantEnableWorkload: false,
+		},
+		{
+			name: "non-empty workloadAudiences enables workload exchange",
+			workloadAudiences: map[string][]string{
+				"system:serviceaccount:agent-ns:kagent": {"cluster-a"},
+			},
+			wantEnableWorkload:          true,
+			wantWorkloadAudienceSubject: "system:serviceaccount:agent-ns:kagent",
+			wantWorkloadAudienceAuds:    []string{"cluster-a"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.OAuthServerConfig{
+				BaseURL: "https://muster.example.com",
+				TokenExchangeBroker: config.TokenExchangeBrokerConfig{
+					WorkloadAudiences: tc.workloadAudiences,
+				},
+			}
+
+			got := newOAuthServerConfig(cfg, time.Hour)
+
+			require.Equal(t, tc.wantEnableWorkload, got.EnableWorkloadTokenExchange)
+			if tc.wantWorkloadAudienceSubject != "" {
+				require.Equal(t, tc.wantWorkloadAudienceAuds, got.WorkloadAudiences[tc.wantWorkloadAudienceSubject])
+			}
+		})
+	}
+}
+
 func TestNewOAuthServerConfig_AllowPrivateIPJWKSMirrorsDexFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -52,7 +52,7 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		// Only consulted when an Exchanger is registered (see
 		// buildOAuthServerOptions); a miss returns invalid_target.
 		TokenExchangeClientAudiences: cfg.TokenExchangeBroker.ClientAudiences,
-		WorkloadAudiences:            cfg.TokenExchangeBroker.WorkloadAudiences,
+		WorkloadAudiences:            workloadGrantsFromConfig(cfg.TokenExchangeBroker.WorkloadAudiences),
 		EnableWorkloadTokenExchange:  len(cfg.TokenExchangeBroker.WorkloadAudiences) > 0,
 	}
 	if cfg.AllowedOrigins != "" {
@@ -183,6 +183,21 @@ func newDPoPReplayCache(storageCfg config.OAuthStorageConfig) (oauthserver.DPoPR
 }
 
 // logEnabledOAuthOptions emits operator-facing Info lines confirming which
+// workloadGrantsFromConfig converts the muster config map (subject → audiences)
+// to the mcp-oauth WorkloadGrant slice. An empty Issuer field on each grant
+// means any trusted issuer matches (the most permissive setting compatible with
+// the previous map-based config schema).
+func workloadGrantsFromConfig(m map[string][]string) []oauthserver.WorkloadGrant {
+	grants := make([]oauthserver.WorkloadGrant, 0, len(m))
+	for subject, audiences := range m {
+		grants = append(grants, oauthserver.WorkloadGrant{
+			Subject:   subject,
+			Audiences: audiences,
+		})
+	}
+	return grants
+}
+
 // security subsystems came up. Call only after the constructor succeeded.
 func logEnabledOAuthOptions(logger *slog.Logger) {
 	logger.Info("Security audit logging enabled")

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -52,14 +52,8 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		// Only consulted when an Exchanger is registered (see
 		// buildOAuthServerOptions); a miss returns invalid_target.
 		TokenExchangeClientAudiences: cfg.TokenExchangeBroker.ClientAudiences,
-		// Workload-authenticated token exchange (no confidential-client credentials).
-		// WorkloadAudiences maps workload subjects to allowed audiences; enforcement
-		// is performed by mcp-oauth's WorkloadExchangeSubjectToken before the
-		// Exchanger is invoked. EnableWorkloadTokenExchange is set whenever
-		// workload audiences are configured so the handler routes credential-less
-		// requests to the workload path instead of rejecting them as invalid_client.
-		WorkloadAudiences:           cfg.TokenExchangeBroker.WorkloadAudiences,
-		EnableWorkloadTokenExchange: len(cfg.TokenExchangeBroker.WorkloadAudiences) > 0,
+		WorkloadAudiences:            cfg.TokenExchangeBroker.WorkloadAudiences,
+		EnableWorkloadTokenExchange:  len(cfg.TokenExchangeBroker.WorkloadAudiences) > 0,
 	}
 	if cfg.AllowedOrigins != "" {
 		result.CORS.AllowedOrigins = strings.Split(cfg.AllowedOrigins, ",")

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -58,7 +58,7 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		// Exchanger is invoked. EnableWorkloadTokenExchange is set whenever
 		// workload audiences are configured so the handler routes credential-less
 		// requests to the workload path instead of rejecting them as invalid_client.
-		WorkloadAudiences:          cfg.TokenExchangeBroker.WorkloadAudiences,
+		WorkloadAudiences:           cfg.TokenExchangeBroker.WorkloadAudiences,
 		EnableWorkloadTokenExchange: len(cfg.TokenExchangeBroker.WorkloadAudiences) > 0,
 	}
 	if cfg.AllowedOrigins != "" {

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -182,11 +182,12 @@ func newDPoPReplayCache(storageCfg config.OAuthStorageConfig) (oauthserver.DPoPR
 	return oauthserver.NewMemoryDPoPReplayCache(), nil, nil
 }
 
-// logEnabledOAuthOptions emits operator-facing Info lines confirming which
 // workloadGrantsFromConfig converts the muster config map (subject → audiences)
 // to the mcp-oauth WorkloadGrant slice. An empty Issuer field on each grant
-// means any trusted issuer matches (the most permissive setting compatible with
-// the previous map-based config schema).
+// means any trusted issuer matches. In single-issuer deployments this is safe;
+// with multiple TrustedIssuers a workload SA token from any of them satisfies
+// any grant. Add an optional issuer field to WorkloadAudiences config entries
+// and propagate it here before deploying with more than one trusted issuer.
 func workloadGrantsFromConfig(m map[string][]string) []oauthserver.WorkloadGrant {
 	grants := make([]oauthserver.WorkloadGrant, 0, len(m))
 	for subject, audiences := range m {

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -52,6 +52,14 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		// Only consulted when an Exchanger is registered (see
 		// buildOAuthServerOptions); a miss returns invalid_target.
 		TokenExchangeClientAudiences: cfg.TokenExchangeBroker.ClientAudiences,
+		// Workload-authenticated token exchange (no confidential-client credentials).
+		// WorkloadAudiences maps workload subjects to allowed audiences; enforcement
+		// is performed by mcp-oauth's WorkloadExchangeSubjectToken before the
+		// Exchanger is invoked. EnableWorkloadTokenExchange is set whenever
+		// workload audiences are configured so the handler routes credential-less
+		// requests to the workload path instead of rejecting them as invalid_client.
+		WorkloadAudiences:          cfg.TokenExchangeBroker.WorkloadAudiences,
+		EnableWorkloadTokenExchange: len(cfg.TokenExchangeBroker.WorkloadAudiences) > 0,
 	}
 	if cfg.AllowedOrigins != "" {
 		result.CORS.AllowedOrigins = strings.Split(cfg.AllowedOrigins, ",")
@@ -113,7 +121,8 @@ func buildOAuthServerOptions(cfg config.OAuthServerConfig, logger *slog.Logger) 
 		}
 		brokerLogger.Info("Brokered RFC 8693 token exchange enabled",
 			"targets", len(cfg.TokenExchangeBroker.Targets),
-			"brokerClients", len(cfg.TokenExchangeBroker.ClientAudiences))
+			"brokerClients", len(cfg.TokenExchangeBroker.ClientAudiences),
+			"workloadSubjects", len(cfg.TokenExchangeBroker.WorkloadAudiences))
 	}
 
 	if len(cfg.TrustedProxyCIDRs) > 0 {


### PR DESCRIPTION
## What

Adds `type: github-app` as a new credential provider for `oauth.server.tokenExchangeBroker.targets`. External confidential clients (or workloads via `workloadAudiences`) can request an audience backed by a GitHub App and receive a short-lived installation token.

Also ships the `CredentialProvider` registry seam and workload-audience plumbing that this builds on (P2.1+P2.2).

## How

**Minting flow** (`internal/oauth/github_app_provider.go`):
1. Check cache — return hit as `MintResult{FromCache:true}` if valid.
2. Fetch RSA PEM from a Kubernetes Secret via `SecretCredentialsHandler.LoadSecretKey`.
3. Build an RS256 App JWT (go-jose/v4): `iss=AppID`, `iat=now-60s` (clock skew), `exp=iat+9min`.
4. Resolve installation ID: use `cfg.InstallationID` directly, or `GET /repos/{owner}/{repo}/installation`.
5. `POST /app/installations/{id}/access_tokens` with optional `repositories`/`permissions` scope restriction.
6. Cache the result keyed on `(installationID, sha256(repositories+permissions))` using a dedicated `oidc.TokenExchangeCache` instance.

Subject token and subject identity are **not** forwarded to GitHub — installation tokens are app-scoped. Authorization is enforced upstream by mcp-oauth before `Mint` is called.

**Config path**: `oauth.server.tokenExchangeBroker.targets[].githubApp` — `appId`, `installationId` or `owner`+`repo`, `privateKeyRef` (RSA PEM in a Kubernetes Secret; key defaults to `private-key`), optional `repositories`, `permissions`, `baseUrl`.

**`SecretCredentialsHandler`** gains `LoadSecretKey(ctx, ref, key, defaultNS) ([]byte, error)` — generic key retrieval from Kubernetes Secrets without logging the value. Implemented on `CredentialsAdapter`; all existing test doubles updated.

**`BrokerTargetType`** is a typed enum (`type BrokerTargetType string`) with `TargetTypeOIDCExchange` and `TargetTypeGithubApp` constants.

**`providerDeps` struct** threads long-lived dependencies (github cache, HTTP client) through the factory so caches survive per-request provider reconstruction.

## Helm

- `values.schema.json`: removes the hard `required:[dexTokenEndpoint,connectorId]` constraint that would reject non-oidc targets; adds `type` enum, `githubApp` object, `workloadAudiences`, and `defaultSecretNamespace` to the broker schema.
- `values.yaml`: comment block extended with `github-app` and `workloadAudiences` examples.
- New configmap test: `github-app` typed target flows through `toYaml` into `config.yaml`.

## Tests

8 table-driven tests in `internal/oauth/github_app_provider_test.go` using `httptest.NewServer`:

| Test | Asserts |
|---|---|
| `AppJWTClaims` | `iss==AppID`, `iat` backdated, `exp-iat ≤ 10min` |
| `RequestBody` | `repositories` and `permissions` forwarded in POST body |
| `EmptyReposPermissions` | nil repos/permissions omitted (`omitempty`) |
| `InstallationDiscovery` | GET `/repos/{owner}/{repo}/installation` path + returned ID used in POST |
| `Cache` | second Mint returns `FromCache:true`, GitHub API called once |
| `NoSecretHandler` | nil handler → "no secret credentials handler registered" |
| `MissingConfig` | nil `githubApp` block → clear error |
| `ProviderRegistry_GithubAppType` | `type: github-app` resolves to provider, not `ErrInvalidTarget` |