### PR TITLE
chore(deps): bump mcp-oauth to v0.18.0 for OBO session assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- On-behalf-of tool calls now reach the backend instead of failing closed. A muster self-issued OBO bearer (`sub=human`, `act=agent`) re-presented at the front door is signature-validated with no token-store entry, so it previously carried no session ID; backend tools that require session auth then rejected it and the connection fell back to the agent ServiceAccount. Bumping mcp-oauth to v0.18.0 makes the `ValidateToken` middleware assign a session to every validated token (`FamilyID` when present, else the deterministic bearer-derived ID), so the existing session lookup resolves the OBO bearer and the per-backend localMint runs as the human. No muster code change.
+
 ### Added
 
 - `oauth.server.trustedIssuers[].allowPrivateIPJWKSHosts` (`[]string`): host-scoped alternative to `allowPrivateIPJWKS`. The issuer's `jwksUrl` may resolve to a private IP only when its hostname matches one of these values; all other hosts keep the SSRF guard. Maps to mcp-oauth's `TrustedIssuer.AllowPrivateIPJWKSHosts`. Prefer it over the blanket bool for a known in-cluster JWKS endpoint (e.g. a Dex fronted by an internal LB whose public hostname resolves to a private VIP).

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v0.17.0
+	github.com/giantswarm/mcp-oauth v0.18.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.17.0 h1:P5O9JmzBJWuqKO9m5yRVRsF+4Vn7rscDhzTDU+dB81w=
-github.com/giantswarm/mcp-oauth v0.17.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.18.0 h1:5RLH993jUpUzPR0pJc7sZ2QR1K0sw2BvDI/72OoUO5o=
+github.com/giantswarm/mcp-oauth v0.18.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=


### PR DESCRIPTION
## What

Bumps `github.com/giantswarm/mcp-oauth` v0.17.0 → v0.18.0.

v0.18.0 ([mcp-oauth#483](https://github.com/giantswarm/mcp-oauth/pull/483)) makes the resource-server `ValidateToken` middleware assign a session ID to **every** validated token — `FamilyID` when the token has a refresh-token family, else the deterministic bearer-derived ID (`SessionIDForBearer`, the same `ext-<hex>` derivation the forwarded-token and workload-exchange paths already use).

## Why

A muster self-issued on-behalf-of bearer (`sub=human`, `act=agent`), minted at the front door and re-presented for a backend call, is signature-validated with no token-store entry — so it carried **no session**. The aggregator's `getSessionIDFromContext` returned empty, the `RequiresSessionAuth` dispatch gate failed closed (`"requires authentication but no session is available"`), and the backend connection fell back to the agent ServiceAccount instead of acting as the human. M2M (SA forwarded token) was unaffected because the trusted-issuer path already produced a session.

With v0.18.0 the OBO bearer now carries a session, so the aggregator's existing lookup resolves it and the per-backend localMint re-binds the OBO token (preserving the `act` chain) as the human.

## Scope

Dependency bump only — no muster code change. The aggregator already reads the session via `oauthhandler.SessionIDFromContext` as the fallback in `getSessionIDFromContext`; v0.18.0 simply populates it for the self-issued case. The M2M session value is unchanged (same derivation, same bearer).

Build green; `internal/aggregator` + `internal/server` suites pass (531).