### PR TITLE
perf(workflow): resolve session tool set once per workflow list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Workflow listing no longer rebuilds the session tool set once per workflow. `getWorkflows` evaluated each workflow's availability independently, and every check resolved the caller's full session-scoped tool set (`GetAllToolsForSession` across all backend MCP servers) from scratch — an O(workflows) blow-up that made `core_workflow_list` take ~30 s for ~280 workflows. The list path now installs a request-scoped memo (`api.SessionToolMemo`) so the session tool set is resolved once for the whole request and shared across all per-workflow availability checks. Single-workflow paths are unchanged (no memo, same per-call behavior).
+
 - M2M (no-actor) local-mint exchanges now mint with the granted subject. A workload group grant's `granted.subject` was dropped on the local-mint broker path, so an impersonating exchange minted the workload ServiceAccount's own `sub` instead of the configured impersonated user (granted groups were already applied). The broker now forwards the granted subject to the local-mint provider.
 
 - local-mint backends are now treated as session-based for tool registration. `isServerSSOBased` did not recognize the local-mint auth mode, so the aggregator event handler attempted global registration for a local-mint backend (which has no global persistent client), failed on 401, and the backend's tools never reached the caller. local-mint now joins token forwarding and token exchange as a per-session auth mode.

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -2217,18 +2217,35 @@ func (a *AggregatorServer) MissingToolsForSession(ctx context.Context, toolNames
 		sessionTools    map[string]struct{}
 		sessionResolved bool
 	)
-	// resolveSessionTools lazily builds the session-scoped tool set so the
-	// (potentially store-backed) rebuild happens at most once per call, and
-	// only when a non-core tool actually needs it.
+	// build performs the (potentially store-backed) rebuild of the
+	// session-scoped tool set. It is invoked at most once per call locally, and
+	// — when the context carries a SessionToolMemo — at most once across every
+	// availability check sharing that memo (e.g. all workflows in one list
+	// request), removing the O(items) rebuild blow-up.
+	build := func() map[string]struct{} {
+		tools := a.GetToolsForSession(ctx, sessionID)
+		set := make(map[string]struct{}, len(tools))
+		for _, tool := range tools {
+			set[tool.Name] = struct{}{}
+		}
+		return set
+	}
+
+	// resolveSessionTools lazily resolves the session-scoped tool set so the
+	// rebuild happens only when a non-core tool actually needs it. If the
+	// context carries a request-scoped memo, the set is resolved through it so
+	// it is built once across the whole request; otherwise it is built once per
+	// call (preserving prior behavior outside list requests).
+	memo := api.SessionToolMemoFromContext(ctx)
 	resolveSessionTools := func() map[string]struct{} {
 		if sessionResolved {
 			return sessionTools
 		}
 		sessionResolved = true
-		tools := a.GetToolsForSession(ctx, sessionID)
-		sessionTools = make(map[string]struct{}, len(tools))
-		for _, tool := range tools {
-			sessionTools[tool.Name] = struct{}{}
+		if memo != nil {
+			sessionTools = memo.Resolve(build)
+		} else {
+			sessionTools = build()
 		}
 		return sessionTools
 	}

--- a/internal/aggregator/server_test.go
+++ b/internal/aggregator/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1316,5 +1317,78 @@ func TestAggregatorServer_MissingToolsForSession(t *testing.T) {
 		})
 		assert.Equal(t, []string{"x_this_tool_does_not_exist"}, missing,
 			"only the genuinely missing tool is returned, deduplicated and in input order")
