### PR TITLE
feat(oauth): declaratively seed confidential broker clients at startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.9.3
+	github.com/giantswarm/mcp-oauth v0.11.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.9.3 h1:muG2x9JFeaqXB8eez+tOFA+LQ2DdeJc+xjuWfpIb7PQ=
-github.com/giantswarm/mcp-oauth v0.9.3/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.11.0 h1:2VRg/Clz+pd8HrsABTZPgSD+eaKLrKhKP2OIKFA6KCo=
+github.com/giantswarm/mcp-oauth v0.11.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/helm/muster/tests/configmap_test.yaml
+++ b/helm/muster/tests/configmap_test.yaml
@@ -152,6 +152,29 @@ tests:
           path: data["config.yaml"]
           pattern: "workloadAudiences:"
 
+  - it: renders brokerClients seeding config into config.yaml
+    set:
+      muster.oauth.server.enabled: true
+      muster.oauth.server.baseUrl: "https://muster.example.com"
+      muster.oauth.server.existingSecret: "muster-oauth"
+      muster.oauth.server.dex.issuerUrl: "https://dex.example.com"
+      muster.oauth.server.dex.clientId: "muster"
+      muster.oauth.server.tokenExchangeBroker:
+        clientAudiences:
+          portal-backend:
+            - cluster-a
+        brokerClients:
+          portal-backend:
+            clientCredentialsSecretRef:
+              name: muster-broker-clients
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "brokerClients:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "muster-broker-clients"
+
   - it: renders local-mint typed broker target and actorDelegationPolicy into config.yaml
     set:
       muster.oauth.server.enabled: true

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -583,6 +583,27 @@
                   "additionalProperties": {"type": "array", "items": {"type": "string"}},
                   "description": "Per-client audience allowlist: broker client ID → audiences it may request. Requests outside the list get invalid_target."
                 },
