### PR TITLE
feat(oauth): opt-in delegateToSelf for resource-less OBO exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `oauth.server.tokenExchangeBroker.delegateToSelf` (default false): when enabled, a delegated (on-behalf-of) token exchange that carries an `actor_token` but omits the RFC 8707 `resource` is bound to muster's own `resourceIdentifier`, so an agent STS client that cannot set a resource itself still receives a token muster accepts back and re-mints per backend on the localMint path. Only the delegation path is affected; a resource-less plain exchange still errors. Requires mcp-oauth v0.16.0.
+
 - Chart values now document the `muster-valkey` persistence model as a deliberate cache-only choice (RDB-only is intentional; every critical record is reconstructable at startup), with a per-record-type recovery table, and explain why AOF is not enabled (it does not survive PVC loss, and a config-flip restart is a data-loss footgun). Documentation only; no behaviour change. ([#884](https://github.com/giantswarm/muster/issues/884))
 
 - `workloadGroupGrants[].granted.subject`: when set, replaces the validated workload credential's `sub` in the minted token so the downstream sees a stable agent principal. `workloadGroupGrants[].granted.groups` is the new canonical location for injected groups (previously a top-level `groups` field). Both map to `oauthserver.WorkloadGrant.Granted`; requires mcp-oauth v0.14.0.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.14.1
+	github.com/giantswarm/mcp-oauth v0.16.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.14.1 h1:iYzYPuAI9ugYqpnldMLYRJ4J8QyycU8h2XO64o66CjA=
-github.com/giantswarm/mcp-oauth v0.14.1/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.16.0 h1:pE/ZnzIi4/B5OQZC6Mw2XxKUOQ6up0x0bXYtf1crq5k=
+github.com/giantswarm/mcp-oauth v0.16.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -412,6 +412,14 @@ type TokenExchangeBrokerConfig struct {
 	// plain workload exchanges are unaffected.
 	ActorDelegationPolicy []DelegationGrantConfig `yaml:"actorDelegationPolicy,omitempty"`
 
+	// DelegateToSelf lets a delegated (on-behalf-of) exchange omit the RFC 8707
+	// resource: muster binds the minted token to its own ResourceIdentifier so an
+	// agent STS client that cannot set a resource still receives a token muster
+	// accepts back and re-mints per backend on the localMint path. Only the
+	// delegation path (actor_token present) is affected; a resource-less plain
+	// exchange still errors. Requires ResourceIdentifier. Default false.
+	DelegateToSelf bool `yaml:"delegateToSelf,omitempty"`
+
 	// DefaultSecretNamespace is the namespace used for target credential
 	// secret refs that do not set an explicit namespace. Populated from the
 	// muster namespace by the serve command; not user-facing config.

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -69,6 +69,9 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 	if len(cfg.TokenExchangeBroker.ActorDelegationPolicy) > 0 {
 		result.ActorDelegationPolicy = delegationGrantsFromConfig(cfg.TokenExchangeBroker.ActorDelegationPolicy)
 	}
+	if cfg.TokenExchangeBroker.DelegateToSelf {
+		result.DelegationDefaultResource = cfg.ResourceIdentifier
+	}
 	return result
 }
 

--- a/internal/server/oauth_server_config_test.go
+++ b/internal/server/oauth_server_config_test.go
@@ -35,6 +35,33 @@ func TestNewOAuthServerConfig_EnableJWTMode(t *testing.T) {
 	})
 }
 
+func TestNewOAuthServerConfig_DelegateToSelf(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enabled binds default resource to ResourceIdentifier", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.OAuthServerConfig{
+			BaseURL:            "https://muster.example.com",
+			ResourceIdentifier: "https://muster.example.com/mcp",
+			TokenExchangeBroker: config.TokenExchangeBrokerConfig{
+				DelegateToSelf: true,
+			},
+		}
+		got := newOAuthServerConfig(cfg, time.Hour)
+		require.Equal(t, "https://muster.example.com/mcp", got.DelegationDefaultResource)
+	})
+
+	t.Run("disabled leaves default resource empty", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.OAuthServerConfig{
+			BaseURL:            "https://muster.example.com",
+			ResourceIdentifier: "https://muster.example.com/mcp",
+		}
+		got := newOAuthServerConfig(cfg, time.Hour)
+		require.Empty(t, got.DelegationDefaultResource)
+	})
+}
+
 func TestParseCIDRs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

- Bumps `mcp-oauth` v0.14.1 → v0.16.0 (clean build; no breaking API muster uses).
- Wires the new `server.Config.DelegationDefaultResource` behind an opt-in muster config flag `oauth.server.tokenExchangeBroker.delegateToSelf` (default false). When enabled, `DelegationDefaultResource` is set to muster's `resourceIdentifier`.

## Why

Completes the on-behalf-of (OBO) path for kagent agents on pinned kagent 0.9.9, with **no kagent change**. The agent's STS plugin posts `subject=human + actor=SA` to muster's `/oauth/token` with no RFC 8707 `resource` and currently fails `resource_missing`. With `delegateToSelf`, muster binds the mint to its own `resourceIdentifier` (`.../mcp`), so:

1. muster mints `sub=human, act=SA, aud=.../mcp` (gated by `actorDelegationPolicy`),
2. the agent's `header_provider` sends it as `Authorization`,
3. muster's front door accepts `aud=.../mcp`,
4. localMint re-mints per backend, preserving `act=SA` (via the existing `LocalMintExchanger` actor-chain nesting),
5. mcp-kubernetes impersonates the human.

## Security

- Opt-in (default false) and actor-gated: a resource-less exchange with **no** `actor_token` still errors. Authorization is unchanged — subject/actor validation and `actorDelegationPolicy` still gate the mint; `resource` is targeting, not authorization. Minted audience is muster's own identifier (narrow), not a wildcard.

## Tests

- mcp-oauth: `TestHandleTokenExchangeGrant_DelegationDefaultResource` (allow + two deny gates), shipped in mcp-oauth #478.
- muster: `TestNewOAuthServerConfig_DelegateToSelf` (flag → `DelegationDefaultResource`; off → empty).

Broker-side BDD (muster receiving an agent actor token) needs harness extension — the current OAuth BDD harness exercises muster-as-client; tracked as follow-up. End-to-end is verified live on glean.