### PR TITLE
fix(aggregator): carry actor token into SSO bootstrap context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- localMint backends connected during SSO bootstrap now mint on the on-behalf-of delegation path instead of falling back to M2M. When `initSSOForSession` rebuilt its detached background context it carried the subject bearer and ID token but dropped the inbound `X-Actor-Token`, so a bootstrap-established connection minted with no actor and the broker authorized the per-backend exchange on the human subject (`token_exchange_audience_not_allowed`) rather than the agent ServiceAccount. The per-request credential tokens (subject bearer, actor token, ID token) are now carried into the bootstrap context as one unit, so the bootstrap and live-request paths mint identically.
+- localMint backends connected during SSO bootstrap now mint on the on-behalf-of delegation path instead of falling back to M2M; the bootstrap and live-request paths now carry the same credential bundle.
 
 - Connected MCP clients now receive `notifications/{tools,resources,prompts}/list_changed` when a backend connects after the session was opened (localMint/OBO background bootstrap, post-restart re-init), so late-connecting backends no longer stay invisible for the session's lifetime.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- localMint backends connected during SSO bootstrap now mint on the on-behalf-of delegation path instead of falling back to M2M. When `initSSOForSession` rebuilt its detached background context it carried the subject bearer and ID token but dropped the inbound `X-Actor-Token`, so a bootstrap-established connection minted with no actor and the broker authorized the per-backend exchange on the human subject (`token_exchange_audience_not_allowed`) rather than the agent ServiceAccount. The per-request credential tokens (subject bearer, actor token, ID token) are now carried into the bootstrap context as one unit, so the bootstrap and live-request paths mint identically.
