### PR TITLE
feat(oauth): map trustedIssuers allowPrivateIPJWKSHosts (host-scoped JWKS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `oauth.server.trustedIssuers[].allowPrivateIPJWKSHosts` (`[]string`): host-scoped alternative to `allowPrivateIPJWKS`. The issuer's `jwksUrl` may resolve to a private IP only when its hostname matches one of these values; all other hosts keep the SSRF guard. Maps to mcp-oauth's `TrustedIssuer.AllowPrivateIPJWKSHosts`. Prefer it over the blanket bool for a known in-cluster JWKS endpoint (e.g. a Dex fronted by an internal LB whose public hostname resolves to a private VIP).
+
 - `oauth.server.tokenExchangeBroker.delegateToSelf` (default false): when enabled, a delegated (on-behalf-of) token exchange that carries an `actor_token` but omits the RFC 8707 `resource` is bound to muster's own `resourceIdentifier`, so an agent STS client that cannot set a resource itself still receives a token muster accepts back and re-mints per backend on the localMint path. Only the delegation path is affected; a resource-less plain exchange still errors. Requires mcp-oauth v0.16.0.
 
 - Chart values now document the `muster-valkey` persistence model as a deliberate cache-only choice (RDB-only is intentional; every critical record is reconstructable at startup), with a per-record-type recovery table, and explain why AOF is not enabled (it does not survive PVC loss, and a config-flip restart is a data-loss footgun). Documentation only; no behaviour change. ([#884](https://github.com/giantswarm/muster/issues/884))

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -622,6 +622,12 @@ type TrustedIssuerConfig struct {
 	// is https://kubernetes.default.svc/openid/v1/jwks. Emits a startup warning
 	// when set (mcp-oauth dev-override flag). Default: false.
 	AllowPrivateIPJWKS bool `yaml:"allowPrivateIPJWKS,omitempty"`
+	// AllowPrivateIPJWKSHosts is the host-scoped alternative to AllowPrivateIPJWKS:
+	// the JwksURL may resolve to a private IP only when its hostname matches one of
+	// these values; all other hosts keep the SSRF guard. Prefer this over the
+	// blanket bool for a known in-cluster endpoint (e.g. a Dex fronted by an
+	// internal LB whose public hostname resolves to a private VIP).
+	AllowPrivateIPJWKSHosts []string `yaml:"allowPrivateIPJWKSHosts,omitempty"`
 	// AcceptedTypHeaders lists the JWT typ header values accepted for Bearer
 	// tokens from this issuer. Empty keeps the RFC 9068 default ("at+jwt").
 	// Kubernetes ServiceAccount tokens carry no typ header; use [""] to

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -205,14 +205,15 @@ func seedBrokerClients(ctx context.Context, srv *oauth.Server, broker config.Tok
 
 func toTrustedIssuer(iss config.TrustedIssuerConfig) oauthserver.TrustedIssuer {
 	return oauthserver.TrustedIssuer{
-		Issuer:             iss.Issuer,
-		JwksURL:            iss.JwksURL,
-		AllowedAudiences:   iss.AllowedAudiences,
-		AllowedScopes:      iss.AllowedScopes,
-		AllowedClaims:      iss.AllowedClaims,
-		SubjectClaim:       iss.SubjectClaim,
-		AllowPrivateIPJWKS: iss.AllowPrivateIPJWKS,
-		AcceptedTypHeaders: iss.AcceptedTypHeaders,
+		Issuer:                  iss.Issuer,
+		JwksURL:                 iss.JwksURL,
+		AllowedAudiences:        iss.AllowedAudiences,
+		AllowedScopes:           iss.AllowedScopes,
+		AllowedClaims:           iss.AllowedClaims,
+		SubjectClaim:            iss.SubjectClaim,
+		AllowPrivateIPJWKS:      iss.AllowPrivateIPJWKS,
+		AllowPrivateIPJWKSHosts: iss.AllowPrivateIPJWKSHosts,
+		AcceptedTypHeaders:      iss.AcceptedTypHeaders,
 	}
 }
 

--- a/internal/server/oauth_server_config_test.go
+++ b/internal/server/oauth_server_config_test.go
@@ -152,14 +152,15 @@ func TestToTrustedIssuer_MapsAllFields(t *testing.T) {
 	t.Parallel()
 
 	in := config.TrustedIssuerConfig{
-		Issuer:             "https://idp.example.com",
-		JwksURL:            "https://idp.example.com/jwks",
-		AllowedAudiences:   []string{"aud1", "aud2"},
-		AllowedScopes:      []string{"read", "write"},
-		AllowedClaims:      map[string]string{"sub": "system:serviceaccount:ns:*"},
-		SubjectClaim:       "email",
-		AllowPrivateIPJWKS: true,
-		AcceptedTypHeaders: []string{""},
+		Issuer:                  "https://idp.example.com",
+		JwksURL:                 "https://idp.example.com/jwks",
+		AllowedAudiences:        []string{"aud1", "aud2"},
+		AllowedScopes:           []string{"read", "write"},
+		AllowedClaims:           map[string]string{"sub": "system:serviceaccount:ns:*"},
+		SubjectClaim:            "email",
+		AllowPrivateIPJWKS:      true,
+		AllowPrivateIPJWKSHosts: []string{"dex.example.com"},
+		AcceptedTypHeaders:      []string{""},
 	}
 	got := toTrustedIssuer(in)
 	require.Equal(t, in.Issuer, got.Issuer)
@@ -169,6 +170,7 @@ func TestToTrustedIssuer_MapsAllFields(t *testing.T) {
 	require.Equal(t, in.AllowedClaims, got.AllowedClaims)
 	require.Equal(t, in.SubjectClaim, got.SubjectClaim)
 	require.True(t, got.AllowPrivateIPJWKS)
+	require.Equal(t, in.AllowPrivateIPJWKSHosts, got.AllowPrivateIPJWKSHosts)
 	require.Equal(t, in.AcceptedTypHeaders, got.AcceptedTypHeaders)
 }
 


### PR DESCRIPTION
Wires mcp-oauth's `server.TrustedIssuer.AllowPrivateIPJWKSHosts` (present since v0.16.0) through muster's `config.TrustedIssuerConfig` and `toTrustedIssuer`.

`oauth.server.trustedIssuers[].allowPrivateIPJWKSHosts` lets a single issuer's `jwksUrl` resolve to a private IP only when its hostname matches the allowlist; all other hosts keep the SSRF/DNS-rebinding guard. Host-scoped is the secure alternative to the blanket `allowPrivateIPJWKS` bool for a known in-cluster JWKS endpoint (e.g. a Dex fronted by an internal LB whose public hostname resolves to a private VIP).

Needed for the OBO human path: muster validates the human Dex subject token by fetching Dex's JWKS, whose public hostname resolves to the cluster's internal Envoy LB VIP.

Test: `TestToTrustedIssuer_MapsAllFields` extended to assert the new field maps through.