### PR TITLE
docs(crd): add example CRs for the docs CRD reference

### DIFF
--- a/docs/cr/muster.giantswarm.io_v1alpha1_mcpserver.yaml
+++ b/docs/cr/muster.giantswarm.io_v1alpha1_mcpserver.yaml
@@ -1,0 +1,14 @@
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: git-tools
+  namespace: default
+spec:
+  type: stdio
+  autoStart: true
+  command: npx
+  args: ["@modelcontextprotocol/server-git"]
+  env:
+    GIT_ROOT: "/workspace"
+    LOG_LEVEL: "info"
+  description: "Git tools MCP server for repository operations"

--- a/docs/cr/muster.giantswarm.io_v1alpha1_workflow.yaml
+++ b/docs/cr/muster.giantswarm.io_v1alpha1_workflow.yaml
@@ -24,17 +24,17 @@ spec:
       args:
         name: "{{.input.app_name}}"
         tag: "{{.input.environment}}-latest"
-      store: true
+      output: true
     - id: deploy_service
       tool: kubectl_apply
       args:
         name: "{{.input.app_name}}-{{.input.environment}}"
         image: "{{.results.build_image.image_id}}"
         replicas: "{{.input.replicas}}"
-      store: true
+      output: true
     - id: verify_deployment
       tool: health_check
       args:
         service_name: "{{.results.deploy_service.name}}"
         timeout: "5m"
-      store: true
+      output: true

--- a/docs/cr/muster.giantswarm.io_v1alpha1_workflow.yaml
+++ b/docs/cr/muster.giantswarm.io_v1alpha1_workflow.yaml
@@ -1,0 +1,40 @@
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: Workflow
+metadata:
+  name: deploy-application
+  namespace: default
+spec:
+  description: "Deploy application to production environment with validation"
+  args:
+    app_name:
+      type: string
+      required: true
+      description: "Name of the application to deploy"
+    environment:
+      type: string
+      default: "production"
+      description: "Target deployment environment"
+    replicas:
+      type: integer
+      default: 3
+      description: "Number of application replicas"
+  steps:
+    - id: build_image
+      tool: docker_build
+      args:
+        name: "{{.input.app_name}}"
+        tag: "{{.input.environment}}-latest"
+      store: true
+    - id: deploy_service
+      tool: kubectl_apply
+      args:
+        name: "{{.input.app_name}}-{{.input.environment}}"
+        image: "{{.results.build_image.image_id}}"
+        replicas: "{{.input.replicas}}"
+      store: true
+    - id: verify_deployment
+      tool: health_check
+      args:
+        service_name: "{{.results.deploy_service.name}}"
+        timeout: "5m"
+      store: true


### PR DESCRIPTION
## What

Adds correctly-named, single-document example CRs under `docs/cr/`:

- `docs/cr/muster.giantswarm.io_v1alpha1_workflow.yaml`
- `docs/cr/muster.giantswarm.io_v1alpha1_mcpserver.yaml`

## Why

We're publishing muster's CRDs on the [Giant Swarm CRD reference](https://docs.giantswarm.io/reference/platform-api/crd/)
(companion PR in `giantswarm/docs`). The generator
([`crd-docs-generator`](https://github.com/giantswarm/crd-docs-generator))
only attaches an example to a CRD page when it finds a file named **exactly**
`{group}_{version}_{singular}.yaml` sitting **directly** in a configured
`cr_paths` directory, with **one resource per file**.

Our existing `examples/` files don't match that convention (wrong names, and
`mcpserver-example.yaml` bundles six resources in one file), so these dedicated
files are added for the docs generator. Content is adapted from the existing
`examples/` so it stays representative.

## Notes

- Once merged, this needs a release so `giantswarm/docs` can pin its
  `commit_reference` to a tag that contains `docs/cr/`.
- `WorkflowExecution` is intentionally not included — it's a controller-created
  runtime record, not a user-authored resource. Easy to add later if we want it
  on the reference too.