+
 - Connected MCP clients now receive `notifications/{tools,resources,prompts}/list_changed` when a backend connects after the session was opened (localMint/OBO background bootstrap, post-restart re-init), so late-connecting backends no longer stay invisible for the session's lifetime.
 
 - OBO sessions now connect localMint backends. After the emission fix that adds `email` to muster-minted OBO JWTs, `fireOnAuthenticated` fires for OBO requests, but the `onAuthenticated` callback returned early at the `idToken == ""` guard (written to avoid 403-spam for post-restart Dex sessions). The guard is now narrowed: OBO sessions (detected via `userInfo.ActorSubject`) are allowed through. The inbound OBO bearer is threaded into the detached `initSSOForSession` background context and used as the RFC 8693 subject token in `EstablishConnectionWithLocalMint`, falling back from the Dex ID-token lookup when none is present.

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -375,7 +375,7 @@ func (a *AggregatorServer) initSSOForSession(sso ssoSession) {
 	defer cancel()
 	bgCtx = api.WithSubject(bgCtx, sso.userID)
 	bgCtx = api.WithSessionID(bgCtx, sso.sessionID)
-	bgCtx = server.ContextWithCallerTokens(bgCtx, sso.callerTokens())
+	bgCtx = server.ContextWithCallerTokens(bgCtx, sso.tokens)
 
 	var pending []*ServerInfo
 	servers := a.registry.GetAllServers()

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -375,12 +375,7 @@ func (a *AggregatorServer) initSSOForSession(sso ssoSession) {
 	defer cancel()
 	bgCtx = api.WithSubject(bgCtx, sso.userID)
 	bgCtx = api.WithSessionID(bgCtx, sso.sessionID)
-	if sso.idToken != "" {
-		bgCtx = server.ContextWithIDToken(bgCtx, sso.idToken)
-	}
-	if sso.bearer != "" {
-		bgCtx = server.ContextWithBearerToken(bgCtx, sso.bearer)
-	}
+	bgCtx = server.ContextWithCallerTokens(bgCtx, sso.callerTokens())
 
 	var pending []*ServerInfo
 	servers := a.registry.GetAllServers()

--- a/internal/aggregator/connection_helper_test.go
+++ b/internal/aggregator/connection_helper_test.go
@@ -851,6 +851,28 @@ func TestMakeLocalMintHeaderFunc_Delegation(t *testing.T) {
 	require.Equal(t, "Bearer minted-obo", headers["Authorization"])
 }
 
+// The SSO bootstrap path connects backends on a detached context that carries
+// no live request headers, so makeLocalMintHeaderFunc must fall back to the
+// captured actor token. Without it the delegated exchange drops the actor,
+// falls to the M2M branch, and is authorized on the human subject instead of
+// the agent SA.
+func TestMakeLocalMintHeaderFunc_CapturedActorFallback(t *testing.T) {
+	minter := &fakeBackendTokenMinter{result: api.BackendMintResult{AccessToken: "minted-obo"}}
+	api.RegisterBackendTokenMinter(minter)
+	defer api.RegisterBackendTokenMinter(nil)
+
+	userToken := unsignedJWT(t, map[string]any{"sub": "alice", "email": "alice@example.com", "email_verified": true})
+	headerFunc := makeLocalMintHeaderFunc("backend", "be-audience", userToken, "agent-sa-token", nil)
+
+	// Context carries no bearer or actor: the detached bootstrap context.
+	headers := headerFunc(context.Background())
+
+	require.True(t, minter.called)
+	require.Equal(t, userToken, minter.gotReq.SubjectToken)
+	require.Equal(t, "agent-sa-token", minter.gotReq.ActorToken, "captured actor must survive the bootstrap path")
+	require.Equal(t, "Bearer minted-obo", headers["Authorization"])
+}
+
 func TestMakeLocalMintHeaderFunc_EmailUnverifiedFailsClosed(t *testing.T) {
 	minter := &fakeBackendTokenMinter{result: api.BackendMintResult{AccessToken: "should-not-mint"}}
 	api.RegisterBackendTokenMinter(minter)

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1595,7 +1595,7 @@ func (a *AggregatorServer) ssoLifecycleOptions() []oauth.ServerOption {
 				slog.String("familyID", logging.TruncateIdentifier(familyID)),
 				slog.Bool("hasIDToken", idToken != ""),
 				slog.Int("idTokenLen", len(idToken)))
-			a.initSSOForSession(ssoSession{userID: userID, sessionID: familyID, idToken: idToken})
+			a.initSSOForSession(ssoSession{userID: userID, sessionID: familyID, tokens: server.CallerTokens{IDToken: idToken}})
 			a.storeIDTokenForSSO(familyID, userID, idToken)
 		}),
 		// An upstream refresh with no ID token signals a broken refresh chain

--- a/internal/aggregator/sso_session.go
+++ b/internal/aggregator/sso_session.go
@@ -18,14 +18,14 @@ type ssoSession struct {
 	sessionID   string
 	idToken     string
 	bearer      string
+	actorToken  string
 	tokenSource providers.TokenSource
 }
 
 // ssoSessionFromContext extracts the SSO-relevant token state from an
 // authenticated request context.
 func ssoSessionFromContext(ctx context.Context, sessionID string) ssoSession {
-	idToken, _ := server.GetIDTokenFromContext(ctx)
-	bearer := server.GetBearerTokenFromContext(ctx)
+	tokens := server.CallerTokensFromContext(ctx)
 	userInfo, _ := oauthhandler.UserInfoFromContext(ctx)
 	var tokenSource providers.TokenSource
 	if userInfo != nil {
@@ -34,10 +34,17 @@ func ssoSessionFromContext(ctx context.Context, sessionID string) ssoSession {
 	return ssoSession{
 		userID:      getUserSubjectFromContext(ctx),
 		sessionID:   sessionID,
-		idToken:     idToken,
-		bearer:      bearer,
+		idToken:     tokens.IDToken,
+		bearer:      tokens.Bearer,
+		actorToken:  tokens.Actor,
 		tokenSource: tokenSource,
 	}
+}
+
+// callerTokens reconstructs the credential bundle this session carries, for
+// re-injection into a context rebuilt off the request path.
+func (s ssoSession) callerTokens() server.CallerTokens {
+	return server.CallerTokens{IDToken: s.idToken, Bearer: s.bearer, Actor: s.actorToken}
 }
 
 // canBootstrapSSO reports whether the session has a usable subject token for
@@ -56,6 +63,7 @@ func (s ssoSession) LogValue() slog.Value {
 		slog.String("sessionID", logging.TruncateIdentifier(s.sessionID)),
 		slog.Int("idTokenLen", len(s.idToken)),
 		slog.Int("bearerLen", len(s.bearer)),
+		slog.Int("actorTokenLen", len(s.actorToken)),
 		slog.String("tokenSource", string(s.tokenSource)),
 	)
 }

--- a/internal/aggregator/sso_session.go
+++ b/internal/aggregator/sso_session.go
@@ -16,16 +16,13 @@ import (
 type ssoSession struct {
 	userID      string
 	sessionID   string
-	idToken     string
-	bearer      string
-	actorToken  string
+	tokens      server.CallerTokens
 	tokenSource providers.TokenSource
 }
 
 // ssoSessionFromContext extracts the SSO-relevant token state from an
 // authenticated request context.
 func ssoSessionFromContext(ctx context.Context, sessionID string) ssoSession {
-	tokens := server.CallerTokensFromContext(ctx)
 	userInfo, _ := oauthhandler.UserInfoFromContext(ctx)
 	var tokenSource providers.TokenSource
 	if userInfo != nil {
@@ -34,17 +31,9 @@ func ssoSessionFromContext(ctx context.Context, sessionID string) ssoSession {
 	return ssoSession{
 		userID:      getUserSubjectFromContext(ctx),
 		sessionID:   sessionID,
-		idToken:     tokens.IDToken,
-		bearer:      tokens.Bearer,
-		actorToken:  tokens.Actor,
+		tokens:      server.CallerTokensFromContext(ctx),
 		tokenSource: tokenSource,
 	}
-}
-
-// callerTokens reconstructs the credential bundle this session carries, for
-// re-injection into a context rebuilt off the request path.
-func (s ssoSession) callerTokens() server.CallerTokens {
-	return server.CallerTokens{IDToken: s.idToken, Bearer: s.bearer, Actor: s.actorToken}
 }
 
 // canBootstrapSSO reports whether the session has a usable subject token for
@@ -52,7 +41,7 @@ func (s ssoSession) callerTokens() server.CallerTokens {
 // upstream ID token nor a delegated OBO bearer is present — the session cannot
 // drive a token exchange and bootstrapping would fail immediately.
 func (s ssoSession) canBootstrapSSO() bool {
-	return s.idToken != "" || s.tokenSource == providers.TokenSourceOBO
+	return s.tokens.IDToken != "" || s.tokenSource == providers.TokenSourceOBO
 }
 
 // LogValue implements slog.LogValuer so ssoSession can be passed directly to
@@ -61,9 +50,9 @@ func (s ssoSession) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("userID", logging.TruncateIdentifier(s.userID)),
 		slog.String("sessionID", logging.TruncateIdentifier(s.sessionID)),
-		slog.Int("idTokenLen", len(s.idToken)),
-		slog.Int("bearerLen", len(s.bearer)),
-		slog.Int("actorTokenLen", len(s.actorToken)),
+		slog.Int("idTokenLen", len(s.tokens.IDToken)),
+		slog.Int("bearerLen", len(s.tokens.Bearer)),
+		slog.Int("actorTokenLen", len(s.tokens.Actor)),
 		slog.String("tokenSource", string(s.tokenSource)),
 	)
 }

--- a/internal/aggregator/sso_session_test.go
+++ b/internal/aggregator/sso_session_test.go
@@ -1,0 +1,36 @@
+package aggregator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/server"
+)
+
+// ssoSessionFromContext must lift the inbound actor token so the SSO bootstrap
+// can re-present it on the detached context. Dropping it here makes the
+// bootstrap-established localMint connection mint without an actor, which the
+// broker authorizes on the human subject (token_exchange_audience_not_allowed).
+func TestSSOSessionFromContext_CapturesActorToken(t *testing.T) {
+	ctx := api.WithSubject(context.Background(), "alice")
+	ctx = server.ContextWithBearerToken(ctx, "user-bearer")
+	ctx = server.ContextWithActorToken(ctx, "agent-sa-token")
+
+	sso := ssoSessionFromContext(ctx, "session-1")
+
+	require.Equal(t, "alice", sso.userID)
+	require.Equal(t, "user-bearer", sso.bearer)
+	require.Equal(t, "agent-sa-token", sso.actorToken)
+}
+
+func TestSSOSessionFromContext_NoActorToken(t *testing.T) {
+	ctx := api.WithSubject(context.Background(), "alice")
+	ctx = server.ContextWithBearerToken(ctx, "user-bearer")
+
+	sso := ssoSessionFromContext(ctx, "session-1")
+
+	require.Empty(t, sso.actorToken)
+}

--- a/internal/aggregator/sso_session_test.go
+++ b/internal/aggregator/sso_session_test.go
@@ -10,11 +10,7 @@ import (
 	"github.com/giantswarm/muster/internal/server"
 )
 
-// ssoSessionFromContext must lift the inbound actor token so the SSO bootstrap
-// can re-present it on the detached context. Dropping it here makes the
-// bootstrap-established localMint connection mint without an actor, which the
-// broker authorizes on the human subject (token_exchange_audience_not_allowed).
-func TestSSOSessionFromContext_CapturesActorToken(t *testing.T) {
+func TestSSOSessionFromContext_CapturesCallerTokens(t *testing.T) {
 	ctx := api.WithSubject(context.Background(), "alice")
 	ctx = server.ContextWithBearerToken(ctx, "user-bearer")
 	ctx = server.ContextWithActorToken(ctx, "agent-sa-token")
@@ -22,8 +18,8 @@ func TestSSOSessionFromContext_CapturesActorToken(t *testing.T) {
 	sso := ssoSessionFromContext(ctx, "session-1")
 
 	require.Equal(t, "alice", sso.userID)
-	require.Equal(t, "user-bearer", sso.bearer)
-	require.Equal(t, "agent-sa-token", sso.actorToken)
+	require.Equal(t, "user-bearer", sso.tokens.Bearer)
+	require.Equal(t, "agent-sa-token", sso.tokens.Actor)
 }
 
 func TestSSOSessionFromContext_NoActorToken(t *testing.T) {
@@ -32,5 +28,5 @@ func TestSSOSessionFromContext_NoActorToken(t *testing.T) {
 
 	sso := ssoSessionFromContext(ctx, "session-1")
 
-	require.Empty(t, sso.actorToken)
+	require.Empty(t, sso.tokens.Actor)
 }

--- a/internal/server/token_provider.go
+++ b/internal/server/token_provider.go
@@ -76,12 +76,9 @@ func GetActorTokenFromContext(ctx context.Context) string {
 	return token
 }
 
-// CallerTokens is the set of per-request credential tokens that travel together
-// from an inbound request to a downstream backend connection. They are carried
-// as a unit so a context rebuilt off the request path (SSO bootstrap, reconnect,
-// background refresh) cannot silently drop one — a dropped actor token degrades
-// a localMint delegation to the M2M path and authorizes the exchange on the
-// human subject instead of the agent.
+// CallerTokens is the set of per-request credential tokens (subject bearer,
+// ID token, actor) carried as a unit so a context rebuilt off the request path
+// cannot silently drop one.
 type CallerTokens struct {
 	IDToken string
 	Bearer  string
@@ -98,19 +95,12 @@ func CallerTokensFromContext(ctx context.Context) CallerTokens {
 	}
 }
 
-// ContextWithCallerTokens stores each non-empty token on ctx via its dedicated
-// key, so the existing per-field getters observe identical values. Empty fields
-// are left untouched, preserving any value already on ctx.
+// ContextWithCallerTokens stores all three tokens on ctx via their dedicated
+// keys so the per-field getters observe identical values.
 func ContextWithCallerTokens(ctx context.Context, tokens CallerTokens) context.Context {
-	if tokens.IDToken != "" {
-		ctx = ContextWithIDToken(ctx, tokens.IDToken)
-	}
-	if tokens.Bearer != "" {
-		ctx = ContextWithBearerToken(ctx, tokens.Bearer)
-	}
-	if tokens.Actor != "" {
-		ctx = ContextWithActorToken(ctx, tokens.Actor)
-	}
+	ctx = ContextWithIDToken(ctx, tokens.IDToken)
+	ctx = ContextWithBearerToken(ctx, tokens.Bearer)
+	ctx = ContextWithActorToken(ctx, tokens.Actor)
 	return ctx
 }
 

--- a/internal/server/token_provider.go
+++ b/internal/server/token_provider.go
@@ -76,6 +76,44 @@ func GetActorTokenFromContext(ctx context.Context) string {
 	return token
 }
 
+// CallerTokens is the set of per-request credential tokens that travel together
+// from an inbound request to a downstream backend connection. They are carried
+// as a unit so a context rebuilt off the request path (SSO bootstrap, reconnect,
+// background refresh) cannot silently drop one — a dropped actor token degrades
+// a localMint delegation to the M2M path and authorizes the exchange on the
+// human subject instead of the agent.
+type CallerTokens struct {
+	IDToken string
+	Bearer  string
+	Actor   string
+}
+
+// CallerTokensFromContext snapshots the credential tokens present on ctx.
+func CallerTokensFromContext(ctx context.Context) CallerTokens {
+	idToken, _ := GetIDTokenFromContext(ctx)
+	return CallerTokens{
+		IDToken: idToken,
+		Bearer:  GetBearerTokenFromContext(ctx),
+		Actor:   GetActorTokenFromContext(ctx),
+	}
+}
+
+// ContextWithCallerTokens stores each non-empty token on ctx via its dedicated
+// key, so the existing per-field getters observe identical values. Empty fields
+// are left untouched, preserving any value already on ctx.
+func ContextWithCallerTokens(ctx context.Context, tokens CallerTokens) context.Context {
+	if tokens.IDToken != "" {
+		ctx = ContextWithIDToken(ctx, tokens.IDToken)
+	}
+	if tokens.Bearer != "" {
+		ctx = ContextWithBearerToken(ctx, tokens.Bearer)
+	}
+	if tokens.Actor != "" {
+		ctx = ContextWithActorToken(ctx, tokens.Actor)
+	}
+	return ctx
+}
+
 // GetIDToken extracts the ID token from an OAuth2 token.
 // OIDC providers include an id_token in the Extra data.
 // Kubernetes OIDC authentication requires the ID token, not the access token.

--- a/internal/server/token_provider_test.go
+++ b/internal/server/token_provider_test.go
@@ -13,8 +13,6 @@ func TestCallerTokens_RoundTrip(t *testing.T) {
 	ctx := ContextWithCallerTokens(context.Background(), want)
 
 	require.Equal(t, want, CallerTokensFromContext(ctx))
-	// The per-field getters must observe identical values so the non-bootstrap
-	// paths that read them directly are unaffected.
 	id, ok := GetIDTokenFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, "id-tok", id)
@@ -22,20 +20,8 @@ func TestCallerTokens_RoundTrip(t *testing.T) {
 	require.Equal(t, "actor-tok", GetActorTokenFromContext(ctx))
 }
 
-// A dropped actor is the bug this bundle exists to prevent: the round trip must
-// carry every credential token, not just subject/idToken.
 func TestCallerTokens_CarriesActor(t *testing.T) {
 	ctx := ContextWithCallerTokens(context.Background(), CallerTokens{Bearer: "b", Actor: "a"})
 	require.Equal(t, "a", GetActorTokenFromContext(ctx))
 	require.Equal(t, "a", CallerTokensFromContext(ctx).Actor)
-}
-
-// Empty fields must not overwrite values already present on the context.
-func TestContextWithCallerTokens_EmptyFieldsPreserveExisting(t *testing.T) {
-	ctx := ContextWithActorToken(context.Background(), "pre-existing-actor")
-
-	ctx = ContextWithCallerTokens(ctx, CallerTokens{Bearer: "b"})
-
-	require.Equal(t, "pre-existing-actor", GetActorTokenFromContext(ctx), "empty Actor must not clear an existing one")
-	require.Equal(t, "b", GetBearerTokenFromContext(ctx))
 }

--- a/internal/server/token_provider_test.go
+++ b/internal/server/token_provider_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallerTokens_RoundTrip(t *testing.T) {
+	want := CallerTokens{IDToken: "id-tok", Bearer: "bearer-tok", Actor: "actor-tok"}
+
+	ctx := ContextWithCallerTokens(context.Background(), want)
+
+	require.Equal(t, want, CallerTokensFromContext(ctx))
+	// The per-field getters must observe identical values so the non-bootstrap
+	// paths that read them directly are unaffected.
+	id, ok := GetIDTokenFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "id-tok", id)
+	require.Equal(t, "bearer-tok", GetBearerTokenFromContext(ctx))
+	require.Equal(t, "actor-tok", GetActorTokenFromContext(ctx))
+}
+
+// A dropped actor is the bug this bundle exists to prevent: the round trip must
+// carry every credential token, not just subject/idToken.
+func TestCallerTokens_CarriesActor(t *testing.T) {
+	ctx := ContextWithCallerTokens(context.Background(), CallerTokens{Bearer: "b", Actor: "a"})
+	require.Equal(t, "a", GetActorTokenFromContext(ctx))
+	require.Equal(t, "a", CallerTokensFromContext(ctx).Actor)
+}
+
+// Empty fields must not overwrite values already present on the context.
+func TestContextWithCallerTokens_EmptyFieldsPreserveExisting(t *testing.T) {
+	ctx := ContextWithActorToken(context.Background(), "pre-existing-actor")
+
+	ctx = ContextWithCallerTokens(ctx, CallerTokens{Bearer: "b"})
+
+	require.Equal(t, "pre-existing-actor", GetActorTokenFromContext(ctx), "empty Actor must not clear an existing one")
+	require.Equal(t, "b", GetBearerTokenFromContext(ctx))
+}


### PR DESCRIPTION
## What

`initSSOForSession` rebuilds a detached background context to connect a new session's SSO backends. It carried the subject bearer and ID token but dropped the inbound `X-Actor-Token`, so a localMint connection established during bootstrap minted with no actor. The broker (`WorkloadExchangeSubjectToken`) then fell to the M2M branch and authorized the per-backend exchange on the human subject instead of the agent ServiceAccount, failing with `token_exchange_audience_not_allowed`.

The live-request path was unaffected because it reads the actor straight off the request context; only the bootstrap-established connection dropped it.

## Change

- Add `server.CallerTokens{IDToken, Bearer, Actor}` plus `CallerTokensFromContext` / `ContextWithCallerTokens`, carrying the per-request credential tokens as one unit so a context rebuilt off the request path cannot silently drop one.
- Route `ssoSessionFromContext` (read) and the `initSSOForSession` context rebuild (write) through the bundle. The bootstrap and live-request paths now mint identically.
- The existing per-field getters (`GetBearerTokenFromContext`, `GetIDTokenFromContext`, `GetActorTokenFromContext`) are unchanged and `ContextWithCallerTokens` writes through them, so token-exchange, token-forwarding, and dynamic-auth backends observe identical values.

## Tests

- `CallerTokens` round-trip, actor-carried, and empty-preserves-existing.
- `ssoSessionFromContext` captures the actor token.
- localMint header func uses the captured actor on the bootstrap (header-less context) path.