+	})
+}
+
+// countingCapStore wraps a CapabilityStore and counts Get calls, so a test can
+// observe how many times the (expensive) session tool set is rebuilt.
+type countingCapStore struct {
+	oauthstore.CapabilityStore
+	gets atomic.Int64
+}
+
+func (s *countingCapStore) Get(ctx context.Context, sessionID, serverName string) (*oauthstore.Capabilities, error) {
+	s.gets.Add(1)
+	return s.CapabilityStore.Get(ctx, sessionID, serverName)
+}
+
+// TestAggregatorServer_MissingToolsForSession_SessionToolMemo is the regression
+// guard for the O(workflows) session-tool-rebuild blow-up: a request that checks
+// many items' availability (e.g. listing ~280 workflows) must resolve the
+// session's accessible tool set once for the whole request, not once per item.
+//
+// Each MissingToolsForSession call resolves the session set by reading every
+// auth-protected server's capabilities from the store. With two such servers,
+// one rebuild costs two store.Get calls. Without a memo the rebuild repeats per
+// call; with a request-scoped memo in ctx it happens exactly once.
+func TestAggregatorServer_MissingToolsForSession_SessionToolMemo(t *testing.T) {
+	const sessionID = "session-memo"
+
+	newAgg := func(t *testing.T) (*AggregatorServer, *countingCapStore, func()) {
+		t.Helper()
+		reg := NewServerRegistry("x")
+		registerAuthFamilyMember(t, reg, "mc1-mcp-kubernetes", "kubernetes", "management_cluster")
+		registerAuthFamilyMember(t, reg, "mc2-mcp-kubernetes", "kubernetes", "management_cluster")
+
+		base := oauthstore.NewInMemoryCapabilityStore(30 * time.Minute)
+		ctx := context.Background()
+		require.NoError(t, base.Set(ctx, sessionID, "mc1-mcp-kubernetes",
+			&oauthstore.Capabilities{Tools: []mcp.Tool{{Name: "list", Description: "List resources"}}}))
+		require.NoError(t, base.Set(ctx, sessionID, "mc2-mcp-kubernetes",
+			&oauthstore.Capabilities{Tools: []mcp.Tool{{Name: "list", Description: "List resources"}}}))
+
+		store := &countingCapStore{CapabilityStore: base}
+		a := &AggregatorServer{registry: reg, capabilityStore: store}
+		return a, store, base.Stop
+	}
+
+	// checkN simulates checking N items' availability, each resolving the same
+	// session-scoped tool — the workflow-list access pattern.
+	checkN := func(a *AggregatorServer, ctx context.Context, n int) {
+		for i := 0; i < n; i++ {
+			a.MissingToolsForSession(ctx, []string{"x_kubernetes_list"})
+		}
+	}
+
+	t.Run("without a memo the session tool set is rebuilt per check", func(t *testing.T) {
+		a, store, stop := newAgg(t)
+		defer stop()
+
+		ctx := api.WithSessionID(context.Background(), sessionID)
+		store.gets.Store(0)
+		checkN(a, ctx, 3)
+		assert.Equal(t, int64(6), store.gets.Load(),
+			"three checks rebuild the session set three times (two auth servers each)")
+	})
+
+	t.Run("with a memo the session tool set is built once for the whole request", func(t *testing.T) {
+		a, store, stop := newAgg(t)
+		defer stop()
+
+		ctx := api.WithSessionToolMemo(api.WithSessionID(context.Background(), sessionID))
+		store.gets.Store(0)
+		checkN(a, ctx, 3)
+		assert.Equal(t, int64(2), store.gets.Load(),
+			"the request-scoped memo collapses N rebuilds into one (two auth servers, once)")
 	})
 }

--- a/internal/api/session_tool_cache.go
+++ b/internal/api/session_tool_cache.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"context"
+	"sync"
+)
+
+// SessionToolMemo caches a session's resolved accessible-tool set for the
+// duration of a single request, so callers that perform many per-item
+// availability checks (e.g. listing N workflows) rebuild the session tool set
+// at most once instead of once per item.
+//
+// The accessible-tool set is identical for every item in one list request, yet
+// resolving it is expensive (a full rebuild across all backend MCP servers).
+// Without the memo, a workflow list of N entries rebuilds it N times — the
+// O(workflows) blow-up that made /api/muster/workflows take ~30 s.
+type SessionToolMemo struct {
+	mu    sync.Mutex
+	tools map[string]struct{}
+	done  bool
+}
+
+// sessionToolMemoContextKey is the context key under which a SessionToolMemo is
+// carried for the lifetime of a request.
+type sessionToolMemoContextKey struct{}
+
+// WithSessionToolMemo returns a context carrying an empty SessionToolMemo. It is
+// idempotent: if the context already carries a memo, the same context is
+// returned unchanged so nested scopes share one cache.
+func WithSessionToolMemo(ctx context.Context) context.Context {
+	if SessionToolMemoFromContext(ctx) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionToolMemoContextKey{}, &SessionToolMemo{})
+}
+
+// SessionToolMemoFromContext returns the SessionToolMemo carried by ctx, or nil
+// when none is present. Callers outside a memo-scoped request get nil and keep
+// their per-call behavior.
+func SessionToolMemoFromContext(ctx context.Context) *SessionToolMemo {
+	memo, _ := ctx.Value(sessionToolMemoContextKey{}).(*SessionToolMemo)
+	return memo
+}
+
+// Resolve returns the cached session tool set, invoking build exactly once to
+// populate it on first use. Subsequent calls return the cached set without
+// calling build again. Safe for concurrent use.
+func (m *SessionToolMemo) Resolve(build func() map[string]struct{}) map[string]struct{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.done {
+		m.tools = build()
+		m.done = true
+	}
+	return m.tools
+}

