### PR TITLE
fix(oauth): request id_token in cross-cluster token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 - `oauth.server.tokenExchangeBroker.targets[].type: local-mint` mints a muster-signed RFC 9068 JWT locally. Requires `enableJWTMode: true`. The issued token carries `sub` = the validated human subject and `act` = the validated agent SA (issuer + subject), signed by muster's own access-token key. Downstream services that trust muster as an issuer receive the full delegation chain without a separate Dex exchange.
 - `oauth.server.tokenExchangeBroker.actorDelegationPolicy`: allowlist of `(actorIssuer, actorSubject, subjectIssuer, subjectSubject)` entries that permit RFC 8693 delegated token exchange. An empty or absent list denies all delegated exchanges (mcp-oauth default). Required when any broker target uses `type: local-mint` and the exchange carries an `actor_token`.
 
+### Fixed
+
+- Cross-cluster RFC 8693 token exchange now requests an `id_token` (was `access_token`). The exchanged token is forwarded as the downstream bearer and must serve as the user's OIDC identity; Dex's default access token is opaque, so `mcp-kubernetes` (strict `--downstream-oauth`) could not use it for Kubernetes OIDC and denied tool calls with `authentication required: please log in to access this resource`, even though the connection reported `Connected [SSO: Exchanged]`. Requesting an `id_token` yields a JWT whose `aud` carries the configured `requiredAudiences`, so `mcp-oauth` accepts it via the forwarded-ID-token (SSO) path — mirroring the token-forwarding behaviour. `mcp-prometheus` and other identity-only downstreams were unaffected and keep working.
+
 ### Changed
 
 - Broker credential minting extracted behind a `CredentialProvider` interface and an `oidc-exchange` provider dispatched through a registry (`internal/oauth`). No behaviour change; the oidc-exchange provider preserves per-(endpoint, connector, user) token caching.

--- a/internal/oauth/token_exchange.go
+++ b/internal/oauth/token_exchange.go
@@ -216,14 +216,28 @@ func (e *TokenExchanger) Exchange(ctx context.Context, req *ExchangeRequest) (*E
 	logging.Debug("TokenExchange", "Exchanging token for user=%s endpoint=%s connector=%s",
 		logging.TruncateIdentifier(req.UserID), req.Config.DexTokenEndpoint, req.Config.ConnectorID)
 
-	// Build the token exchange request with client credentials if available
+	// Build the token exchange request with client credentials if available.
+	//
+	// Request an ID token (not an access token). The exchanged token is forwarded
+	// as the bearer to the downstream MCP server, where it must serve as the
+	// user's OIDC identity:
+	//   - mcp-kubernetes (strict --downstream-oauth) uses it as the Kubernetes
+	//     OIDC ID token to mint a per-user client against the remote apiserver.
+	//   - mcp-oauth only treats a forwarded bearer as an SSO identity when it is
+	//     a JWT whose aud is in the server's TrustedAudiences (the audience scopes
+	//     appended from RequiredAudiences land in the id_token's aud claim).
+	// Dex's default access token is opaque, so requesting access_token yields a
+	// token that downstream servers can validate via /userinfo but cannot use for
+	// OIDC — mcp-kubernetes then denies with "authentication required". Requesting
+	// an id_token mirrors the token-forwarding path, which forwards the user's
+	// ID token directly.
 	exchangeReq := oidc.TokenExchangeRequest{
 		TokenEndpoint:      req.Config.DexTokenEndpoint,
 		SubjectToken:       req.SubjectToken,
 		SubjectTokenType:   tokenType,
 		ConnectorID:        req.Config.ConnectorID,
 		Scope:              scopes,
-		RequestedTokenType: oidc.TokenTypeAccessToken,
+		RequestedTokenType: oidc.TokenTypeIDToken,
 		ClientID:           req.Config.ClientID,
 		ClientSecret:       req.Config.ClientSecret,
 	}


### PR DESCRIPTION
## Summary

Cross-cluster RFC 8693 token exchange (`EstablishConnectionWithTokenExchange`) requested an **access token** and forwarded it as the downstream bearer. Dex's default access token is **opaque**, so it cannot serve as the user's OIDC identity downstream:

- `mcp-oauth` only treats a forwarded bearer as an SSO identity when it is a **JWT** whose `aud` is in the server's `TrustedAudiences` (the forwarded-ID-token path). An opaque token never qualifies → it falls through to the opaque `/userinfo` path with `TokenSource=OAuth`, **not** SSO.
- `mcp-kubernetes` in strict `--downstream-oauth` mode needs an **ID token** in context to mint a per-user client against the remote apiserver. With no ID token it fails closed:

  ```
  WARN Failed to retrieve token metadata: token metadata not found
  WARN No ID token in context, denying access (strict mode enabled)
  tool_failed cluster_health ... error="authentication required: please log in to access this resource"
  ```

  This happened on **every** remote (token-exchange) cluster even though `auth status` reported `Connected [SSO: Exchanged]`.

`mcp-prometheus` (and other identity-only downstreams) only need an authenticated identity, so the opaque access token worked there — which is why the failure looked Kubernetes-specific.

## Fix

Request an **`id_token`** from the exchange. Dex returns a JWT whose `aud` carries the `requiredAudiences` muster already appends as cross-client audience scopes, so `mcp-oauth` accepts it via the forwarded-ID-token (SSO) path and `mcp-kubernetes` uses it for downstream Kubernetes OIDC. This mirrors the token-**forwarding** path, which already forwards the user's ID token directly. Identity-only downstreams keep working (and stop logging the spurious `token metadata not found` warning).

One-line behaviour change in `internal/oauth/token_exchange.go` (`RequestedTokenType: access_token → id_token`), plus an explanatory comment and CHANGELOG entry.

## Root cause evidence

Reproduced as a human user via the `muster` CLI against a live deployment:

| Call | Before |
|---|---|
| `x_kubernetes_*` on remote MCs (token exchange) | ❌ `authentication required: please log in` |
| `x_kubernetes_*` on local MC (token forwarding) | ✅ authenticated |
| `x_prometheus_check_ready` on remote MC (token exchange) | ✅ ok |

## Test plan

- [x] `go build ./internal/oauth/...`
- [x] `go test ./internal/oauth/`
- [x] pre-commit (golangci-lint, go fmt, imports) green
- [ ] Deploy and confirm `mcp-kubernetes` tool calls via the AI chat / `muster` CLI succeed against a remote (token-exchange) cluster

Made with [Cursor](https://cursor.com)