### PR TITLE
refactor(aggregator): replace token params with ssoSession value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- OBO sessions now connect localMint backends. After the emission fix that adds `email` to muster-minted OBO JWTs, `fireOnAuthenticated` fires for OBO requests, but the `onAuthenticated` callback returned early at the `idToken == ""` guard (written to avoid 403-spam for post-restart Dex sessions). The guard is now narrowed: OBO sessions (detected via `userInfo.ActorSubject`) are allowed through. The inbound OBO bearer is threaded into the detached `initSSOForSession` background context and used as the RFC 8693 subject token in `EstablishConnectionWithLocalMint`, falling back from the Dex ID-token lookup when none is present.
+
 - On-behalf-of tool calls now reach the backend instead of failing closed. A muster self-issued OBO bearer (`sub=human`, `act=agent`) re-presented at the front door is signature-validated with no token-store entry, so it previously carried no session ID; backend tools that require session auth then rejected it and the connection fell back to the agent ServiceAccount. Bumping mcp-oauth to v0.18.0 makes the `ValidateToken` middleware assign a session to every validated token (`FamilyID` when present, else the deterministic bearer-derived ID), so the existing session lookup resolves the OBO bearer and the per-backend localMint runs as the human. No muster code change.
 
 ### Added

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -345,9 +345,9 @@ const initSSOTimeout = 15 * time.Second
 // initSSOForSession detaches its own timeout-bounded context internally, so
 // blocking here does not tie the bootstrap to request cancellation. singleflight
 // collapses concurrent first requests for the same session into one bootstrap.
