### PR TITLE
fix(aggregator): pass resolved exchange config to the refresh closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Token re-exchange on the persistent oidc-exchange connection now uses the resolved per-connection config. The initial-connection path handed the refresh closure the shared spec-only `TokenExchange` pointer (which, since [#940](https://github.com/giantswarm/muster/pull/940), deliberately never carries the runtime-resolved credentials or appended `requiredAudiences` scopes), so every re-exchange after the first token neared expiry ran without client credentials — failing outright against a Dex requiring client auth and evicting the session back to `Auth Required` — and without the required audiences, minting tokens the downstream server rejects. ([#942](https://github.com/giantswarm/muster/issues/942))
+
 - Data race in the token-forwarding and localMint connection header functions. Both mutate per-connection failure counters, which mcp-go invokes concurrently from the listener goroutine and tool-call goroutines, so under load the stale-connection eviction could double-fire (double eviction/revoke). The counters are now mutex-guarded. ([#939](https://github.com/giantswarm/muster/issues/939))
 
 - Token-exchange (oidc-exchange) backends no longer get stuck in `Auth Required` once their exchanged token expires. The persistent aggregator connection now re-exchanges a fresh token before expiry, and evicts itself only when the subject token can no longer be refreshed.

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -821,7 +821,7 @@ func EstablishConnectionWithTokenExchange(
 	// the subject can no longer be refreshed, so the listener stops instead of
 	// looping an expired token and the state settles to Auth Required.
 	reexchange, onStaleToken := a.makeTokenExchangeRefreshClosures(
-		serverInfo.Name, sessionID, userID, musterIssuer, oauthHandler, serverInfo.AuthConfig.TokenExchange,
+		serverInfo.Name, sessionID, userID, musterIssuer, oauthHandler, &exchangeConfig,
 	)
 
 	headerFunc := makeTokenExchangeHeaderFunc(serverInfo.Name, exchangedToken, tokenExpiry, reexchange, onStaleToken)

--- a/internal/aggregator/connection_helper_test.go
+++ b/internal/aggregator/connection_helper_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/muster/internal/server"
 	"github.com/giantswarm/muster/pkg/logging"
 
+	mcpgoserver "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1361,4 +1362,95 @@ func TestBuildConnectionTokenExchangeConfig_NoAudiences(t *testing.T) {
 	assert.Equal(t, "cid", cfg.ClientID)
 	assert.Empty(t, base.ClientID, "shared definition must not be mutated")
 	assert.Equal(t, "openid profile", base.Scopes)
+}
+
+// TestEstablishConnectionWithTokenExchange_RefreshUsesResolvedConfig pins the
+// wiring at the real call site: the refresh closures behind the persistent
+// connection's header func must receive the resolved per-connection exchange
+// config (client credentials + appended audience scopes), not the shared
+// spec-only serverInfo.AuthConfig.TokenExchange pointer. With the shared
+// pointer, every re-exchange after the initial token neared expiry ran without
+// client credentials and without requiredAudiences.
+//
+// The initial exchange deliberately returns a token already inside
+// tokenExchangeRefreshMargin, so the first header invocation during
+// client.Initialize triggers a re-exchange synchronously — the second captured
+// config is the one the refresh closure actually uses.
+func TestEstablishConnectionWithTokenExchange_RefreshUsesResolvedConfig(t *testing.T) {
+	var logBuf bytes.Buffer
+	logging.InitForCLI(logging.LevelDebug, &logBuf)
+
+	// Fake downstream MCP server for the exchanged-token connection.
+	downstream := mcpgoserver.NewTestStreamableHTTPServer(
+		mcpgoserver.NewMCPServer("downstream", "1.0.0", mcpgoserver.WithToolCapabilities(true)),
+	)
+	t.Cleanup(downstream.Close)
+
+	subjectToken := unsignedJWT(t, map[string]any{"sub": "alice", "exp": time.Now().Add(time.Hour).Unix()})
+
+	var mu sync.Mutex
+	var gotConfigs []api.TokenExchangeConfig
+	mock := &issuerMockOAuthHandler{
+		enabled: true,
+		getFullTokenFunc: func(string, string) *api.OAuthToken {
+			return &api.OAuthToken{IDToken: subjectToken}
+		},
+		exchangeFunc: func(_ context.Context, _, _ string, config *api.TokenExchangeConfig) (string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			gotConfigs = append(gotConfigs, *config)
+			if len(gotConfigs) == 1 {
+				// Already within tokenExchangeRefreshMargin: forces re-exchange
+				// on the first header invocation.
+				return unsignedJWT(t, map[string]any{"exp": time.Now().Add(time.Minute).Unix()}), nil
+			}
+			return unsignedJWT(t, map[string]any{"exp": time.Now().Add(time.Hour).Unix()}), nil
+		},
+	}
+	api.RegisterOAuthHandler(mock)
+	t.Cleanup(func() { api.RegisterOAuthHandler(nil) })
+
+	api.RegisterSecretCredentialsHandler(&mockSecretCredentialsHandler{
+		credentials: &api.ClientCredentials{ClientID: "resolved-client-id", ClientSecret: "resolved-client-secret"},
+	})
+	t.Cleanup(func() { api.RegisterSecretCredentialsHandler(nil) })
+
+	shared := &api.TokenExchangeConfig{
+		Enabled:                    true,
+		DexTokenEndpoint:           "https://dex.remote.example/token",
+		ConnectorID:                "cluster-a-dex",
+		Scopes:                     "openid profile email groups",
+		ClientCredentialsSecretRef: &api.ClientCredentialsSecretRef{Name: "creds"},
+	}
+	serverInfo := &ServerInfo{
+		Name: "remote-srv",
+		URL:  downstream.URL,
+		AuthConfig: &api.MCPServerAuth{
+			TokenExchange:     shared,
+			RequiredAudiences: []string{"dex-k8s-authenticator"},
+		},
+	}
+
+	ctx := api.WithSessionID(api.WithSubject(context.Background(), "alice"), "sess-1")
+	result, err := EstablishConnectionWithTokenExchange(ctx, &AggregatorServer{}, serverInfo, "https://muster.example.com")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = result.Client.Close() })
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(gotConfigs), 2,
+		"initialize must trigger a re-exchange through the refresh closure")
+	for i, cfg := range gotConfigs {
+		assert.Equal(t, "resolved-client-id", cfg.ClientID,
+			"exchange call %d must carry the resolved client ID", i)
+		assert.Equal(t, "resolved-client-secret", cfg.ClientSecret,
+			"exchange call %d must carry the resolved client secret", i)
+		assert.Contains(t, cfg.Scopes, "dex-k8s-authenticator",
+			"exchange call %d must carry the appended audience scopes", i)
+	}
+
+	// The shared registry definition stays spec-only (giantswarm/giantswarm#37060).
+	assert.Empty(t, shared.ClientID)
+	assert.Empty(t, shared.ClientSecret)
+	assert.Equal(t, "openid profile email groups", shared.Scopes)
 }


### PR DESCRIPTION
## What

Pass the resolved per-connection exchange config (`&exchangeConfig`) to `makeTokenExchangeRefreshClosures` in `EstablishConnectionWithTokenExchange`, instead of the shared spec-only `serverInfo.AuthConfig.TokenExchange` registry pointer.

## Why

Found while analyzing #942 (see [this comment](https://github.com/giantswarm/muster/issues/942#issuecomment-4865287814)). #938 wired the token-refresh closures into both exchange paths, but inconsistently:

- `server.go` (tool-call path) correctly passes `&exchangeConfig` — the resolved copy carrying client credentials and appended `requiredAudiences` scopes.
- `connection_helper.go` (initial-connection path) passed the shared registry pointer, which since #940 is deliberately never mutated and therefore carries **no** resolved `ClientID`/`ClientSecret` and **no** audience scopes.

That violates the contract documented on `makeTokenExchangeRefreshClosures` itself (*"exchangeConfig must already carry resolved client credentials and audience scopes"*). Consequence on the persistent connection, once the exchanged token nears expiry (~25 min with Dex defaults):

- Against a remote Dex requiring client auth, every re-exchange fails; after 3 consecutive failures the connection is evicted and the session drops back to `Auth Required`.
- Even a successful re-exchange mints a token missing the required audiences, so downstream calls 401.

## Test

The new regression test exercises the **real call site** end-to-end (the existing closure unit test only asserted pass-through of whatever config it was given): a fake streamable-HTTP MCP server plus a mock exchange handler whose first exchange returns a token already inside the refresh margin, so `client.Initialize` synchronously triggers a re-exchange through the closure. The test asserts every exchange call carries the resolved credentials and audience scopes, and that the shared registry config stays untouched (carrying over the #940 churn assertions).

Verified the test fails against the unfixed code with exactly the predicted symptom (re-exchange config has empty credentials, spec-only scopes) and passes with the fix. Full `internal/aggregator` suite green with `-race`.

Refs #942, follow-up to #938/#940. The #942 refactor will land separately on top of this.
