### PR TITLE
fix: empty team ownership label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Team ownership label. `application.giantswarm.io/team` now renders `bumblebee` instead of an empty string: the labels helper looked up the annotation under the wrong key (`application.giantswarm.io/team`) instead of the OCI key `io.giantswarm.application.team` set in `Chart.yaml`.
+
+
 ### Removed
 
 - M2M (machine-to-machine) token exchange. The `oauth.server.tokenExchangeBroker.workloadAudiences`, `workloadGroupGrants`, and `actorDelegationPolicy` config keys are removed, along with broker-granted identity injection (`granted.subject` / `granted.groups`). On-behalf-of (OBO) delegation is unchanged and now accepts any actor validated against the trusted issuers; the impersonated subject's downstream authorization governs access. Requires mcp-oauth v0.18.7.

--- a/helm/muster/templates/_helpers.tpl
+++ b/helm/muster/templates/_helpers.tpl
@@ -40,7 +40,7 @@ helm.sh/chart: {{ include "muster.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The `muster.labels` helper looked up the team annotation under key `application.giantswarm.io/team`, but `Chart.yaml` defines it under the OCI-standard key `io.giantswarm.application.team`. The lookup missed, so every muster resource rendered `application.giantswarm.io/team: ""` and nothing team-derived (metrics, dashboards, alert routing) attributed to bumblebee.

Points the helper at the correct annotation key. `helm template` now renders `application.giantswarm.io/team: "bumblebee"`.