### PR TITLE
chore: temporary build-tree dirtiness diagnostic

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -20,7 +20,9 @@ workflows:
         # (-race, integration suites, govulncheck, helm-unittest, CRD-freshness)
         # override their own `make test`. See devctl makefile gen and the
         # make-target-ci-interface ADR.
-        test_target: test
+        # TEMPORARY: test-diag wraps `test` to print git status AFTER go test, to
+        # locate the +dirty culprit. Revert to `test` once identified.
+        test_target: test-diag
         # Cross-platform binaries attached to the GitHub Release by the
         # upload-release-assets job below (cli flavour). yamllint disables the
         # line-length rule for the 132-char matrix value.

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -16,16 +16,20 @@ helm-lint: ## Run Helm linter
 # Makefile.gen.go.mk; these prerequisites run before it (CRD freshness, then the
 # integration suite) and only add prerequisites -- they do not override the
 # generated recipe.
-test: verify-crds muster-integration-test vcs-dirty-diagnostic
+test: verify-crds muster-integration-test
 
 # TEMPORARY DIAGNOSTIC -- remove once the +dirty culprit is found.
 # Release binaries embed `vX.Y.Z+dirty` because Go's build-info VCS stamp records
 # `vcs.modified=true` at link time, i.e. `git status` is non-empty when architect's
-# go-build links the binaries. The known scratch files (.ldflags/.platforms/binaries)
-# are already gitignored and a local repro is clean, so something the CI job writes
-# is still escaping. This target prints exactly what Go's buildvcs reads, as the last
-# `test` prerequisite -- the closest consumer-side point to architect's "Build
-# binaries" step (nothing between them writes to the worktree).
+# go-build links the binaries. A first run showed the tree clean at the end of the
+# `test` PREREQUISITES -- but that point is before the generated `go test ./...`
+# recipe, so a file left by `go test` itself wouldn't show. This wrapper runs the
+# full `test` (incl. the go test recipe) and only THEN the diagnostic, the last
+# consumer-controlled point before architect's nancy + Build binaries steps.
+# .circleci/workflows.yml points test_target at this wrapper for the diagnostic.
+.PHONY: test-diag
+test-diag: test vcs-dirty-diagnostic
+
 .PHONY: vcs-dirty-diagnostic
 vcs-dirty-diagnostic:
 	@echo "VCSDIRTY>> ===== git status --porcelain (untracked=all; what go buildvcs reads) ====="

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -16,7 +16,25 @@ helm-lint: ## Run Helm linter
 # Makefile.gen.go.mk; these prerequisites run before it (CRD freshness, then the
 # integration suite) and only add prerequisites -- they do not override the
 # generated recipe.
-test: verify-crds muster-integration-test
+test: verify-crds muster-integration-test vcs-dirty-diagnostic
+
+# TEMPORARY DIAGNOSTIC -- remove once the +dirty culprit is found.
+# Release binaries embed `vX.Y.Z+dirty` because Go's build-info VCS stamp records
+# `vcs.modified=true` at link time, i.e. `git status` is non-empty when architect's
+# go-build links the binaries. The known scratch files (.ldflags/.platforms/binaries)
+# are already gitignored and a local repro is clean, so something the CI job writes
+# is still escaping. This target prints exactly what Go's buildvcs reads, as the last
+# `test` prerequisite -- the closest consumer-side point to architect's "Build
+# binaries" step (nothing between them writes to the worktree).
+.PHONY: vcs-dirty-diagnostic
+vcs-dirty-diagnostic:
+	@echo "VCSDIRTY>> ===== git status --porcelain (untracked=all; what go buildvcs reads) ====="
+	@git status --porcelain --untracked-files=all || true
+	@echo "VCSDIRTY>> ===== tracked diffs (name + stat) ====="
+	@git --no-pager diff --stat || true
+	@echo "VCSDIRTY>> ===== ignored artifacts currently present (context only) ====="
+	@git status --porcelain --ignored=matching --untracked-files=all 2>/dev/null | grep '^!!' | head -30 || true
+	@echo "VCSDIRTY>> ===== end ====="
 
 CONTROLLER_GEN_VERSION := v0.21.0
 


### PR DESCRIPTION
**Draft / diagnostic only — do not merge.**

Release binaries report `vX.Y.Z+dirty` (e.g. `muster version v0.18.9+dirty`) because Go's build-info VCS stamp records `vcs.modified=true` at link time — the working tree is non-empty when architect's `go-build` links the binaries. The known scratch files (`.ldflags`, `.platforms`, per-arch binaries) are already gitignored and a local repro is clean, so a CI-written artifact is still escaping.

This wires a `vcs-dirty-diagnostic` target as the last `make test` prerequisite (closest consumer-side point to the orb's "Build binaries" step) that prints `git status --porcelain`. The `go-build` job log will show the offending path under the `VCSDIRTY>>` markers.

Once we know the file, revert this and either gitignore it or fix it at the architect-orb layer.

Made with [Cursor](https://cursor.com)