--- a/internal/api/session_tool_cache_test.go
+++ b/internal/api/session_tool_cache_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSessionToolMemo_ResolveBuildsOnce(t *testing.T) {
+	memo := &SessionToolMemo{}
+	calls := 0
+	build := func() map[string]struct{} {
+		calls++
+		return map[string]struct{}{"a": {}, "b": {}}
+	}
+
+	first := memo.Resolve(build)
+	second := memo.Resolve(build)
+
+	if calls != 1 {
+		t.Fatalf("build invoked %d times, want exactly 1", calls)
+	}
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("resolved sets have unexpected size: first=%d second=%d", len(first), len(second))
+	}
+}
+
+func TestSessionToolMemoFromContext_AbsentReturnsNil(t *testing.T) {
+	if memo := SessionToolMemoFromContext(context.Background()); memo != nil {
+		t.Fatalf("expected nil memo on a bare context, got %v", memo)
+	}
+}
+
+func TestWithSessionToolMemo_PresentAndIdempotent(t *testing.T) {
+	ctx := WithSessionToolMemo(context.Background())
+	memo := SessionToolMemoFromContext(ctx)
+	if memo == nil {
+		t.Fatal("expected a memo to be present after WithSessionToolMemo")
+	}
+
+	// Re-wrapping must not replace the existing memo, so a shared request keeps
+	// one cache.
+	ctx2 := WithSessionToolMemo(ctx)
+	if got := SessionToolMemoFromContext(ctx2); got != memo {
+		t.Fatal("WithSessionToolMemo must be idempotent and reuse the existing memo")
+	}
+}

--- a/internal/workflow/api_adapter.go
+++ b/internal/workflow/api_adapter.go
@@ -216,6 +216,12 @@ func (a *Adapter) getWorkflows(ctx context.Context) []api.Workflow {
 		return []api.Workflow{}
 	}
 
+	// Every workflow's availability check resolves the same session tool set.
+	// Install a request-scoped memo so that expensive resolution happens once
+	// for the whole list instead of once per workflow (the O(workflows)
+	// rebuild that made this endpoint take ~30 s for ~280 workflows).
+	ctx = api.WithSessionToolMemo(ctx)
+
 	workflows := make([]api.Workflow, 0, len(workflowCRDs))
 	for _, workflowCRD := range workflowCRDs {
 		workflow := a.convertCRDToWorkflow(&workflowCRD)


### PR DESCRIPTION
## Summary

`core_workflow_list` (the `/api/muster/workflows` backend) took ~30s for ~280 workflows. Root cause is entirely an O(workflows) blow-up in availability evaluation, not payload size or rendering.

`getWorkflows` evaluates each workflow's availability independently:

```
getWorkflows --(x N workflows)--> isWorkflowAvailable -> findMissingTools
  -> toolChecker.MissingToolsForSession -> GetToolsForSession
  -> registry.GetAllToolsForSession (rebuilds the full session tool set across all backend MCP servers)
```

The session's accessible tool set is **identical for every workflow in one list request**, yet it was rebuilt **once per workflow** (~100ms x 282 ≈ the observed 30s).

## Fix

Resolve the session tool set once per request and share it across all per-workflow availability checks:

- New `internal/api/session_tool_cache.go`: `SessionToolMemo` with `WithSessionToolMemo(ctx)` (idempotent), `SessionToolMemoFromContext(ctx)` (nil when absent), and `Resolve(build)` (builds once, caches).
- `internal/aggregator/server.go` `MissingToolsForSession`: when a memo is present in ctx, resolve the session tool set through `memo.Resolve(...)`; otherwise keep the existing per-call build.
- `internal/workflow/api_adapter.go` `getWorkflows`: install the memo once on ctx before the per-workflow loop.

Semantics (including transitive nested-workflow checks) are unchanged; only redundant rebuilds are removed. Single-workflow paths carry no memo and keep current behavior. Expected: ~30s -> sub-second.

## Test plan

- [x] `go build ./internal/...`
- [x] `internal/api`: memo builds once, `From` returns nil when absent, `With` is idempotent
- [x] `internal/aggregator`: `MissingToolsForSession` with a memo in ctx resolves the session set once across N checks (2 store reads), without a memo rebuilds per check (6 reads for 3 checks); existing `#764` session-awareness tests still pass
- [x] `go vet` + `golangci-lint` clean
- [ ] Re-measure `/api/muster/workflows` TTFB on the gazelle devportal after the release lands on the cluster (expect <1s)

Made with [Cursor](https://cursor.com)