### PR TITLE
fix(aggregator): connect localMint backends for OBO sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- OBO sessions now connect localMint backends. After the emission fix that adds `email` to muster-minted OBO JWTs, `fireOnAuthenticated` fires for OBO requests, but the `onAuthenticated` callback returned early at the `idToken == ""` guard (written to avoid 403-spam for post-restart Dex sessions). The guard is now narrowed: OBO sessions (detected via `userInfo.ActorSubject`) are allowed through. The inbound OBO bearer is threaded into the detached `initSSOForSession` background context and used as the RFC 8693 subject token in `EstablishConnectionWithLocalMint`, falling back from the Dex ID-token lookup when none is present.
+
 - On-behalf-of tool calls now reach the backend instead of failing closed. A muster self-issued OBO bearer (`sub=human`, `act=agent`) re-presented at the front door is signature-validated with no token-store entry, so it previously carried no session ID; backend tools that require session auth then rejected it and the connection fell back to the agent ServiceAccount. Bumping mcp-oauth to v0.18.0 makes the `ValidateToken` middleware assign a session to every validated token (`FamilyID` when present, else the deterministic bearer-derived ID), so the existing session lookup resolves the OBO bearer and the per-backend localMint runs as the human. No muster code change.
 
 ### Added

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -345,9 +345,9 @@ const initSSOTimeout = 15 * time.Second
 // initSSOForSession detaches its own timeout-bounded context internally, so
 // blocking here does not tie the bootstrap to request cancellation. singleflight
 // collapses concurrent first requests for the same session into one bootstrap.
-func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken string) {
+func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken, bearerToken string) {
 	_, _, _ = a.ssoInitGroup.Do(sessionID, func() (any, error) {
-		a.initSSOForSession(userID, sessionID, idToken)
+		a.initSSOForSession(userID, sessionID, idToken, bearerToken)
 		return nil, nil
 	})
 }
@@ -359,11 +359,11 @@ func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken str
 // fully connected before the client receives its access token.
 // Connections to individual servers run in parallel with a shared timeout
 // so that a single slow server cannot block the entire login flow.
