### PR TITLE
fix(oauth): connect localMint backends for self-issued OBO sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- On-behalf-of sessions now connect their localMint backends and advertise their tools. A self-issued OBO bearer (emailless, the human identity in `sub`) reached the dispatch gate after the mcp-oauth v0.18.0 bump but never triggered the per-session backend connect, so the agent saw only core tools. The access-token injector now bridges the validated session into the `api` namespace and fires `onAuthenticated` for self-issued JWTs, so the human session connects its localMint backends and registers their tools.
+
 - On-behalf-of tool calls now reach the backend instead of failing closed. A muster self-issued OBO bearer (`sub=human`, `act=agent`) re-presented at the front door is signature-validated with no token-store entry, so it previously carried no session ID; backend tools that require session auth then rejected it and the connection fell back to the agent ServiceAccount. Bumping mcp-oauth to v0.18.0 makes the `ValidateToken` middleware assign a session to every validated token (`FamilyID` when present, else the deterministic bearer-derived ID), so the existing session lookup resolves the OBO bearer and the per-backend localMint runs as the human. No muster code change.
 
 ### Added

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -327,6 +327,26 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 			if s.injectExternalIDToken(w, r, ctx, next) {
 				return
 			}
+			// A self-issued muster JWT (an on-behalf-of token re-presented at the
+			// front door) is emailless — the human identity is in `sub`, not an
+			// `email` claim — and is neither a forwarded nor a trusted-issuer
+			// token, so it lands here. mcp-oauth has validated it and assigned a
+			// session; bridge that into the api namespace and fire onAuthenticated
+			// so the session's localMint backends connect and advertise their
+			// tools. fireOnAuthenticated reads the api-namespace session, which the
+			// email and forwarded paths set but this path otherwise does not.
+			if userInfo.TokenSource == providers.TokenSourceJWT {
+				if sessionID, ok := oauthhandler.SessionIDFromContext(ctx); ok {
+					ctx = api.WithSessionID(ctx, sessionID)
+					if userInfo.ID != "" {
+						ctx = api.WithSubject(ctx, userInfo.ID)
+					}
+					r = r.WithContext(ctx)
+					s.fireOnAuthenticated(ctx)
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
 			if s.debug {
 				logging.Debug("OAuth", "User info has no email, proceeding without token injection")
 			}

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -531,6 +531,72 @@ func TestFireOnAuthenticated(t *testing.T) {
 	})
 }
 
