### PR TITLE
fix(aggregator): establish localMint backends for human OBO sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- On-behalf-of sessions now establish their per-backend local-mint connections. A human OBO bearer (muster's own self-issued JWT carrying `sub`=human and an `act` chain, validated as `TokenSourceJWT` with no email claim) was dropped by three checks, so the agent only ever saw the core meta-tools: the OAuth middleware did not fire `onAuthenticated` for an emailless self-issued JWT, `canBootstrapSSO` did not count an `act`-bearing bearer as a usable subject, and `EstablishConnectionWithLocalMint` resolved the local-mint subject from the upstream ID token (which carries no `act`) instead of the inbound OBO bearer. The OAuth middleware now fires `onAuthenticated` for a self-issued JWT, `canBootstrapSSO` accepts a bearer carrying an `act` claim, and local-mint uses that bearer as the exchange subject so the broker re-binds the delegation chain to each backend audience.
+
 - M2M (no-actor) local-mint exchanges now mint with the granted subject. A workload group grant's `granted.subject` was dropped on the local-mint broker path, so an impersonating exchange minted the workload ServiceAccount's own `sub` instead of the configured impersonated user (granted groups were already applied). The broker now forwards the granted subject to the local-mint provider.
 
 - local-mint backends are now treated as session-based for tool registration. `isServerSSOBased` did not recognize the local-mint auth mode, so the aggregator event handler attempted global registration for a local-mint backend (which has no global persistent client), failed on 401, and the backend's tools never reached the caller. local-mint now joins token forwarding and token exchange as a per-session auth mode.

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -461,12 +461,25 @@ func EstablishConnectionWithLocalMint(
 		return nil, err
 	}
 
-	subjectToken := getIDTokenForForwarding(ctx, sessionID, musterIssuer, a.sessionRefresher())
+	// An on-behalf-of session presents muster's own self-issued bearer
+	// (sub=human, act=agent). It must be the exchange subject so the broker
+	// re-binds the delegation chain to the backend audience and authorizes on
+	// the acting principal. getIDTokenForForwarding returns the upstream Dex ID
+	// token, which carries no act claim and forces the bare-human workload path
+	// (token_exchange_audience_not_allowed).
+	var subjectToken string
+	if bearer := server.GetBearerTokenFromContext(ctx); bearer != "" {
+		if hasAct, err := pkgoauth.HasActClaim(bearer); err == nil && hasAct {
+			subjectToken = bearer
+		}
+	}
 	if subjectToken == "" {
-		// OBO sessions carry no Dex ID token; the muster-issued bearer is the
-		// RFC 8693 subject for the localMint exchange. Fall back to it here so
-		// the background bgCtx (which has the bearer threaded in by
-		// initSSOForSession) can still establish the per-backend connection.
+		subjectToken = getIDTokenForForwarding(ctx, sessionID, musterIssuer, a.sessionRefresher())
+	}
+	if subjectToken == "" {
+		// No upstream Dex ID token (e.g. an OBO session whose bearer carries no
+		// decodable act, or a background context); fall back to the raw bearer
+		// threaded in by initSSOForSession.
 		subjectToken = server.GetBearerTokenFromContext(ctx)
 	}
 	if subjectToken == "" {

--- a/internal/aggregator/sso_session.go
+++ b/internal/aggregator/sso_session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/giantswarm/muster/internal/server"
 	"github.com/giantswarm/muster/pkg/logging"
+	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 )
 
 // ssoSession captures the token state for a single authenticated request,
@@ -41,7 +42,15 @@ func ssoSessionFromContext(ctx context.Context, sessionID string) ssoSession {
 // upstream ID token nor a delegated OBO bearer is present — the session cannot
 // drive a token exchange and bootstrapping would fail immediately.
 func (s ssoSession) canBootstrapSSO() bool {
-	return s.tokens.IDToken != "" || s.tokenSource == providers.TokenSourceOBO
+	if s.tokens.IDToken != "" || s.tokenSource == providers.TokenSourceOBO {
+		return true
+	}
+	// A self-issued on-behalf-of bearer (sub=human, act=agent) carries no
+	// separate upstream ID token and validates as TokenSourceJWT rather than
+	// TokenSourceOBO, but it is a usable localMint subject: the broker re-binds
+	// it to the backend audience on the embedded act principal.
+	hasAct, err := pkgoauth.HasActClaim(s.tokens.Bearer)
+	return err == nil && hasAct
 }
 
 // LogValue implements slog.LogValuer so ssoSession can be passed directly to

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -327,6 +327,22 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 			if s.injectExternalIDToken(w, r, ctx, next) {
 				return
 			}
+			// A self-issued JWT with no email is muster's own on-behalf-of bearer
+			// (sub=human, act=agent): the delegated token carries the human in sub
+			// and no email claim. It still needs onAuthenticated so the per-backend
+			// localMint SSO connections bootstrap; the mint reads the act-bearing
+			// bearer from context. Without this an agent run only ever sees the
+			// core meta-tools because no backend connection is established.
+			if userInfo.IsJWT() {
+				if sessionID, ok := oauthhandler.SessionIDFromContext(ctx); ok {
+					ctx = api.WithSessionID(ctx, sessionID)
+					ctx = api.WithSubject(ctx, userInfo.ID)
+					r = r.WithContext(ctx)
+					s.fireOnAuthenticated(ctx)
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
 			if s.debug {
 				logging.Debug("OAuth", "User info has no email, proceeding without token injection")
 			}

--- a/pkg/oauth/jwt.go
+++ b/pkg/oauth/jwt.go
@@ -25,8 +25,15 @@ var jwtParser = jwt.NewParser(jwt.WithPaddingAllowed())
 // tokens. Using one struct keeps the accessors symmetrical.
 type tokenClaims struct {
 	jwt.RegisteredClaims
-	Email         string `json:"email,omitempty"`
-	EmailVerified bool   `json:"email_verified,omitempty"`
+	Email         string      `json:"email,omitempty"`
+	EmailVerified bool        `json:"email_verified,omitempty"`
+	Act           *actorClaim `json:"act,omitempty"`
+}
+
+// actorClaim mirrors the RFC 8693 §4.4 act claim. Only presence is needed by
+// callers in this package; the broker walks the nested chain.
+type actorClaim struct {
+	Subject string `json:"sub,omitempty"`
 }
 
 func parseUnverified(token string) (tokenClaims, error) {
@@ -91,6 +98,17 @@ func Issuer(token string) (string, error) {
 		return "", fmt.Errorf("decode token: %w", err)
 	}
 	return c.Issuer, nil
+}
+
+// HasActClaim reports whether a trusted JWT carries an RFC 8693 §4.4 act
+// claim, i.e. it is a delegation (on-behalf-of) token. Returns false with a
+// wrapped error on decode failure.
+func HasActClaim(token string) (bool, error) {
+	c, err := parseUnverified(token)
+	if err != nil {
+		return false, fmt.Errorf("decode token: %w", err)
+	}
+	return c.Act != nil, nil
 }
 
 // IsExpired reports whether a trusted JWT's exp claim is in the past or


### PR DESCRIPTION
## What

A human on-behalf-of session presents muster's own self-issued JWT (`sub`=human, `act`=agent), validated as `TokenSourceJWT` with no email claim. Three checks each dropped it, so an OBO session only ever saw the core meta-tools (no backend tools):

1. `createAccessTokenInjectorMiddleware` did not fire `onAuthenticated` for an emailless self-issued JWT, so per-backend SSO bootstrap never ran.
2. `canBootstrapSSO` required an upstream ID token or `TokenSourceOBO` and did not treat an `act`-bearing bearer as a usable subject.
3. `EstablishConnectionWithLocalMint` resolved the local-mint subject from the upstream ID token (which carries no `act`), shadowing the inbound OBO bearer.

This change:
- fires `onAuthenticated` for a self-issued JWT when a session is present;
- accepts a bearer carrying an `act` claim in `canBootstrapSSO`;
- feeds that bearer as the local-mint exchange subject, so the broker re-binds the delegation chain to each backend audience.

Adds `pkg/oauth.HasActClaim`.

## Why

On the glean OBO path, `x_kubernetes_*` / `x_prometheus_*` never appeared for a human agent run; only the 28 core tools did. With these fixes the agent session bootstraps its backends and the per-backend local-mint succeeds. Live on glean the agent lists pods as the human identity.

## Note

Full identity propagation (email and groups in the minted token) also needs giantswarm/mcp-oauth#489; this PR covers the muster-side session and subject-selection fixes and is independent at compile time (builds against mcp-oauth v0.18.5). BDD scenarios for the emailless self-issued-bearer rebind path are a follow-up.