-func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken string) {
+func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken, bearerToken string) {
 	musterIssuer := a.getMusterIssuer()
 
-	logging.Info("Aggregator", "SSO: initSSOForSession called (userID=%s, sessionID=%s, idTokenLen=%d, musterIssuer=%s)",
-		logging.TruncateIdentifier(userID), logging.TruncateIdentifier(sessionID), len(idToken), musterIssuer)
+	logging.Info("Aggregator", "SSO: initSSOForSession called (userID=%s, sessionID=%s, idTokenLen=%d, bearerTokenLen=%d, musterIssuer=%s)",
+		logging.TruncateIdentifier(userID), logging.TruncateIdentifier(sessionID), len(idToken), len(bearerToken), musterIssuer)
 
 	if musterIssuer == "" {
 		logging.Info("Aggregator", "SSO: initSSOForSession returning early: musterIssuer is empty")
@@ -378,6 +378,9 @@ func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken string) 
 	bgCtx = api.WithSessionID(bgCtx, sessionID)
 	if idToken != "" {
 		bgCtx = server.ContextWithIDToken(bgCtx, idToken)
+	}
+	if bearerToken != "" {
+		bgCtx = server.ContextWithBearerToken(bgCtx, bearerToken)
 	}
 
 	var pending []*ServerInfo

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -463,6 +463,13 @@ func EstablishConnectionWithLocalMint(
 
 	subjectToken := getIDTokenForForwarding(ctx, sessionID, musterIssuer, a.sessionRefresher())
 	if subjectToken == "" {
+		// OBO sessions carry no Dex ID token; the muster-issued bearer is the
+		// RFC 8693 subject for the localMint exchange. Fall back to it here so
+		// the background bgCtx (which has the bearer threaded in by
+		// initSSOForSession) can still establish the per-backend connection.
+		subjectToken = server.GetBearerTokenFromContext(ctx)
+	}
+	if subjectToken == "" {
 		return nil, fmt.Errorf("no session token available to mint localMint discovery for %s", serverInfo.Name)
 	}
 

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1510,12 +1510,14 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 
 		userID := getUserSubjectFromContext(ctx)
 		idToken, _ := server.GetIDTokenFromContext(ctx)
+		userInfo, _ := oauthhandler.UserInfoFromContext(ctx)
 
 		logging.InfoWithAttrs("Aggregator", "SSO: onAuthenticated callback",
 			slog.String("sessionID", logging.TruncateIdentifier(sessionID)),
 			slog.String("userID", logging.TruncateIdentifier(userID)),
 			slog.Bool("authAlive", authAlive),
-			slog.Bool("hasIDToken", idToken != ""))
+			slog.Bool("hasIDToken", idToken != ""),
+			slog.Bool("isOBO", userInfo != nil && userInfo.ActorSubject != ""))
 
 		if authAlive {
 			if idToken == "" {
@@ -1538,17 +1540,22 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 			if a.getMusterIssuer() != "" && a.ssoPoolMissNeedingInit(userID, sessionID) {
 				logging.InfoWithAttrs("Aggregator", "SSO: pool miss on live session, triggering SSO re-init",
 					slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
-				go a.initSSOForSession(userID, sessionID, idToken) //nolint:gosec // G118: SSO re-init goroutine must outlive the request that triggered it
+				go a.initSSOForSession(userID, sessionID, idToken, "") //nolint:gosec // G118: SSO re-init goroutine must outlive the request that triggered it
 			}
 			return
 		}
 
-		// Don't initiate SSO for stale sessions without a usable ID token.
-		// After a pod restart, Valkey may still have valid access tokens but no ID token
-		// in the OAuth store. Without this gate, downstream connections are established
-		// that immediately start spamming 403 errors.
-		if idToken == "" {
-			logging.InfoWithAttrs("Aggregator", "SSO: skipping initSSOForSession, no ID token available (stale session after restart)",
+		// OBO sessions (delegated human identity) have no Dex ID token — the
+		// muster-issued bearer itself is the subject token for localMint exchanges.
+		// Allow them through; initSSOForSession handles an empty idToken gracefully
+		// and EstablishConnectionWithLocalMint falls back to the bearer.
+		//
+		// For post-restart sessions where neither an ID token nor an OBO actor is
+		// present, skip to avoid spinning up connections with a stale bearer that
+		// has no valid subject for backend token exchanges.
+		isOBO := userInfo != nil && userInfo.ActorSubject != ""
+		if idToken == "" && !isOBO {
+			logging.InfoWithAttrs("Aggregator", "SSO: skipping initSSOForSession, no ID token and not an OBO session (stale session after restart)",
 				slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
 			return
 		}
@@ -1562,7 +1569,8 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 			a.ssoTracker.ClearAllSSOFailed(userID)
 		}
 
-		a.bootstrapNewSessionSSO(userID, sessionID, idToken)
+		bearerToken := server.GetBearerTokenFromContext(ctx)
+		a.bootstrapNewSessionSSO(userID, sessionID, idToken, bearerToken)
 	})
 
 	logging.InfoWithAttrs("Aggregator", "OAuth 2.1 server protection enabled",
@@ -1604,7 +1612,7 @@ func (a *AggregatorServer) ssoLifecycleOptions() []oauth.ServerOption {
 				slog.String("familyID", logging.TruncateIdentifier(familyID)),
 				slog.Bool("hasIDToken", idToken != ""),
 				slog.Int("idTokenLen", len(idToken)))
-			a.initSSOForSession(userID, familyID, idToken)
+			a.initSSOForSession(userID, familyID, idToken, "")
 			a.storeIDTokenForSSO(familyID, userID, idToken)
 		}),
 		// An upstream refresh with no ID token signals a broken refresh chain

--- a/internal/aggregator/sso_reconnect_test.go
+++ b/internal/aggregator/sso_reconnect_test.go
@@ -1068,7 +1068,7 @@ func TestBootstrapNewSessionSSO_ConnectsForwardTokenSynchronously(t *testing.T) 
 
 	// No ID token is resolvable (none in context, no usable OAuth proxy entry),
 	// so the forward-token connect fails fast without a network round-trip.
-	agg.bootstrapNewSessionSSO(userID, sessionID, "")
+	agg.bootstrapNewSessionSSO(userID, sessionID, "", "")
 
 	// Synchronous contract: the connect outcome is recorded by the time the call
 	// returns. An asynchronous bootstrap would not have this observable yet.


### PR DESCRIPTION
## What

The `onAuthenticated` callback had a `idToken == ""` early-return guard
that was added to prevent 403-spam for post-restart Dex sessions where
the OAuth proxy store loses its ID token. OBO sessions also have no Dex
ID token, so they hit the same guard and never triggered
`bootstrapNewSessionSSO` — backends were never connected, the agent saw
no tools under the human identity.

## Changes

**1. Narrow the stale-restart guard (`server.go`)**

Before: `if idToken == "" { return }` — blocks any new session without a
Dex ID token.

After: only skip when the session also carries no RFC 8693 `act` claim
(`userInfo.ActorSubject`). A non-empty `ActorSubject` means the bearer is
a delegated OBO token; those are allowed through.

**2. Thread the bearer into `initSSOForSession`'s background context
(`auth_resource.go`)**

`initSSOForSession` creates a detached `context.Background()` to survive
request cancellation. The inbound OBO bearer was previously dropped there.
It is now threaded via `server.ContextWithBearerToken` so it survives into
the background goroutines that call `EstablishConnectionWithLocalMint`.

**3. Bearer fallback in `EstablishConnectionWithLocalMint`
(`connection_helper.go`)**

`getIDTokenForForwarding` checks the Dex ID-token store — always empty for
OBO sessions. Added a fallback to `server.GetBearerTokenFromContext`: for
OBO the muster-issued JWT is itself the RFC 8693 subject for the per-backend
exchange, so using it here preserves the delegation chain to the backend.
The fallback is local to this function; `EstablishConnectionWithTokenForwarding`
callers are unaffected (they need a Dex token specifically).

## Dependency

Requires the emission fix on main (commits `137efa2`/`f61b86b`): OBO tokens
must carry the `email` claim so `createAccessTokenInjectorMiddleware` passes
the `userInfo.Email == ""` gate and calls `fireOnAuthenticated` at all.
Both fixes together complete the OBO localMint connection path.