+                "brokerClients": {
+                  "type": "object",
+                  "description": "Declaratively seed confidential broker clients at startup, keyed by client ID. mcp-oauth stores a broker client's record (id → bcrypt secret hash) only in its backing store (Valkey); a store wipe leaves the client record gone, so every exchange returns invalid_client. Seeding re-creates the record from the same id+secret on every startup so a wipe self-heals. The id+secret must match those the broker client (e.g. Backstage) presents.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "clientCredentialsSecretRef": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                          "name": {"type": "string"},
+                          "namespace": {"type": "string", "description": "Defaults to the muster namespace."},
+                          "clientIdKey": {"type": "string", "description": "Defaults to client-id."},
+                          "clientSecretKey": {"type": "string", "description": "Defaults to client-secret."}
+                        },
+                        "description": "Kubernetes Secret holding the broker client's id and secret. The same secret the broker client authenticates with. The config map key is authoritative for the client id."
+                      },
+                      "scopes": {"type": "array", "items": {"type": "string"}, "description": "Optional scopes recorded on the seeded client record. Audiences are gated by clientAudiences, not by these scopes."}
+                    }
+                  }
+                },
                 "targets": {
                   "type": "object",
                   "description": "Audience name → credential provider target. Set type to select the provider (default: oidc-exchange).",

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -553,6 +553,17 @@ muster:
       # workload-authenticated exchange (no confidential-client credentials):
       #   workloadAudiences:
       #     "system:serviceaccount:ai-platform:*": ["github-infra", "cluster-a"]
+      #
+      # brokerClients: declaratively (re)seed confidential broker clients at
+      # startup from Kubernetes Secrets. mcp-oauth stores the client record
+      # (id -> bcrypt secret hash) only in Valkey; a store wipe leaves the
+      # client record gone and every exchange returns invalid_client. Seeding
+      # re-creates it from the same id+secret on every startup so a wipe
+      # self-heals. The id+secret must match what the broker client presents.
+      #   brokerClients:
+      #     portal-backend:
+      #       clientCredentialsSecretRef:
+      #         name: muster-broker-clients   # keys default to client-id/client-secret
       tokenExchangeBroker: {}
 
       # CIDRs from which X-Forwarded-Proto and X-Forwarded-Host headers are

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -365,6 +365,16 @@ type TokenExchangeBrokerConfig struct {
 	// Config.TokenExchangeClientAudiences.
 	ClientAudiences map[string][]string `yaml:"clientAudiences,omitempty"`
 
+	// BrokerClients declaratively seeds confidential broker clients at startup
+	// from mounted Kubernetes Secrets, keyed by client ID. mcp-oauth stores a
+	// broker client's record (id -> bcrypt secret hash) only in its backing
+	// store (Valkey); a store wipe leaves the audience allowlist in config and
+	// the credentials in the holder's secret, but the client record gone, so
+	// every exchange returns invalid_client. Seeding re-creates the record from
+	// the same id+secret on every startup, so a wipe self-heals. The id+secret
+	// must match those the broker client (e.g. Backstage) presents.
+	BrokerClients map[string]BrokerClientConfig `yaml:"brokerClients,omitempty"`
+
 	// Targets maps an RFC 8693 audience name (e.g. a management cluster name)
 	// to the downstream credential provider target.
 	Targets map[string]BrokerTargetConfig `yaml:"targets,omitempty"`
@@ -503,6 +513,23 @@ type GithubAppSecretKeyRef struct {
 	Namespace string `yaml:"namespace,omitempty"`
 	// Key is the data key within the Secret. Defaults to "private-key".
 	Key string `yaml:"key,omitempty"`
+}
+
+// BrokerClientConfig declaratively seeds one confidential broker client. The
+// map key is the client ID; the secret is resolved from the referenced
+// Kubernetes Secret at startup and the client record is idempotently ensured
+// in mcp-oauth's store.
+type BrokerClientConfig struct {
+	// ClientCredentialsSecretRef references the Kubernetes Secret holding the
+	// broker client's id and secret. The same secret the broker client (e.g.
+	// Backstage) authenticates with. The ClientID resolved from the secret must
+	// match the map key; the map key wins if they differ.
+	ClientCredentialsSecretRef *BrokerSecretRefConfig `yaml:"clientCredentialsSecretRef,omitempty"`
+
+	// Scopes optionally records the scopes granted to the seeded client. The
+	// audiences a client may request are gated by ClientAudiences, not by these
+	// scopes; this is informational on the client record.
+	Scopes []string `yaml:"scopes,omitempty"`
 }
 
 // BrokerSecretRefConfig references a Kubernetes Secret with OAuth client

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -775,6 +775,10 @@ func createOAuthServer(cfg config.OAuthServerConfig, opts []oauth.ServerOption) 
 
 	logEnabledOAuthOptions(logger)
 
+	// Declaratively (re)seed confidential broker clients from mounted secrets so
+	// that a wiped client store self-heals. Best-effort; never fails startup.
+	seedBrokerClients(context.Background(), oauthSrv, cfg.TokenExchangeBroker, logger)
+
 	return oauthSrv, combinedStore, dpopClient, nil
 }
 

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"github.com/giantswarm/mcp-oauth/storage/valkey"
 	valkeygo "github.com/valkey-io/valkey-go"
 
+	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/config"
 	musteroauth "github.com/giantswarm/muster/internal/oauth"
 )
@@ -134,6 +136,68 @@ func buildOAuthServerOptions(cfg config.OAuthServerConfig, logger *slog.Logger, 
 	}
 
 	return opts, nil