+// A self-issued muster JWT (an emailless on-behalf-of token re-presented at the
+// front door) is not a forwarded or trusted-issuer token, so it reaches the
+// emailless fall-through. Its validated session must be bridged into the api
+// namespace and onAuthenticated must fire, so the session's localMint backends
+// connect and advertise their tools.
+func TestAccessTokenInjector_SelfIssuedJWT_FiresOnAuthenticated(t *testing.T) {
+	defer stubAcceptForwardedIDToken(func(context.Context, string) (*oauthserver.ForwardedIDTokenAcceptance, error) {
+		return nil, oauth.ErrTrustedAudienceMismatch
+	})()
+	defer stubAcceptTrustedIssuerToken(func(context.Context, string) (*oauthserver.ForwardedIDTokenAcceptance, error) {
+		return nil, oauthserver.ErrIssuerNotTrusted
+	})()
+
+	s := &OAuthHTTPServer{config: config.OAuthServerConfig{BaseURL: "https://muster.test"}}
+	var firedSession string
+	s.SetOnAuthenticated(func(_ context.Context, sessionID string) {
+		firedSession = sessionID
+	})
+
+	var capturedCtx context.Context
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+	})
+
+	r := requestWithBearer("self-issued-obo")
+	ctx := oauthhandler.ContextWithUserInfo(r.Context(), &providers.UserInfo{
+		ID:          "quentin@giantswarm.io",
+		TokenSource: providers.TokenSourceJWT,
+	})
+	ctx = oauthhandler.ContextWithSessionID(ctx, "ext-obo-session")
+	r = r.WithContext(ctx)
+
+	s.createAccessTokenInjectorMiddleware(next).ServeHTTP(httptest.NewRecorder(), r)
+
+	require.NotNil(t, capturedCtx, "next must be invoked")
+	assert.Equal(t, "ext-obo-session", api.GetSessionIDFromContext(capturedCtx), "session bridged into api namespace")
+	assert.Equal(t, "quentin@giantswarm.io", api.GetSubjectFromContext(capturedCtx), "subject set from UserInfo.ID")
+	assert.Equal(t, "ext-obo-session", firedSession, "onAuthenticated fired with the bridged session ID")
+}
+
+// An emailless token that is not a self-issued JWT must not fire onAuthenticated
+// from the emailless fall-through, even when a session is present.
+func TestAccessTokenInjector_EmaillessNonJWT_DoesNotFire(t *testing.T) {
+	defer stubAcceptForwardedIDToken(func(context.Context, string) (*oauthserver.ForwardedIDTokenAcceptance, error) {
+		return nil, oauth.ErrTrustedAudienceMismatch
+	})()
+	defer stubAcceptTrustedIssuerToken(func(context.Context, string) (*oauthserver.ForwardedIDTokenAcceptance, error) {
+		return nil, oauthserver.ErrIssuerNotTrusted
+	})()
+
+	s := &OAuthHTTPServer{config: config.OAuthServerConfig{BaseURL: "https://muster.test"}}
+	fired := false
+	s.SetOnAuthenticated(func(context.Context, string) { fired = true })
+
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	r := requestWithBearer("opaque")
+	ctx := oauthhandler.ContextWithUserInfo(r.Context(), &providers.UserInfo{ID: "system:serviceaccount:ns:sa"})
+	ctx = oauthhandler.ContextWithSessionID(ctx, "ext-sa")
+	r = r.WithContext(ctx)
+
+	s.createAccessTokenInjectorMiddleware(next).ServeHTTP(httptest.NewRecorder(), r)
+
+	assert.False(t, fired, "onAuthenticated must not fire for a non-JWT emailless token")
+}
+
 // fakeJWT returns a syntactically valid JWT whose payload is the given claims
 // JSON-encoded. The header and signature parts are placeholders — the function
 // under test does not verify signatures.


### PR DESCRIPTION
## What

OBO sessions were broken in two layers; both are fixed here.

**Layer 1 — emission (broker/local-mint):** muster-minted OBO tokens had no \`email\` claim. The broker dropped \`SubjectIdentity.Claims\` when projecting into \`MintRequest\`, so \`localMintProvider\` forwarded a bare subject string to \`LocalMintExchanger\` and the minted JWT carried only \`sub\`. mcp-oauth's exchanger already copies \`Claims.Email → AccessTokenClaims.Email\` when the claims are present — the gap was purely on the muster side. Fixed by threading \`SubjectIdentity\` (including \`Claims\`) through \`MintRequest\` and into the \`ExchangerRequest\`.

**Layer 2 — consumption (access-token injector):** a muster self-issued OBO token is emailless at re-presentation — the human identity is in \`sub\`, not an \`email\` claim — and is neither a forwarded nor a trusted-issuer token, so it fell through the emailless branch without firing \`onAuthenticated\`. Without it, the human OBO session never connected its localMint backends, so the agent saw only core tools. Fixed by gating on \`TokenSource == JWT\` in the emailless fall-through: the validated session is bridged into the \`api\` namespace, the subject is set from \`UserInfo.ID\`, and \`onAuthenticated\` fires.

Layer 1 fixes future-minted tokens at the source. Layer 2 handles the re-presentation path and acts as a general fallback for any self-issued token that legitimately has no \`email\` claim.

## Live verification (glean)

After release + auto-pull, a fresh-login UI run should show in the muster audit:
- \`SSO: Connecting … for session ext-<human>\` for the human session, then \`token_issued audience=mcp-kubernetes subject_iss=…muster.glean…\` with an \`act\` claim;
- the agent's tool list includes \`x_kubernetes_*\`, not just \`core_*\`;
- target apiserver audit shows \`impersonatedUser.username=quentin@…\`.