-func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken, bearerToken string) {
-	_, _, _ = a.ssoInitGroup.Do(sessionID, func() (any, error) {
-		a.initSSOForSession(userID, sessionID, idToken, bearerToken)
+func (a *AggregatorServer) bootstrapNewSessionSSO(sso ssoSession) {
+	_, _, _ = a.ssoInitGroup.Do(sso.sessionID, func() (any, error) {
+		a.initSSOForSession(sso)
 		return nil, nil
 	})
 }
@@ -359,11 +359,10 @@ func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken, be
 // fully connected before the client receives its access token.
 // Connections to individual servers run in parallel with a shared timeout
 // so that a single slow server cannot block the entire login flow.
-func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken, bearerToken string) {
+func (a *AggregatorServer) initSSOForSession(sso ssoSession) {
 	musterIssuer := a.getMusterIssuer()
 
-	logging.Info("Aggregator", "SSO: initSSOForSession called (userID=%s, sessionID=%s, idTokenLen=%d, bearerTokenLen=%d, musterIssuer=%s)",
-		logging.TruncateIdentifier(userID), logging.TruncateIdentifier(sessionID), len(idToken), len(bearerToken), musterIssuer)
+	logging.Info("Aggregator", "SSO: initSSOForSession called (session=%v, musterIssuer=%s)", sso, musterIssuer)
 
 	if musterIssuer == "" {
 		logging.Info("Aggregator", "SSO: initSSOForSession returning early: musterIssuer is empty")
@@ -374,13 +373,13 @@ func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken, bearerT
 	// context may be cancelled before SSO work finishes.
 	bgCtx, cancel := context.WithTimeout(context.Background(), initSSOTimeout)
 	defer cancel()
-	bgCtx = api.WithSubject(bgCtx, userID)
-	bgCtx = api.WithSessionID(bgCtx, sessionID)
-	if idToken != "" {
-		bgCtx = server.ContextWithIDToken(bgCtx, idToken)
+	bgCtx = api.WithSubject(bgCtx, sso.userID)
+	bgCtx = api.WithSessionID(bgCtx, sso.sessionID)
+	if sso.idToken != "" {
+		bgCtx = server.ContextWithIDToken(bgCtx, sso.idToken)
 	}
-	if bearerToken != "" {
-		bgCtx = server.ContextWithBearerToken(bgCtx, bearerToken)
+	if sso.bearer != "" {
+		bgCtx = server.ContextWithBearerToken(bgCtx, sso.bearer)
 	}
 
 	var pending []*ServerInfo
@@ -395,10 +394,10 @@ func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken, bearerT
 			skippedNotSSO++
 			continue
 		}
-		if a.ssoTracker != nil && a.ssoTracker.HasSSOFailed(userID, info.Name) {
-			fc := a.ssoTracker.GetFailureCount(userID, info.Name)
+		if a.ssoTracker != nil && a.ssoTracker.HasSSOFailed(sso.userID, info.Name) {
+			fc := a.ssoTracker.GetFailureCount(sso.userID, info.Name)
 			logging.Debug("Aggregator", "SSO: skipping %s for user %s (failureCount=%d, backoff=%v)",
-				info.Name, logging.TruncateIdentifier(userID), fc, ssoBackoffDuration(fc))
+				info.Name, logging.TruncateIdentifier(sso.userID), fc, ssoBackoffDuration(fc))
 			skippedPriorFailure++
 			continue
 		}
@@ -413,7 +412,7 @@ func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken, bearerT
 	}
 
 	logging.Info("Aggregator", "SSO: Connecting %d servers for session %s",
-		len(pending), logging.TruncateIdentifier(sessionID))
+		len(pending), logging.TruncateIdentifier(sso.sessionID))
 
 	var wg sync.WaitGroup
 	for _, info := range pending {
@@ -433,10 +432,10 @@ func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken, bearerT
 	select {
 	case <-done:
 		logging.Debug("Aggregator", "SSO: All %d servers connected for session %s",
-			len(pending), logging.TruncateIdentifier(sessionID))
+			len(pending), logging.TruncateIdentifier(sso.sessionID))
 	case <-bgCtx.Done():
 		logging.Warn("Aggregator", "SSO: Init timed out after %v for session %s",
-			initSSOTimeout, logging.TruncateIdentifier(sessionID))
+			initSSOTimeout, logging.TruncateIdentifier(sso.sessionID))
 	}
 }
 

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -345,9 +345,9 @@ const initSSOTimeout = 15 * time.Second
 // initSSOForSession detaches its own timeout-bounded context internally, so
 // blocking here does not tie the bootstrap to request cancellation. singleflight
 // collapses concurrent first requests for the same session into one bootstrap.
-func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken string) {
+func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken, bearerToken string) {
 	_, _, _ = a.ssoInitGroup.Do(sessionID, func() (any, error) {
-		a.initSSOForSession(userID, sessionID, idToken)
+		a.initSSOForSession(userID, sessionID, idToken, bearerToken)
 		return nil, nil
 	})
 }
@@ -359,11 +359,11 @@ func (a *AggregatorServer) bootstrapNewSessionSSO(userID, sessionID, idToken str
 // fully connected before the client receives its access token.
 // Connections to individual servers run in parallel with a shared timeout
 // so that a single slow server cannot block the entire login flow.
-func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken string) {
+func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken, bearerToken string) {
 	musterIssuer := a.getMusterIssuer()
 
-	logging.Info("Aggregator", "SSO: initSSOForSession called (userID=%s, sessionID=%s, idTokenLen=%d, musterIssuer=%s)",
-		logging.TruncateIdentifier(userID), logging.TruncateIdentifier(sessionID), len(idToken), musterIssuer)
+	logging.Info("Aggregator", "SSO: initSSOForSession called (userID=%s, sessionID=%s, idTokenLen=%d, bearerTokenLen=%d, musterIssuer=%s)",
+		logging.TruncateIdentifier(userID), logging.TruncateIdentifier(sessionID), len(idToken), len(bearerToken), musterIssuer)
 
 	if musterIssuer == "" {
 		logging.Info("Aggregator", "SSO: initSSOForSession returning early: musterIssuer is empty")
@@ -378,6 +378,9 @@ func (a *AggregatorServer) initSSOForSession(userID, sessionID, idToken string) 
 	bgCtx = api.WithSessionID(bgCtx, sessionID)
 	if idToken != "" {
 		bgCtx = server.ContextWithIDToken(bgCtx, idToken)
+	}
+	if bearerToken != "" {
+		bgCtx = server.ContextWithBearerToken(bgCtx, bearerToken)
 	}
 
 	var pending []*ServerInfo

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -463,6 +463,13 @@ func EstablishConnectionWithLocalMint(
 
 	subjectToken := getIDTokenForForwarding(ctx, sessionID, musterIssuer, a.sessionRefresher())
 	if subjectToken == "" {
+		// OBO sessions carry no Dex ID token; the muster-issued bearer is the
+		// RFC 8693 subject for the localMint exchange. Fall back to it here so
+		// the background bgCtx (which has the bearer threaded in by
+		// initSSOForSession) can still establish the per-backend connection.
+		subjectToken = server.GetBearerTokenFromContext(ctx)
+	}
+	if subjectToken == "" {
 		return nil, fmt.Errorf("no session token available to mint localMint discovery for %s", serverInfo.Name)
 	}
 

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1508,24 +1508,18 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 		}
 		_, _ = a.capabilityStore.Touch(ctx, sessionID)
 
-		userID := getUserSubjectFromContext(ctx)
-		idToken, _ := server.GetIDTokenFromContext(ctx)
-		userInfo, _ := oauthhandler.UserInfoFromContext(ctx)
+		sso := ssoSessionFromContext(ctx, sessionID)
 
 		logging.InfoWithAttrs("Aggregator", "SSO: onAuthenticated callback",
-			slog.String("sessionID", logging.TruncateIdentifier(sessionID)),
-			slog.String("userID", logging.TruncateIdentifier(userID)),
-			slog.Bool("authAlive", authAlive),
-			slog.Bool("hasIDToken", idToken != ""),
-			slog.Bool("isOBO", userInfo != nil && userInfo.ActorSubject != ""))
+			slog.Any("session", sso),
+			slog.Bool("authAlive", authAlive))
 
 		if authAlive {
-			if idToken == "" {
-				// Session is known but the ID token is gone: the upstream
-				// refresh chain is broken (e.g. Dex -> GitHub returned 401).
+			if !sso.canBootstrapSSO() {
+				// No usable subject token: the upstream credential is gone.
 				// Evict stale SSO connections to stop mcp-go's infinite
 				// 1-second retry loop.
-				a.handleUpstreamRefreshFailure(sessionID, userID, "onAuthenticated: ID token missing for active session")
+				a.handleUpstreamRefreshFailure(sessionID, sso.userID, "onAuthenticated: no usable subject token for active session")
 				return
 			}
 			// After a pod restart the auth store survives in Valkey but the
@@ -1535,27 +1529,16 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 			// in-memory, so after a restart there are no stale failures, and
 			// clearing it on every request would retry a persistently failing
 			// exchange per-request instead of on the backoff schedule.
-			// The issuer check mirrors initSSOForSession's early return so
-			// pending slots are not claimed when no exchange can run.
-			if a.getMusterIssuer() != "" && a.ssoPoolMissNeedingInit(userID, sessionID) {
+			if a.getMusterIssuer() != "" && a.ssoPoolMissNeedingInit(sso.userID, sessionID) {
 				logging.InfoWithAttrs("Aggregator", "SSO: pool miss on live session, triggering SSO re-init",
 					slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
-				go a.initSSOForSession(userID, sessionID, idToken, "") //nolint:gosec // G118: SSO re-init goroutine must outlive the request that triggered it
+				go a.initSSOForSession(sso) //nolint:gosec // G118: SSO re-init goroutine must outlive the request that triggered it
 			}
 			return
 		}
 
-		// OBO sessions (delegated human identity) have no Dex ID token — the
-		// muster-issued bearer itself is the subject token for localMint exchanges.
-		// Allow them through; initSSOForSession handles an empty idToken gracefully
-		// and EstablishConnectionWithLocalMint falls back to the bearer.
-		//
-		// For post-restart sessions where neither an ID token nor an OBO actor is
-		// present, skip to avoid spinning up connections with a stale bearer that
-		// has no valid subject for backend token exchanges.
-		isOBO := userInfo != nil && userInfo.ActorSubject != ""
-		if idToken == "" && !isOBO {
-			logging.InfoWithAttrs("Aggregator", "SSO: skipping initSSOForSession, no ID token and not an OBO session (stale session after restart)",
+		if !sso.canBootstrapSSO() {
+			logging.InfoWithAttrs("Aggregator", "SSO: skipping bootstrap, no usable subject token",
 				slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
 			return
 		}
@@ -1565,12 +1548,11 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 		// restart or after a transient token-storage error) would be skipped
 		// for ssoTrackerFailureTTL even though the underlying cause may have
 		// been resolved.
-		if a.ssoTracker != nil && userID != "" {
-			a.ssoTracker.ClearAllSSOFailed(userID)
+		if a.ssoTracker != nil && sso.userID != "" {
+			a.ssoTracker.ClearAllSSOFailed(sso.userID)
 		}
 
-		bearerToken := server.GetBearerTokenFromContext(ctx)
-		a.bootstrapNewSessionSSO(userID, sessionID, idToken, bearerToken)
+		a.bootstrapNewSessionSSO(sso)
 	})
 
 	logging.InfoWithAttrs("Aggregator", "OAuth 2.1 server protection enabled",
@@ -1612,7 +1594,7 @@ func (a *AggregatorServer) ssoLifecycleOptions() []oauth.ServerOption {
 				slog.String("familyID", logging.TruncateIdentifier(familyID)),
 				slog.Bool("hasIDToken", idToken != ""),
 				slog.Int("idTokenLen", len(idToken)))
-			a.initSSOForSession(userID, familyID, idToken, "")
+			a.initSSOForSession(ssoSession{userID: userID, sessionID: familyID, idToken: idToken})
 			a.storeIDTokenForSSO(familyID, userID, idToken)
 		}),
 		// An upstream refresh with no ID token signals a broken refresh chain

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1842,7 +1843,7 @@ func (a *AggregatorServer) IsYoloMode() bool {
 //   - args: Arguments to pass to the tool as key-value pairs
 //
 // Returns the tool execution result or an error if the tool cannot be found or executed.
-func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string, args map[string]interface{}) (res *mcp.CallToolResult, err error) {
+func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string, args map[string]any) (res *mcp.CallToolResult, err error) {
 	logging.DebugWithAttrs("Aggregator", "CallToolInternal called",
 		slog.String("tool", toolName))
 
@@ -1866,7 +1867,7 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 			return nil, fmt.Errorf("tool %s is provided by a family on servers %s; the %q parameter is required",
 				toolName, strings.Join(providers, ", "), instanceArg)
 		}
-		forwarded := make(map[string]interface{}, len(args)-1)
+		forwarded := make(map[string]any, len(args)-1)
 		for k, v := range args {
 			if k != instanceArg {
 				forwarded[k] = v
@@ -1920,7 +1921,7 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 // for solo tools or via ResolveToolNameForServer for family-grouped tools).
 // It encapsulates the global-client vs. session-scoped vs. token-exchange
 // branching that previously lived inline in CallToolInternal.
-func (a *AggregatorServer) dispatchResolvedTool(ctx context.Context, toolName, serverName, originalName string, args map[string]interface{}, sessionID, sub string) (*mcp.CallToolResult, error) {
+func (a *AggregatorServer) dispatchResolvedTool(ctx context.Context, toolName, serverName, originalName string, args map[string]any, sessionID, sub string) (*mcp.CallToolResult, error) {
 	serverInfo, exists := a.registry.GetServerInfo(serverName)
 	if !exists || serverInfo == nil {
 		return nil, fmt.Errorf("server not found: %s", serverName)
@@ -1998,7 +1999,7 @@ func (a *AggregatorServer) isCoreToolByName(toolName string) bool {
 //
 // Returns the tool execution result converted to MCP format, or an error if
 // no appropriate handler is found or execution fails.
-func (a *AggregatorServer) callCoreToolDirectly(ctx context.Context, toolName string, args map[string]interface{}) (*mcp.CallToolResult, error) {
+func (a *AggregatorServer) callCoreToolDirectly(ctx context.Context, toolName string, args map[string]any) (*mcp.CallToolResult, error) {
 	logging.DebugWithAttrs("Aggregator", "callCoreToolDirectly called",
 		slog.String("tool", toolName))
 
@@ -2021,13 +2022,7 @@ func (a *AggregatorServer) callCoreToolDirectly(ctx context.Context, toolName st
 				"workflow_update", "workflow_delete", "workflow_validate", "workflow_available",
 				"workflow_execution_list", "workflow_execution_get"}
 
-			isManagementTool := false
-			for _, mgmtTool := range managementTools {
-				if originalToolName == mgmtTool {
-					isManagementTool = true
-					break
-				}
-			}
+			isManagementTool := slices.Contains(managementTools, originalToolName)
 
 			if isManagementTool {
 				// Use the original tool name for workflow management tools
@@ -2917,7 +2912,7 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 				logging.InfoWithAttrs("Aggregator", "Token expiring soon, triggering background refresh",
 					slog.String("server", serverName),
 					slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
-				a.triggerBackgroundTokenRefresh(sessionID, serverName, sub)
+				a.triggerBackgroundTokenRefresh(sessionID, serverName)
 				return pooledClient, func() {}, nil
 
 			default:
@@ -3030,7 +3025,7 @@ func (a *AggregatorServer) callToolWithTokenExchangeRetry(
 	ctx context.Context,
 	serverName string,
 	originalToolName string,
-	args map[string]interface{},
+	args map[string]any,
 	sessionID string,
 	sub string,
 ) (*mcp.CallToolResult, error) {
@@ -3071,11 +3066,11 @@ func (a *AggregatorServer) callToolWithTokenExchangeRetry(
 // the token for a token-exchange server and replace the pooled client.
 // Concurrent calls for the same (sessionID, serverName) are deduplicated via
 // singleflight -- only the first caller spawns the goroutine.
-func (a *AggregatorServer) triggerBackgroundTokenRefresh(sessionID, serverName, sub string) {
+func (a *AggregatorServer) triggerBackgroundTokenRefresh(sessionID, serverName string) {
 	sfKey := sessionID + "/" + serverName
 	go func() {
-		_, _, _ = a.tokenRefreshGroup.Do(sfKey, func() (interface{}, error) {
-			a.backgroundTokenRefresh(sessionID, serverName, sub)
+		_, _, _ = a.tokenRefreshGroup.Do(sfKey, func() (any, error) {
+			a.backgroundTokenRefresh(sessionID, serverName)
 			return nil, nil
 		})
 	}()
@@ -3088,7 +3083,7 @@ func (a *AggregatorServer) triggerBackgroundTokenRefresh(sessionID, serverName, 
 // Failures are logged but never propagated -- the caller already received the
 // still-valid pooled client, and callToolWithTokenExchangeRetry handles the
 // case where the token expires before the background refresh succeeds.
-func (a *AggregatorServer) backgroundTokenRefresh(sessionID, serverName, sub string) {
+func (a *AggregatorServer) backgroundTokenRefresh(sessionID, serverName string) {
 	ctx := context.Background()
 
 	serverInfo, exists := a.registry.GetServerInfo(serverName)
@@ -3226,7 +3221,7 @@ func (a *AggregatorServer) GetPrompt(ctx context.Context, name string, args map[
 	}
 
 	// Convert string args to interface{} args for the client
-	clientArgs := make(map[string]interface{})
+	clientArgs := make(map[string]any)
 	for k, v := range args {
 		clientArgs[k] = v
 	}

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1510,12 +1510,14 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 
 		userID := getUserSubjectFromContext(ctx)
 		idToken, _ := server.GetIDTokenFromContext(ctx)
+		userInfo, _ := oauthhandler.UserInfoFromContext(ctx)
 
 		logging.InfoWithAttrs("Aggregator", "SSO: onAuthenticated callback",
 			slog.String("sessionID", logging.TruncateIdentifier(sessionID)),
 			slog.String("userID", logging.TruncateIdentifier(userID)),
 			slog.Bool("authAlive", authAlive),
-			slog.Bool("hasIDToken", idToken != ""))
+			slog.Bool("hasIDToken", idToken != ""),
+			slog.Bool("isOBO", userInfo != nil && userInfo.ActorSubject != ""))
 
 		if authAlive {
 			if idToken == "" {
@@ -1538,17 +1540,22 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 			if a.getMusterIssuer() != "" && a.ssoPoolMissNeedingInit(userID, sessionID) {
 				logging.InfoWithAttrs("Aggregator", "SSO: pool miss on live session, triggering SSO re-init",
 					slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
-				go a.initSSOForSession(userID, sessionID, idToken) //nolint:gosec // G118: SSO re-init goroutine must outlive the request that triggered it
+				go a.initSSOForSession(userID, sessionID, idToken, "") //nolint:gosec // G118: SSO re-init goroutine must outlive the request that triggered it
 			}
 			return
 		}
 
-		// Don't initiate SSO for stale sessions without a usable ID token.
-		// After a pod restart, Valkey may still have valid access tokens but no ID token
-		// in the OAuth store. Without this gate, downstream connections are established
-		// that immediately start spamming 403 errors.
-		if idToken == "" {
-			logging.InfoWithAttrs("Aggregator", "SSO: skipping initSSOForSession, no ID token available (stale session after restart)",
+		// OBO sessions (delegated human identity) have no Dex ID token — the
+		// muster-issued bearer itself is the subject token for localMint exchanges.
+		// Allow them through; initSSOForSession handles an empty idToken gracefully
+		// and EstablishConnectionWithLocalMint falls back to the bearer.
+		//
+		// For post-restart sessions where neither an ID token nor an OBO actor is
+		// present, skip to avoid spinning up connections with a stale bearer that
+		// has no valid subject for backend token exchanges.
+		isOBO := userInfo != nil && userInfo.ActorSubject != ""
+		if idToken == "" && !isOBO {
+			logging.InfoWithAttrs("Aggregator", "SSO: skipping initSSOForSession, no ID token and not an OBO session (stale session after restart)",
 				slog.String("sessionID", logging.TruncateIdentifier(sessionID)))
 			return
 		}
@@ -1562,7 +1569,8 @@ func (a *AggregatorServer) createOAuthProtectedMux(mcpHandler http.Handler) (htt
 			a.ssoTracker.ClearAllSSOFailed(userID)
 		}
 
-		a.bootstrapNewSessionSSO(userID, sessionID, idToken)
+		bearerToken := server.GetBearerTokenFromContext(ctx)
+		a.bootstrapNewSessionSSO(userID, sessionID, idToken, bearerToken)
 	})
 
 	logging.InfoWithAttrs("Aggregator", "OAuth 2.1 server protection enabled",
@@ -1604,7 +1612,7 @@ func (a *AggregatorServer) ssoLifecycleOptions() []oauth.ServerOption {
 				slog.String("familyID", logging.TruncateIdentifier(familyID)),
 				slog.Bool("hasIDToken", idToken != ""),
 				slog.Int("idTokenLen", len(idToken)))
-			a.initSSOForSession(userID, familyID, idToken)
+			a.initSSOForSession(userID, familyID, idToken, "")
 			a.storeIDTokenForSSO(familyID, userID, idToken)
 		}),
 		// An upstream refresh with no ID token signals a broken refresh chain

--- a/internal/aggregator/sso_reconnect_test.go
+++ b/internal/aggregator/sso_reconnect_test.go
@@ -21,7 +21,7 @@ type noopMCPClient struct{}
 func (c *noopMCPClient) Initialize(context.Context) error              { return nil }
 func (c *noopMCPClient) Close() error                                  { return nil }
 func (c *noopMCPClient) ListTools(context.Context) ([]mcp.Tool, error) { return nil, nil }
-func (c *noopMCPClient) CallTool(context.Context, string, map[string]interface{}) (*mcp.CallToolResult, error) {
+func (c *noopMCPClient) CallTool(context.Context, string, map[string]any) (*mcp.CallToolResult, error) {
 	return nil, nil
 }
 func (c *noopMCPClient) ListResources(context.Context) ([]mcp.Resource, error) { return nil, nil }
@@ -29,7 +29,7 @@ func (c *noopMCPClient) ReadResource(context.Context, string) (*mcp.ReadResource
 	return nil, nil
 }
 func (c *noopMCPClient) ListPrompts(context.Context) ([]mcp.Prompt, error) { return nil, nil }
-func (c *noopMCPClient) GetPrompt(context.Context, string, map[string]interface{}) (*mcp.GetPromptResult, error) {
+func (c *noopMCPClient) GetPrompt(context.Context, string, map[string]any) (*mcp.GetPromptResult, error) {
 	return nil, nil
 }
 func (c *noopMCPClient) Ping(context.Context) error                   { return nil }

--- a/internal/aggregator/sso_reconnect_test.go
+++ b/internal/aggregator/sso_reconnect_test.go
@@ -1068,7 +1068,7 @@ func TestBootstrapNewSessionSSO_ConnectsForwardTokenSynchronously(t *testing.T) 
 
 	// No ID token is resolvable (none in context, no usable OAuth proxy entry),
 	// so the forward-token connect fails fast without a network round-trip.
-	agg.bootstrapNewSessionSSO(userID, sessionID, "")
+	agg.bootstrapNewSessionSSO(userID, sessionID, "", "")
 
 	// Synchronous contract: the connect outcome is recorded by the time the call
 	// returns. An asynchronous bootstrap would not have this observable yet.

--- a/internal/aggregator/sso_reconnect_test.go
+++ b/internal/aggregator/sso_reconnect_test.go
@@ -1068,7 +1068,7 @@ func TestBootstrapNewSessionSSO_ConnectsForwardTokenSynchronously(t *testing.T) 
 
 	// No ID token is resolvable (none in context, no usable OAuth proxy entry),
 	// so the forward-token connect fails fast without a network round-trip.
-	agg.bootstrapNewSessionSSO(userID, sessionID, "", "")
+	agg.bootstrapNewSessionSSO(ssoSession{userID: userID, sessionID: sessionID})
 
 	// Synchronous contract: the connect outcome is recorded by the time the call
 	// returns. An asynchronous bootstrap would not have this observable yet.

--- a/internal/aggregator/sso_session.go
+++ b/internal/aggregator/sso_session.go
@@ -1,0 +1,61 @@
+package aggregator
+
+import (
+	"context"
+	"log/slog"
+
+	oauthhandler "github.com/giantswarm/mcp-oauth/handler"
+	"github.com/giantswarm/mcp-oauth/providers"
+
+	"github.com/giantswarm/muster/internal/server"
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// ssoSession captures the token state for a single authenticated request,
+// providing a stable snapshot for the session bootstrap decision.
+type ssoSession struct {
+	userID      string
+	sessionID   string
+	idToken     string
+	bearer      string
+	tokenSource providers.TokenSource
+}
+
+// ssoSessionFromContext extracts the SSO-relevant token state from an
+// authenticated request context.
+func ssoSessionFromContext(ctx context.Context, sessionID string) ssoSession {
+	idToken, _ := server.GetIDTokenFromContext(ctx)
+	bearer := server.GetBearerTokenFromContext(ctx)
+	userInfo, _ := oauthhandler.UserInfoFromContext(ctx)
+	var tokenSource providers.TokenSource
+	if userInfo != nil {
+		tokenSource = userInfo.TokenSource
+	}
+	return ssoSession{
+		userID:      getUserSubjectFromContext(ctx),
+		sessionID:   sessionID,
+		idToken:     idToken,
+		bearer:      bearer,
+		tokenSource: tokenSource,
+	}
+}
+
+// canBootstrapSSO reports whether the session has a usable subject token for
+// establishing localMint backend connections. Returns false when neither an
+// upstream ID token nor a delegated OBO bearer is present — the session cannot
+// drive a token exchange and bootstrapping would fail immediately.
+func (s ssoSession) canBootstrapSSO() bool {
+	return s.idToken != "" || s.tokenSource == providers.TokenSourceOBO
+}
+
+// LogValue implements slog.LogValuer so ssoSession can be passed directly to
+// structured log calls.
+func (s ssoSession) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("userID", logging.TruncateIdentifier(s.userID)),
+		slog.String("sessionID", logging.TruncateIdentifier(s.sessionID)),
+		slog.Int("idTokenLen", len(s.idToken)),
+		slog.Int("bearerLen", len(s.bearer)),
+		slog.String("tokenSource", string(s.tokenSource)),
+	)
+}


### PR DESCRIPTION
Depends on #917. Once that merges, the diff here shrinks to the refactor only.

`bootstrapNewSessionSSO` and `initSSOForSession` took four loose string parameters
(`userID`, `sessionID`, `idToken`, `bearerToken`). Callers extracted and passed them
separately with no compiler help when a call site missed one (e.g. the pool-miss
goroutine was passing `""` as bearer, silently breaking OBO re-init).

Introduces `ssoSession` — a value type built once from the request context at the
`onAuthenticated` call site — and threads it through both functions.

## Changes

- `ssoSession{userID, sessionID, idToken, bearer, tokenSource}` — `tokenSource` is
  `providers.TokenSource`, covering all session kinds; zero value is safe for call
  sites like `ssoLifecycleOptions` that have no inbound bearer
- `canBootstrapSSO()` — `idToken != "" || tokenSource == TokenSourceOBO` — replaces
  the duplicated `idToken == "" && !isOBO` guards in both branches of `onAuthenticated`
- `LogValue() slog.Value` — single `session=` group replacing per-field log arguments
- `ssoSessionFromContext(ctx, sessionID)` — one extraction point, no scattered
  `GetIDTokenFromContext` / `GetBearerTokenFromContext` calls in `onAuthenticated`
- Idiomatic Go: `interface{}` → `any`, `slices.Contains`, dropped unused `sub` param
  from `triggerBackgroundTokenRefresh` / `backgroundTokenRefresh`