+}
+
+// seedBrokerClients ensures each configured confidential broker client exists
+// in the OAuth server's store, recreating its record from the same id+secret on
+// every startup. mcp-oauth stores a broker client's record (id -> bcrypt secret
+// hash) only in its backing store (Valkey); a store wipe leaves the audience
+// allowlist in config and the credentials in the holder's secret, but the
+// client record gone, so every exchange returns invalid_client. Seeding makes a
+// wipe self-heal.
+//
+// Best-effort: a missing secret handler (non-Kubernetes mode) or an unresolvable
+// secret is logged and skipped rather than failing startup -- the broker would
+// surface the missing client later, and crashing muster over a transient secret
+// read helps no one.
+func seedBrokerClients(ctx context.Context, srv *oauth.Server, broker config.TokenExchangeBrokerConfig, logger *slog.Logger) {
+	if len(broker.BrokerClients) == 0 {
+		return
+	}
+
+	handler := api.GetSecretCredentialsHandler()
+	if handler == nil {
+		logger.Warn("Cannot seed broker clients: no secret credentials handler registered (requires Kubernetes mode)",
+			"brokerClients", len(broker.BrokerClients))
+		return
+	}
+
+	for clientID, bc := range broker.BrokerClients {
+		if bc.ClientCredentialsSecretRef == nil {
+			logger.Warn("Skipping broker client seed: no clientCredentialsSecretRef", "client_id", clientID)
+			continue
+		}
+		ref := bc.ClientCredentialsSecretRef
+		creds, err := handler.LoadClientCredentials(ctx, &api.ClientCredentialsSecretRef{
+			Name:            ref.Name,
+			Namespace:       ref.Namespace,
+			ClientIDKey:     ref.ClientIDKey,
+			ClientSecretKey: ref.ClientSecretKey,
+		}, broker.DefaultSecretNamespace)
+		if err != nil {
+			logger.Warn("Failed to load broker client credentials; skipping seed",
+				"client_id", clientID, "secret", ref.Name, "error", err)
+			continue
+		}
+
+		// The config map key is authoritative for the client id; warn if the
+		// secret carries a different one so a misconfiguration is visible.
+		if creds.ClientID != "" && creds.ClientID != clientID {
+			logger.Warn("Broker client id in secret differs from config key; using config key",
+				"config_client_id", clientID, "secret_client_id", creds.ClientID)
+		}
+
+		seeded, err := srv.EnsureConfidentialClient(ctx, clientID, creds.ClientSecret, bc.Scopes)
+		if err != nil {
+			logger.Warn("Failed to seed broker client", "client_id", clientID, "error", err)
+			continue
+		}
+		if seeded {
+			logger.Info("Seeded confidential broker client", "client_id", clientID)
+		} else {
+			logger.Debug("Broker client already present; no seeding needed", "client_id", clientID)
+		}
+	}
 }
 
 func toTrustedIssuer(iss config.TrustedIssuerConfig) oauthserver.TrustedIssuer {

--- a/internal/server/seed_broker_clients_test.go
+++ b/internal/server/seed_broker_clients_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	oauth "github.com/giantswarm/mcp-oauth"
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+)
+
+type stubSecretHandler struct {
+	creds *api.ClientCredentials
+	err   error
+}
+
+func (s *stubSecretHandler) LoadClientCredentials(_ context.Context, _ *api.ClientCredentialsSecretRef, _ string) (*api.ClientCredentials, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.creds, nil
+}
+
+func (s *stubSecretHandler) LoadSecretKey(_ context.Context, _ *api.ClientCredentialsSecretRef, _ string, _ string) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func newTestOAuthServer(t *testing.T) *oauth.Server {
+	t.Helper()
+	store := memory.New()
+	srv, err := oauth.NewServerWithCombined(mock.NewProvider(), store, &oauth.ServerConfig{
+		Issuer:            "https://muster.example.com",
+		AllowInsecureHTTP: false,
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("NewServerWithCombined: %v", err)
+	}
+	return srv
+}
+
+func TestSeedBrokerClients(t *testing.T) {
+	ctx := context.Background()
+	const (
+		clientID = "broker-client-id"
+		secret   = "broker-client-secret"
+	)
+
+	t.Run("seeds client from secret", func(t *testing.T) {
+		srv := newTestOAuthServer(t)
+		prev := api.GetSecretCredentialsHandler()
+		api.RegisterSecretCredentialsHandler(&stubSecretHandler{
+			creds: &api.ClientCredentials{ClientID: clientID, ClientSecret: secret},
+		})
+		t.Cleanup(func() { api.RegisterSecretCredentialsHandler(prev) })
+
+		broker := config.TokenExchangeBrokerConfig{
+			DefaultSecretNamespace: "agentic-platform",
+			BrokerClients: map[string]config.BrokerClientConfig{
+				clientID: {ClientCredentialsSecretRef: &config.BrokerSecretRefConfig{Name: "muster-broker-clients"}},
+			},
+		}
+
+		seedBrokerClients(ctx, srv, broker, slog.Default())
+
+		if err := srv.ValidateClientCredentials(ctx, clientID, secret); err != nil {
+			t.Errorf("seeded client should validate: %v", err)
+		}
+	})
+
+	t.Run("no handler is a no-op", func(t *testing.T) {
+		srv := newTestOAuthServer(t)
+		prev := api.GetSecretCredentialsHandler()
+		api.RegisterSecretCredentialsHandler(nil)
+		t.Cleanup(func() { api.RegisterSecretCredentialsHandler(prev) })
+
+		broker := config.TokenExchangeBrokerConfig{
+			BrokerClients: map[string]config.BrokerClientConfig{
+				clientID: {ClientCredentialsSecretRef: &config.BrokerSecretRefConfig{Name: "x"}},
+			},
+		}
+		// Must not panic and must not seed.
+		seedBrokerClients(ctx, srv, broker, slog.Default())
+		if _, err := srv.GetClient(ctx, clientID); err == nil {
+			t.Error("expected no client to be seeded without a handler")
+		}
+	})
+
+	t.Run("empty config is a no-op", func(t *testing.T) {
+		srv := newTestOAuthServer(t)
+		seedBrokerClients(ctx, srv, config.TokenExchangeBrokerConfig{}, slog.Default())
+	})
+}


### PR DESCRIPTION
## Summary

mcp-oauth stores a confidential broker client's record (id to bcrypt secret hash) only in its backing store (Valkey). A store wipe leaves the audience allowlist in config and the credentials in the holder's secret, but the client record gone, so every token exchange returns `invalid_client` (observed as a fleet-wide "sign in again" in the devportal).

This adds `tokenExchangeBroker.brokerClients`: a map of client id to `clientCredentialsSecretRef`. At OAuth server startup, muster resolves each referenced Kubernetes Secret (via the existing secret-credentials handler) and calls the new mcp-oauth `Server.EnsureConfidentialClient` to idempotently (re)create the client record from the same id+secret. A Valkey wipe now self-heals on the next muster start.

- Best-effort: a missing secret handler (non-Kubernetes mode) or unresolvable secret is logged and skipped, never failing startup.
- Bumps `github.com/giantswarm/mcp-oauth` `v0.9.3` to `v0.11.0` for the new `EnsureConfidentialClient` API.
- Helm: `brokerClients` renders through the existing `tokenExchangeBroker` passthrough; adds values docs, `values.schema.json`, and a chart test. RBAC already grants the secret read (same path as target `clientCredentialsSecretRef`).

## Test plan

- [x] `go build ./...` and `go test ./internal/server/ ./internal/config/ ./internal/oauth/` green against `mcp-oauth v0.11.0`
- [x] New unit test `internal/server/seed_broker_clients_test.go` (seed from secret, no-handler no-op, empty-config no-op)
- [x] `helm unittest helm/muster -f tests/configmap_test.yaml` green (9/9), incl. new brokerClients render test
- [x] golangci-lint (v2.12.2, CI-pinned) clean on changed packages

Made with [Cursor](https://cursor.com)