### PR TITLE
fix(metatools): lower discovery default filter limit to 5

### DIFF
--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -135,9 +135,12 @@ func (p *Provider) handleDescribeTool(ctx context.Context, args map[string]inter
 }
 
 // defaultFilterLimit caps how many tools the discovery tier returns per
-// filter_tools call when the caller does not specify a limit. It keeps a broad
-// lookup against a large fleet bounded instead of dumping the whole catalogue.
-const defaultFilterLimit = 25
+// filter_tools call when the caller does not specify a limit. Discovery is a
+// "find the right tool" step, not a listing: a small ranked top-K is enough for
+// a caller (typically an LLM) to pick from, and a small default keeps the page
+// — which then rides in the model's context for every following step — cheap.
+// Callers that want more can page explicitly with limit/offset.
+const defaultFilterLimit = 5
 
 // summaryMaxLen caps the length (in runes) of the one-line summary the
 // discovery tier emits in place of a tool's full description.

--- a/internal/metatools/provider.go
+++ b/internal/metatools/provider.go
@@ -117,7 +117,7 @@ func (p *Provider) GetTools() []api.ToolMetadata {
 					Name:        "limit",
 					Type:        api.ArgTypeNumber,
 					Required:    false,
-					Description: "Maximum number of tools to return in this page (default: 25)",
+					Description: "Maximum number of tools to return in this page (default: 5). Increase to page through more matches.",
 					Default:     defaultFilterLimit,
 				},
 				{


### PR DESCRIPTION
## Summary

- Lower `defaultFilterLimit` for the `filter_tools` discovery tier from **25 to 5**.
- Discovery is a "find the right tool" step, not a full listing. A small ranked top-K is enough for a caller (typically an LLM) to pick from, and a small default keeps the returned page cheap — crucially, that page rides in the model's context on **every subsequent step**, so an oversized default is paid for many times over, not once.
- Callers that want more can page explicitly with `limit`/`offset`; `total` + `truncated` already signal when more matches exist.

## Motivation

Follow-up to the discovery tier (#868, #872). While tuning the devportal AI-chat system prompt against the live fleet, a ranked `filter_tools(query=…)` discovery page measured ~4k extra tokens per chat query at the default of 25 vs an explicit `limit=5` — purely from the larger page being re-sent in context across the multi-step tool loop. The cheap value belongs in the server default, not as a `limit=5` workaround hard-coded into every client prompt. With this change the prompt can simply call `filter_tools(query=…)` and get the cheap ranked top-K by default.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/metatools/...` (the limit/offset + truncation test keys off the `defaultFilterLimit` constant, so it now asserts a 5-tool page and `truncated: true` against the 280-tool fixture)

Made with [Cursor](https://cursor.com)