### PR TITLE
revert: migrate token broker to mcp-oauth v1.0.1 self-issued/brokered API (#957)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -158,33 +158,29 @@ estimate.
 | `allowedClaims` | `map[string]string` | Required claim name→pattern pairs. Keys are JWT claim names; values are exact strings or globs where `*` spans any chars including `/` and `?` matches one char. Absent or non-string claims are rejected. Empty means no restriction. |
 | `allowPrivateIPJWKS` | `bool` | Allow `jwksUrl` to resolve to a private or loopback address. Required for in-cluster Kubernetes SA trust where the JWKS endpoint is `https://kubernetes.default.svc/openid/v1/jwks`. Emits a startup warning when set. Default: `false`. |
 
-#### Token Exchange (`tokenExchangeBroker`)
+#### Brokered Token Exchange (`tokenExchangeBroker`)
 
-Configures muster's RFC 8693 token exchange. Subject (and optional actor) tokens are validated against `trustedIssuers`, so at least one issuer entry covering the caller's tokens is required. Each target selects one of two flows via its `type`:
+Exposes muster's RFC 8693 token exchange to external confidential clients: a broker client POSTs a token-exchange request with an `audience` parameter to `/oauth/token` and receives a token minted by the audience's downstream Dex (instead of a muster-issued JWT). Subject tokens are validated against `trustedIssuers`, so at least one issuer entry covering the broker client's tokens is required.
 
-- **`oidc-exchange` (brokered, the default):** an external **confidential client** POSTs a token-exchange request carrying an `audience` parameter to `/oauth/token` and receives a token minted by that audience's downstream Dex (not a muster-issued JWT). Client authentication is mandatory and only confidential clients are accepted; audiences are gated by the per-client allowlist; no refresh tokens are issued (`expires_in` is bounded by the downstream token's expiry — clients re-exchange); DPoP is rejected.
-- **`local-mint` (self-issued):** a **credential-less** caller POSTs a token-exchange request carrying an RFC 8707 `resource` parameter (and **no** `audience`) to `/oauth/token` and receives a JWT muster signs with its own access-token key (requires `enableJWTMode`). The `resource` becomes the minted token's `aud`, defaulting to `resourceIdentifier` when omitted. The set of `local-mint` target names is the allowlist of permitted `resource` values (plus muster's own `resourceIdentifier`); an unlisted resource is rejected with `invalid_target`. A subject asserting an `email` claim without `email_verified: true` is refused. This is also the path muster's aggregator uses in-process to mint per-backend tokens for `localMint` downstream auth.
-
-> **Migration note (mcp-oauth v1.0.1):** `local-mint` targets are no longer audience-routed through the broker. A caller now sends `resource` instead of `audience`, and the request must **not** carry client credentials (an `audience`-carrying request selects the brokered path, which requires a confidential client). The removed `delegateToSelf` knob is now the default: a self-issued exchange with no `resource` binds the token to `resourceIdentifier`.
+Policy enforced by the broker path (mcp-oauth): client authentication is mandatory and only confidential clients are accepted; audiences are gated by the per-client allowlist; no refresh tokens are issued (`expires_in` is bounded by the downstream token's expiry — clients re-exchange); DPoP is rejected.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `clientAudiences` | `map[string][]string` | `{}` | Per-client audience allowlist for the brokered path: broker client ID → audiences it may request. A miss returns `invalid_target`. |
-| `targets` | `map[string]BrokerTargetConfig` | `{}` | Target name → target config. For `oidc-exchange` this is the RFC 8693 audience (e.g. a cluster name) resolved to a downstream Dex exchange; for `local-mint` this is a permitted RFC 8707 `resource` value. |
-| `allowPrivateIP` | `bool` | `false` | Allow downstream token endpoints to resolve to private/loopback IPs. Reduces SSRF protection; internal deployments only. Applies to `oidc-exchange` targets. |
+| `clientAudiences` | `map[string][]string` | `{}` | Per-client audience allowlist: broker client ID → audiences it may request. A miss returns `invalid_target`. |
+| `targets` | `map[string]BrokerTargetConfig` | `{}` | Audience name (e.g. a cluster name) → downstream Dex exchange target. |
+| `allowPrivateIP` | `bool` | `false` | Allow downstream token endpoints to resolve to private/loopback IPs. Reduces SSRF protection; internal deployments only. |
 
 **BrokerTargetConfig fields:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `type` | `string` | `oidc-exchange` (default) or `local-mint`. `local-mint` requires `enableJWTMode` and needs none of the Dex fields below. |
-| `dexTokenEndpoint` | `string` | Downstream Dex token endpoint URL (HTTPS). Required for `oidc-exchange`. |
-| `expectedIssuer` | `string` | Expected `iss` claim of the exchanged token. Derived from `dexTokenEndpoint` when empty. `oidc-exchange` only. |
-| `connectorId` | `string` | Downstream Dex OIDC connector that trusts the subject token's issuer. Required for `oidc-exchange`. |
-| `scopes` | `string` | Space-separated downstream scopes (default: `openid profile email groups`). Kubernetes-bound audiences must include the Dex cross-client scope for the apiserver's client, e.g. `audience:server:client_id:dex-k8s-authenticator` — without it the exchanged token's `aud` is the exchange client only, which the kube-apiserver rejects. The client-supplied RFC 8693 `scope` parameter is intentionally ignored. `oidc-exchange` only. |
-| `clientCredentialsSecretRef` | `object` | Kubernetes Secret with the downstream exchange client credentials: `name` (required), `namespace` (defaults to the muster namespace), `clientIdKey` (default `client-id`), `clientSecretKey` (default `client-secret`). `oidc-exchange` only. |
+| `dexTokenEndpoint` | `string` | Downstream Dex token endpoint URL (HTTPS). Required. |
+| `expectedIssuer` | `string` | Expected `iss` claim of the exchanged token. Derived from `dexTokenEndpoint` when empty. |
+| `connectorId` | `string` | Downstream Dex OIDC connector that trusts the subject token's issuer. Required. |
+| `scopes` | `string` | Space-separated downstream scopes (default: `openid profile email groups`). Kubernetes-bound audiences must include the Dex cross-client scope for the apiserver's client, e.g. `audience:server:client_id:dex-k8s-authenticator` — without it the exchanged token's `aud` is the exchange client only, which the kube-apiserver rejects. The client-supplied RFC 8693 `scope` parameter is intentionally ignored. |
+| `clientCredentialsSecretRef` | `object` | Kubernetes Secret with the downstream exchange client credentials: `name` (required), `namespace` (defaults to the muster namespace), `clientIdKey` (default `client-id`), `clientSecretKey` (default `client-secret`). |
 
-Example (`oidc-exchange`):
+Example:
 
 ```yaml
 aggregator:
@@ -204,34 +200,6 @@ aggregator:
             scopes: "openid profile email groups audience:server:client_id:dex-k8s-authenticator"
             clientCredentialsSecretRef:
               name: muster-token-exchange-cluster-a
-```
-
-Example (`local-mint`, self-issued):
-
-```yaml
-aggregator:
-  oauth:
-    server:
-      enableJWTMode: true
-      jwtSigningKeyFile: /etc/muster/access-token-signing-key.pem
-      resourceIdentifier: https://muster.example.com/mcp
-      trustedIssuers:
-        - issuer: https://workload-idp.example.com
-          jwksUrl: https://workload-idp.example.com/keys
-      tokenExchangeBroker:
-        targets:
-          cluster-b:
-            type: local-mint
-```
-
-A caller then exchanges a trusted-issuer subject token for a muster-signed token bound to `cluster-b`:
-
-```bash
-curl -s https://muster.example.com/mcp/oauth/token \
-  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
-  -d subject_token="$SUBJECT_JWT" \
-  -d subject_token_type=urn:ietf:params:oauth:token-type:jwt \
-  -d resource=cluster-b
 ```
 
 #### Private-IP OIDC Discovery (Dex)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/giantswarm/mcp-oauth v1.0.1
+	github.com/giantswarm/mcp-oauth v1.0.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v1.0.1 h1:rc/hCx5r0KftSPT2vU1qdOiSnw0QIdXpQOwoFLzxsSI=
-github.com/giantswarm/mcp-oauth v1.0.1/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v1.0.0 h1:k/1Dj0jtV6GuitQ7JanITWW79kWMhdg771WJD+B+Yg0=
+github.com/giantswarm/mcp-oauth v1.0.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -384,6 +384,14 @@ type TokenExchangeBrokerConfig struct {
 	// private address.
 	AllowPrivateIP bool `yaml:"allowPrivateIP,omitempty"`
 
+	// DelegateToSelf lets a delegated (on-behalf-of) exchange omit the RFC 8707
+	// resource: muster binds the minted token to its own ResourceIdentifier so an
+	// agent STS client that cannot set a resource still receives a token muster
+	// accepts back and re-mints per backend on the localMint path. Only the
+	// delegation path (actor_token present) is affected; a resource-less plain
+	// exchange still errors. Requires ResourceIdentifier. Default false.
+	DelegateToSelf bool `yaml:"delegateToSelf,omitempty"`
+
 	// DefaultSecretNamespace is the namespace used for target credential
 	// secret refs that do not set an explicit namespace. Populated from the
 	// muster namespace by the serve command; not user-facing config.
@@ -393,35 +401,6 @@ type TokenExchangeBrokerConfig struct {
 // Enabled reports whether brokered token exchange is configured.
 func (c TokenExchangeBrokerConfig) Enabled() bool {
 	return len(c.Targets) > 0
-}
-
-// LocalMintResources returns the audience keys of the local-mint targets. These
-// are the RFC 8707 resource values the credential-less self-issued exchange
-// (mcp-oauth's Server.SelfIssuedExchange) may mint a muster-signed token for, on
-// top of muster's own ResourceIdentifier. They populate mcp-oauth's
-// Config.TokenExchangeAllowedResources so an unlisted resource is rejected with
-// invalid_target.
-func (c TokenExchangeBrokerConfig) LocalMintResources() []string {
-	var resources []string
-	for audience, target := range c.Targets {
-		if target.Type == TargetTypeLocalMint {
-			resources = append(resources, audience)
-		}
-	}
-	return resources
-}
-
-// HasBrokeredTargets reports whether any target routes through the host
-// Exchanger (the downstream OIDC/Dex exchange, i.e. a non-local-mint target).
-// Only then does muster register an Exchanger; local-mint targets are served by
-// the self-issued path, which never reaches the Exchanger.
-func (c TokenExchangeBrokerConfig) HasBrokeredTargets() bool {
-	for _, target := range c.Targets {
-		if target.Type != TargetTypeLocalMint {
-			return true
-		}
-	}
-	return false
 }
 
 // BrokerTargetConfig describes one downstream target of the token broker.

--- a/internal/oauth/broker.go
+++ b/internal/oauth/broker.go
@@ -24,10 +24,6 @@ import (
 // audience → provider dispatch and delegates minting to the registered
 // CredentialProvider.
 //
-// Only the downstream OIDC/Dex exchange (oidc-exchange) targets are served here:
-// local self-issuance moved to mcp-oauth's credential-less self-issued path
-// (Server.SelfIssuedExchange), which never reaches the host Exchanger.
-//
 // The exchanger instance is deliberately separate from the OAuth manager's
 // internal SSO exchanger: broker targets carry their own scope sets (e.g. the
 // Dex cross-client scope for kube-apiserver-bound audiences), and sharing the
@@ -38,11 +34,14 @@ import (
 type BrokerExchanger struct {
 	cfg       config.TokenExchangeBrokerConfig
 	exchanger *TokenExchanger
+	localMint *oauthserver.LocalMintExchanger
 	registry  *providerRegistry
 }
 
 // NewBrokerExchanger creates a BrokerExchanger for the configured targets.
-func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig) *BrokerExchanger {
+// localMint may be nil when JWT mode is disabled; local-mint targets will
+// return a configuration error at Mint time in that case.
+func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig, localMint *oauthserver.LocalMintExchanger) *BrokerExchanger {
 	// Mirror the OAuth manager's internal-deployment handling: mcp-oauth's
 	// private-IP-allowed client bypasses the process-wide augmented transport
 	// (--extra-ca-file), so hand the exchanger an explicit client backed by
@@ -58,7 +57,8 @@ func NewBrokerExchanger(cfg config.TokenExchangeBrokerConfig) *BrokerExchanger {
 			AllowPrivateIP: cfg.AllowPrivateIP,
 			HTTPClient:     httpClient,
 		}),
-		registry: defaultProviderRegistry(),
+		localMint: localMint,
+		registry:  defaultProviderRegistry(),
 	}
 }
 
@@ -75,6 +75,7 @@ func (b *BrokerExchanger) Exchange(ctx context.Context, req *oauthserver.Exchang
 	deps := providerDeps{
 		exchanger: b.exchanger,
 		defaultNS: b.cfg.DefaultSecretNamespace,
+		localMint: b.localMint,
 	}
 	provider, err := b.registry.forTarget(req.Audience, target, deps)
 	if err != nil {

--- a/internal/oauth/broker_test.go
+++ b/internal/oauth/broker_test.go
@@ -52,7 +52,7 @@ func withCredentialsHandler(t *testing.T, h api.SecretCredentialsHandler) {
 }
 
 func newTestBroker(cfg config.TokenExchangeBrokerConfig, httpClient *http.Client) *BrokerExchanger {
-	b := NewBrokerExchanger(cfg)
+	b := NewBrokerExchanger(cfg, nil)
 	if httpClient != nil {
 		b.exchanger = NewTokenExchangerWithOptions(TokenExchangerOptions{
 			AllowPrivateIP: true,

--- a/internal/oauth/credential_provider.go
+++ b/internal/oauth/credential_provider.go
@@ -51,7 +51,9 @@ type MintRequest struct {
 
 	// SubjectIdentity is the full validated subject identity: subject, issuer,
 	// allowed scopes, and Claims carrying email/email_verified/groups plus any
-	// prior RFC 8693 act chain. Nil on paths that only need the Subject string.
+	// prior RFC 8693 act chain. The local-mint provider forwards it so the minted
+	// token reflects the subject's identity claims and preserves a multi-hop act
+	// chain. Nil on paths that only need the Subject string.
 	SubjectIdentity *oauthserver.SubjectIdentity
 }
 
@@ -70,6 +72,9 @@ type MintResult struct {
 type providerDeps struct {
 	exchanger *TokenExchanger
 	defaultNS string
+	// localMint is the mcp-oauth local JWT signer used by TargetTypeLocalMint.
+	// Nil when JWT mode is disabled; the localMintProvider returns an error in that case.
+	localMint *oauthserver.LocalMintExchanger
 }
 
 // providerFactory constructs a CredentialProvider for a single broker target.
@@ -87,6 +92,9 @@ func defaultProviderRegistry() *providerRegistry {
 	r := &providerRegistry{factories: make(map[config.BrokerTargetType]providerFactory)}
 	r.factories[config.TargetTypeOIDCExchange] = func(target config.BrokerTargetConfig, deps providerDeps) CredentialProvider {
 		return &oidcExchangeProvider{target: target, exchanger: deps.exchanger, defaultNS: deps.defaultNS}
+	}
+	r.factories[config.TargetTypeLocalMint] = func(_ config.BrokerTargetConfig, deps providerDeps) CredentialProvider {
+		return &localMintProvider{exchanger: deps.localMint}
 	}
 	return r
 }

--- a/internal/oauth/local_mint_provider.go
+++ b/internal/oauth/local_mint_provider.go
@@ -1,0 +1,57 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+
+	oauthserver "github.com/giantswarm/mcp-oauth/server"
+)
+
+// localMintProvider implements CredentialProvider for the "local-mint" broker
+// target type. It mints an RFC 9068 JWT signed by muster's own access-token
+// signing key via mcp-oauth's LocalMintExchanger.
+//
+// The token carries:
+//   - sub          = the validated human subject (MintRequest.SubjectIdentity.Subject)
+//   - email, groups = the subject's validated identity claims when present
+//   - act          = the validated agent actor (MintRequest.Actor) nested over any
+//     prior act chain carried on the subject token, when present
+//   - iss          = muster's configured BaseURL (the issuer that mcp-kubernetes trusts)
+//   - aud          = the broker target audience (MintRequest.Target)
+//
+// mcp-oauth validates the subject and actor tokens before Exchange is called, so
+// by the time Mint runs both identities are already validated. No re-validation
+// is performed here.
+//
+// Requires enableJWTMode to be true; returns a configuration error otherwise.
+type localMintProvider struct {
+	exchanger *oauthserver.LocalMintExchanger
+}
+
+func (p *localMintProvider) Mint(ctx context.Context, req MintRequest) (*MintResult, error) {
+	if p.exchanger == nil {
+		return nil, fmt.Errorf("local-mint target requires JWT access-token mode (enableJWTMode: true and jwtSigningKeyFile set)")
+	}
+
+	subject := req.SubjectIdentity
+	if subject == nil {
+		subject = &oauthserver.SubjectIdentity{Subject: req.Subject}
+	}
+
+	exchangerReq := &oauthserver.ExchangerRequest{
+		Subject:  subject,
+		Actor:    req.Actor,
+		Audience: req.Target,
+	}
+
+	result, err := p.exchanger.Exchange(ctx, exchangerReq)
+	if err != nil {
+		return nil, fmt.Errorf("local-mint exchange for target %q: %w", req.Target, err)
+	}
+
+	return &MintResult{
+		AccessToken:     result.AccessToken,
+		IssuedTokenType: result.IssuedTokenType,
+		ExpiresAt:       result.ExpiresAt,
+	}, nil
+}

--- a/internal/oauth/local_mint_provider_test.go
+++ b/internal/oauth/local_mint_provider_test.go
@@ -1,339 +1,188 @@
 package oauth
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
-	oauth "github.com/giantswarm/mcp-oauth"
-	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
-	"github.com/giantswarm/mcp-oauth/storage/memory"
 	"github.com/go-jose/go-jose/v4"
-	josejwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/config"
 )
 
-// These tests exercise the credential-less self-issued exchange
-// (Server.SelfIssuedExchange) that replaced the removed standalone
-// LocalMintExchanger. muster's local-mint targets now mint through this path:
-// the server validates the subject (and optional actor) token against its
-// trusted issuers and signs an RFC 9068 JWT whose aud is the requested RFC 8707
-// resource. The tests drive a JWT-mode *oauth.Server directly, minting subject
-// and actor tokens signed by a mock trusted issuer whose JWKS is served locally.
-
-const (
-	selfIssuedWorkloadIssuer = "https://workload-idp.test"
-	selfIssuedMusterIssuer   = "https://muster.test"
-	selfIssuedMusterResource = "https://muster.test/mcp"
-	// selfIssuedJWTType is the RFC 8693 token-type URN for the subject/actor JWTs.
-	selfIssuedJWTType = "urn:ietf:params:oauth:token-type:jwt" //nolint:gosec // G101: RFC 8693 token-type URN, not a credential
-	// selfIssuedAllowedResource is the sole configured local-mint target.
-	selfIssuedAllowedResource = "cluster-b"
-)
-
-// ecKeyWithKID generates a fresh ECDSA P-256 key and its RFC 7638 thumbprint kid.
-func ecKeyWithKID(t *testing.T) (*ecdsa.PrivateKey, string) {
+// newTestLocalMintExchanger constructs a LocalMintExchanger backed by a fresh
+// ECDSA P-256 key for use in tests.
+func newTestLocalMintExchanger(t *testing.T) *oauthserver.LocalMintExchanger {
 	t.Helper()
+
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-	jwk := jose.JSONWebKey{Key: key.Public()}
-	raw, err := jwk.Thumbprint(crypto.SHA256)
+
+	jwkKey := jose.JSONWebKey{Key: key.Public()}
+	raw, err := jwkKey.Thumbprint(crypto.SHA256)
 	require.NoError(t, err)
-	return key, base64.RawURLEncoding.EncodeToString(raw)
+	kid := base64.RawURLEncoding.EncodeToString(raw)
+
+	cfg := &oauthserver.Config{
+		Issuer:                      "https://muster.test",
+		AccessTokenFormat:           oauthserver.AccessTokenFormatJWT,
+		AccessTokenSigningKey:       key,
+		AccessTokenSigningKeyID:     kid,
+		AccessTokenSigningAlgorithm: oauthserver.SigningAlgorithmES256,
+		AccessTokenTTL:              600,
+	}
+	exchanger, err := oauthserver.NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+	return exchanger
 }
 
-// serveJWKS starts an httptest TLS server exposing a single-key JWKS for the
-// given public key and kid, returning the JWKS URL and a cert pool trusting the
-// server. mcp-oauth's JWKS client requires HTTPS even for private-IP issuers, so
-// the pool is threaded into the trusted issuer's RootCAs.
-func serveJWKS(t *testing.T, key *ecdsa.PrivateKey, kid string) (string, *x509.CertPool) {
-	t.Helper()
-	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
-		Key:       key.Public(),
-		KeyID:     kid,
-		Algorithm: string(jose.ES256),
-		Use:       "sig",
-	}}}
-	body, err := json.Marshal(set)
-	require.NoError(t, err)
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(body)
-	}))
-	t.Cleanup(srv.Close)
-	pool := x509.NewCertPool()
-	pool.AddCert(srv.Certificate())
-	return srv.URL, pool
-}
-
-// signIssuerToken signs claims as an ES256 JWT with the issuer key and kid. No
-// typ header is set, matching the AcceptedTypHeaders: [""] trusted-issuer config.
-func signIssuerToken(t *testing.T, key *ecdsa.PrivateKey, kid string, claims map[string]any) string {
-	t.Helper()
-	signer, err := jose.NewSigner(
-		jose.SigningKey{Algorithm: jose.ES256, Key: key},
-		(&jose.SignerOptions{}).WithHeader("kid", kid),
-	)
-	require.NoError(t, err)
-	token, err := josejwt.Signed(signer).Claims(claims).Serialize()
-	require.NoError(t, err)
-	return token
-}
-
-// decodeJWTClaims returns the unverified payload claims of a compact JWT.
-func decodeJWTClaims(t *testing.T, token string) map[string]any {
+// localMintJWTClaims decodes the payload of a dot-separated JWT into a map
+// without verifying the signature.
+func localMintJWTClaims(t *testing.T, token string) map[string]interface{} {
 	t.Helper()
 	parts := strings.Split(token, ".")
-	require.Len(t, parts, 3, "expected a 3-part JWT")
+	require.Len(t, parts, 3, "expected 3-part JWT")
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	require.NoError(t, err)
-	var claims map[string]any
+	var claims map[string]interface{}
 	require.NoError(t, json.Unmarshal(payload, &claims))
 	return claims
 }
 
-// selfIssuedTestServer builds a JWT-mode *oauth.Server that trusts the workload
-// issuer (via the served JWKS) and allows selfIssuedAllowedResource as a
-// self-issued resource. It returns the server and the workload issuer key + kid
-// used to sign subject and actor tokens.
-func selfIssuedTestServer(t *testing.T) (*oauth.Server, *ecdsa.PrivateKey, string) {
-	t.Helper()
-
-	issuerKey, issuerKID := ecKeyWithKID(t)
-	jwksURL, jwksPool := serveJWKS(t, issuerKey, issuerKID)
-
-	musterKey, musterKID := ecKeyWithKID(t)
-	cfg := &oauthserver.Config{
-		Issuer:                        selfIssuedMusterIssuer,
-		ResourceIdentifier:            selfIssuedMusterResource,
-		AccessTokenFormat:             oauthserver.AccessTokenFormatJWT,
-		AccessTokenSigningKey:         musterKey,
-		AccessTokenSigningKeyID:       musterKID,
-		AccessTokenSigningAlgorithm:   oauthserver.SigningAlgorithmES256,
-		AccessTokenTTL:                600,
-		TokenExchangeAllowedResources: []string{selfIssuedAllowedResource},
-	}
-
-	store := memory.New()
-	t.Cleanup(store.Stop)
-
-	ti := oauthserver.TrustedIssuer{
-		Issuer:             selfIssuedWorkloadIssuer,
-		JwksURL:            jwksURL,
-		AllowPrivateIPJWKS: true,
-		AcceptedTypHeaders: []string{""},
-		RootCAs:            jwksPool,
-	}
-	srv, err := oauth.NewServerWithCombined(mock.NewProvider(), store, cfg, nil,
-		oauthserver.WithTrustedIssuers([]oauthserver.TrustedIssuer{ti}))
-	require.NoError(t, err)
-	return srv, issuerKey, issuerKID
-}
-
-// subjectClaims builds a baseline subject-token claim set for the workload issuer.
-func subjectClaims(sub string) map[string]any {
-	return map[string]any{
-		"iss": selfIssuedWorkloadIssuer,
-		"sub": sub,
-		"iat": time.Now().Unix(),
-		"exp": time.Now().Add(time.Hour).Unix(),
-	}
-}
-
-// actorClaims builds an actor-token claim set bound to muster's issuer as its
-// audience (the anti-replay default the server enforces on actor tokens).
-func actorClaims(sub string) map[string]any {
-	c := subjectClaims(sub)
-	c["aud"] = selfIssuedMusterIssuer
-	return c
-}
-
-func TestSelfIssuedExchange_DelegatedMint(t *testing.T) {
+func TestLocalMintProvider_DelegatedMint(t *testing.T) {
 	t.Parallel()
 
-	srv, key, kid := selfIssuedTestServer(t)
+	exchanger := newTestLocalMintExchanger(t)
+	provider := &localMintProvider{exchanger: exchanger}
 
-	subject := signIssuerToken(t, key, kid, subjectClaims("alice@example.com"))
-	actor := signIssuerToken(t, key, kid, actorClaims("system:serviceaccount:agent-ns:kagent"))
-
-	result, err := srv.SelfIssuedExchange(t.Context(), oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject:  oauthserver.TypedToken{Token: subject, Type: selfIssuedJWTType},
-			Actor:    oauthserver.TypedToken{Token: actor, Type: selfIssuedJWTType},
-			Resource: selfIssuedAllowedResource,
+	result, err := provider.Mint(context.Background(), MintRequest{
+		Subject: "alice@example.com",
+		Target:  "mcp-kubernetes",
+		Actor: &oauthserver.SubjectIdentity{
+			Subject: "system:serviceaccount:agent-ns:kagent",
+			Issuer:  "https://kubernetes.default.svc",
 		},
 	})
+
 	require.NoError(t, err)
 	require.NotEmpty(t, result.AccessToken)
 
-	claims := decodeJWTClaims(t, result.AccessToken)
+	claims := localMintJWTClaims(t, result.AccessToken)
 	require.Equal(t, "alice@example.com", claims["sub"], "sub must be the human subject")
-	require.Equal(t, selfIssuedMusterIssuer, claims["iss"])
-	require.Equal(t, selfIssuedAllowedResource, claims["aud"], "aud must be the requested resource")
+	require.Equal(t, "https://muster.test", claims["iss"])
+	require.Equal(t, "mcp-kubernetes", claims["aud"])
 
-	act, ok := claims["act"].(map[string]any)
+	act, ok := claims["act"].(map[string]interface{})
 	require.True(t, ok, "act claim must be present for delegated exchange")
 	require.Equal(t, "system:serviceaccount:agent-ns:kagent", act["sub"])
-	require.Equal(t, selfIssuedWorkloadIssuer, act["iss"])
+	require.Equal(t, "https://kubernetes.default.svc", act["iss"])
 }
 
-func TestSelfIssuedExchange_NilActor_NoActClaim(t *testing.T) {
+func TestLocalMintProvider_NilActor_NoActClaim(t *testing.T) {
 	t.Parallel()
 
-	srv, key, kid := selfIssuedTestServer(t)
-	subject := signIssuerToken(t, key, kid, subjectClaims("alice@example.com"))
+	exchanger := newTestLocalMintExchanger(t)
+	provider := &localMintProvider{exchanger: exchanger}
 
-	result, err := srv.SelfIssuedExchange(t.Context(), oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject:  oauthserver.TypedToken{Token: subject, Type: selfIssuedJWTType},
-			Resource: selfIssuedAllowedResource,
+	result, err := provider.Mint(context.Background(), MintRequest{
+		Subject: "alice@example.com",
+		Target:  "mcp-kubernetes",
+		Actor:   nil,
+	})
+
+	require.NoError(t, err)
+	claims := localMintJWTClaims(t, result.AccessToken)
+	require.Equal(t, "alice@example.com", claims["sub"])
+	_, hasAct := claims["act"]
+	require.False(t, hasAct, "non-delegated exchange must not carry act claim")
+}
+
+// TestLocalMintProvider_ForwardsIdentityClaimsAndGroups verifies that on the OBO
+// path the minted token carries the subject's validated identity claims (email,
+// groups), merges the broker-granted groups, and preserves a multi-hop act chain
+// (the new actor nested over the prior act on the subject token).
+func TestLocalMintProvider_ForwardsIdentityClaims(t *testing.T) {
+	t.Parallel()
+
+	exchanger := newTestLocalMintExchanger(t)
+	provider := &localMintProvider{exchanger: exchanger}
+
+	subject := &oauthserver.SubjectIdentity{
+		Subject: "alice@example.com",
+		Issuer:  "https://dex.example.com",
+		Claims: &oidc.IDTokenClaims{
+			Email:         "alice@example.com",
+			EmailVerified: true,
+			Groups:        []string{"customer:platform-team"},
+			Act:           &oidc.ActorClaim{Issuer: "https://dex.example.com", Subject: "agent-a"},
 		},
+	}
+
+	result, err := provider.Mint(context.Background(), MintRequest{
+		Subject:         subject.Subject,
+		Target:          "mcp-prometheus",
+		SubjectIdentity: subject,
+		Actor:           &oauthserver.SubjectIdentity{Subject: "agent-b", Issuer: "https://kubernetes.default.svc"},
 	})
 	require.NoError(t, err)
 
-	claims := decodeJWTClaims(t, result.AccessToken)
+	claims := localMintJWTClaims(t, result.AccessToken)
 	require.Equal(t, "alice@example.com", claims["sub"])
-	require.NotContains(t, claims, "act", "non-delegated exchange must not carry act claim")
-}
-
-// TestSelfIssuedExchange_ForwardsIdentityClaims verifies the minted token carries
-// the subject's validated identity claims (email, groups) and preserves a
-// multi-hop act chain: the new actor nested over the prior act on the subject.
-func TestSelfIssuedExchange_ForwardsIdentityClaims(t *testing.T) {
-	t.Parallel()
-
-	srv, key, kid := selfIssuedTestServer(t)
-
-	subClaims := subjectClaims("alice@example.com")
-	subClaims["email"] = "alice@example.com"
-	subClaims["email_verified"] = true
-	subClaims["groups"] = []string{"customer:platform-team"}
-	subClaims["act"] = map[string]any{"iss": selfIssuedWorkloadIssuer, "sub": "agent-a"}
-	subject := signIssuerToken(t, key, kid, subClaims)
-	actor := signIssuerToken(t, key, kid, actorClaims("agent-b"))
-
-	result, err := srv.SelfIssuedExchange(t.Context(), oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject:  oauthserver.TypedToken{Token: subject, Type: selfIssuedJWTType},
-			Actor:    oauthserver.TypedToken{Token: actor, Type: selfIssuedJWTType},
-			Resource: selfIssuedAllowedResource,
-		},
-	})
-	require.NoError(t, err)
-
-	claims := decodeJWTClaims(t, result.AccessToken)
-	require.Equal(t, "alice@example.com", claims["sub"])
-	require.Equal(t, "alice@example.com", claims["email"], "subject email must be carried")
+	require.Equal(t, "alice@example.com", claims["email"], "subject email must be carried into the minted token")
 	require.Equal(t, true, claims["email_verified"])
 
 	groups := stringSlice(t, claims["groups"])
 	require.Contains(t, groups, "customer:platform-team", "subject groups must be carried")
 
-	act, ok := claims["act"].(map[string]any)
+	act, ok := claims["act"].(map[string]interface{})
 	require.True(t, ok, "act claim must be present")
 	require.Equal(t, "agent-b", act["sub"], "leaf actor is the new acting party")
+	require.Equal(t, "https://kubernetes.default.svc", act["iss"])
 
-	prior, ok := act["act"].(map[string]any)
+	prior, ok := act["act"].(map[string]interface{})
 	require.True(t, ok, "prior act chain on the subject token must be preserved (not collapsed)")
 	require.Equal(t, "agent-a", prior["sub"])
 }
 
-// TestSelfIssuedExchange_NoSubjectClaims verifies a workload subject with no
-// identity claims mints sub+aud only: no email, groups, or act are fabricated.
-func TestSelfIssuedExchange_NoSubjectClaims(t *testing.T) {
+// TestLocalMintProvider_NoSubjectClaims verifies that an exchange whose subject
+// carries no identity claims mints sub+aud only: no email, no groups, no act are
+// fabricated.
+func TestLocalMintProvider_NoSubjectClaims(t *testing.T) {
 	t.Parallel()
 
-	srv, key, kid := selfIssuedTestServer(t)
-	subject := signIssuerToken(t, key, kid, subjectClaims("system:serviceaccount:agent-ns:kagent"))
+	exchanger := newTestLocalMintExchanger(t)
+	provider := &localMintProvider{exchanger: exchanger}
 
-	result, err := srv.SelfIssuedExchange(t.Context(), oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject:  oauthserver.TypedToken{Token: subject, Type: selfIssuedJWTType},
-			Resource: selfIssuedAllowedResource,
-		},
+	subject := &oauthserver.SubjectIdentity{Subject: "system:serviceaccount:agent-ns:kagent"}
+
+	result, err := provider.Mint(context.Background(), MintRequest{
+		Subject:         subject.Subject,
+		Target:          "mcp-kubernetes",
+		SubjectIdentity: subject,
 	})
 	require.NoError(t, err)
 
-	claims := decodeJWTClaims(t, result.AccessToken)
+	claims := localMintJWTClaims(t, result.AccessToken)
 	require.Equal(t, "system:serviceaccount:agent-ns:kagent", claims["sub"])
-	require.Equal(t, selfIssuedAllowedResource, claims["aud"])
+	require.Equal(t, "mcp-kubernetes", claims["aud"])
 	require.NotContains(t, claims, "email")
 	require.NotContains(t, claims, "groups")
 	require.NotContains(t, claims, "act")
 }
 
-// TestSelfIssuedExchange_DefaultsAudToResourceIdentifier verifies that an
-// exchange with no resource mints a token bound to muster's own resource
-// identifier.
-func TestSelfIssuedExchange_DefaultsAudToResourceIdentifier(t *testing.T) {
-	t.Parallel()
-
-	srv, key, kid := selfIssuedTestServer(t)
-	subject := signIssuerToken(t, key, kid, subjectClaims("system:serviceaccount:agent-ns:kagent"))
-
-	result, err := srv.SelfIssuedExchange(t.Context(), oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject: oauthserver.TypedToken{Token: subject, Type: selfIssuedJWTType},
-		},
-	})
-	require.NoError(t, err)
-
-	claims := decodeJWTClaims(t, result.AccessToken)
-	require.Equal(t, selfIssuedMusterResource, claims["aud"])
-}
-
-// TestSelfIssuedExchange_UnverifiedSubjectEmail_Refused verifies the fail-closed
-// email gate: a subject asserting an email without email_verified=true is refused.
-func TestSelfIssuedExchange_UnverifiedSubjectEmail_Refused(t *testing.T) {
-	t.Parallel()
-
-	srv, key, kid := selfIssuedTestServer(t)
-
-	subClaims := subjectClaims("alice@example.com")
-	subClaims["email"] = "alice@example.com"
-	subClaims["email_verified"] = false
-	subject := signIssuerToken(t, key, kid, subClaims)
-
-	_, err := srv.SelfIssuedExchange(t.Context(), oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject:  oauthserver.TypedToken{Token: subject, Type: selfIssuedJWTType},
-			Resource: selfIssuedAllowedResource,
-		},
-	})
-	require.ErrorIs(t, err, oauthserver.ErrUnverifiedSubjectEmail)
-}
-
-// TestSelfIssuedExchange_DisallowedResource_Refused verifies that a resource
-// outside TokenExchangeAllowedResources is rejected with invalid_target.
-func TestSelfIssuedExchange_DisallowedResource_Refused(t *testing.T) {
-	t.Parallel()
-
-	srv, key, kid := selfIssuedTestServer(t)
-	subject := signIssuerToken(t, key, kid, subjectClaims("system:serviceaccount:agent-ns:kagent"))
-
-	_, err := srv.SelfIssuedExchange(t.Context(), oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject:  oauthserver.TypedToken{Token: subject, Type: selfIssuedJWTType},
-			Resource: "cluster-c",
-		},
-	})
-	require.ErrorIs(t, err, oauthserver.ErrInvalidTarget)
-}
-
 // stringSlice converts a decoded JSON array claim into a []string.
-func stringSlice(t *testing.T, v any) []string {
+func stringSlice(t *testing.T, v interface{}) []string {
 	t.Helper()
-	raw, ok := v.([]any)
+	raw, ok := v.([]interface{})
 	require.True(t, ok, "expected a JSON array, got %T", v)
 	out := make([]string, len(raw))
 	for i := range raw {
@@ -342,4 +191,49 @@ func stringSlice(t *testing.T, v any) []string {
 		out[i] = s
 	}
 	return out
+}
+
+func TestLocalMintProvider_NilExchanger_ReturnsConfigError(t *testing.T) {
+	t.Parallel()
+
+	provider := &localMintProvider{exchanger: nil}
+	_, err := provider.Mint(context.Background(), MintRequest{
+		Subject: "alice@example.com",
+		Target:  "mcp-kubernetes",
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "enableJWTMode")
+}
+
+func TestRegistry_LocalMintTargetResolvesToLocalMintProvider(t *testing.T) {
+	t.Parallel()
+
+	exchanger := newTestLocalMintExchanger(t)
+	registry := defaultProviderRegistry()
+
+	provider, err := registry.forTarget("mcp-kubernetes", config.BrokerTargetConfig{
+		Type: config.TargetTypeLocalMint,
+	}, providerDeps{localMint: exchanger})
+
+	require.NoError(t, err)
+	_, ok := provider.(*localMintProvider)
+	require.True(t, ok, "TargetTypeLocalMint must resolve to localMintProvider")
+}
+
+func TestRegistry_LocalMintWithNilExchanger_ProviderCreated(t *testing.T) {
+	t.Parallel()
+
+	// Registry construction succeeds when localMint is nil; the error is
+	// deferred to Mint time so the broker can start without JWT mode.
+	registry := defaultProviderRegistry()
+
+	provider, err := registry.forTarget("mcp-kubernetes", config.BrokerTargetConfig{
+		Type: config.TargetTypeLocalMint,
+	}, providerDeps{localMint: nil})
+
+	require.NoError(t, err)
+	lp, ok := provider.(*localMintProvider)
+	require.True(t, ok)
+	require.Nil(t, lp.exchanger)
 }

--- a/internal/server/api_adapter.go
+++ b/internal/server/api_adapter.go
@@ -4,16 +4,14 @@ import (
 	"context"
 
 	oauth "github.com/giantswarm/mcp-oauth"
-	oauthserver "github.com/giantswarm/mcp-oauth/server"
 
 	"github.com/giantswarm/muster/internal/api"
 )
 
 // brokerTokenMinter implements api.BackendTokenMinter on top of the embedded
-// mcp-oauth server. It routes every mint through the credential-less self-issued
-// exchange (Server.SelfIssuedExchange) so the server's enforcement (subject and
-// actor token validation, the email-verified gate, and the allowed-resource
-// gate) runs before muster mints the token. It performs no policy of its own.
+// mcp-oauth server. It routes every mint through WorkloadExchangeSubjectToken so
+// the server's enforcement (subject and actor token validation) runs before
+// muster's broker mints the token. It performs no policy of its own.
 type brokerTokenMinter struct {
 	server *oauth.Server
 }
@@ -21,22 +19,12 @@ type brokerTokenMinter struct {
 var _ api.BackendTokenMinter = (*brokerTokenMinter)(nil)
 
 // MintBackendToken mints a per-backend token. An empty ActorToken mints a
-// subject-only token; a non-empty ActorToken selects RFC 8693 delegation. The
-// backend resource identifier (req.Audience) becomes the issued token's aud via
-// the RFC 8707 resource parameter; an empty req.Resource falls back to it.
+// subject-only token; a non-empty ActorToken selects RFC 8693 delegation.
 func (m *brokerTokenMinter) MintBackendToken(ctx context.Context, req api.BackendMintRequest) (api.BackendMintResult, error) {
-	resource := req.Resource
-	if resource == "" {
-		resource = req.Audience
-	}
-	result, err := m.server.SelfIssuedExchange(ctx, oauthserver.SelfIssuedExchangeRequest{
-		SubjectExchange: oauthserver.SubjectExchange{
-			Subject:  oauthserver.TypedToken{Token: req.SubjectToken, Type: req.SubjectTokenType},
-			Actor:    oauthserver.TypedToken{Token: req.ActorToken, Type: req.ActorTokenType},
-			Resource: resource,
-			Scope:    req.Scope,
-		},
-	})
+	result, err := m.server.WorkloadExchangeSubjectToken(ctx,
+		req.SubjectToken, req.SubjectTokenType,
+		req.ActorToken, req.ActorTokenType,
+		req.Audience, req.Resource, req.Scope)
 	if err != nil {
 		return api.BackendMintResult{}, err
 	}

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -761,6 +761,7 @@ func createOAuthServer(cfg config.OAuthServerConfig, opts []oauth.ServerOption) 
 	// operator's extra CA when the issuer is private-IP. nil keeps system-pool.
 	serverConfig.JWKSRootCAs = caPool
 
+	var localMint *oauthserver.LocalMintExchanger
 	if cfg.EnableJWTMode {
 		key, kid, alg, err := loadSigningKey(cfg.JWTSigningKeyFile)
 		if err != nil {
@@ -770,12 +771,24 @@ func createOAuthServer(cfg config.OAuthServerConfig, opts []oauth.ServerOption) 
 		serverConfig.AccessTokenSigningKeyID = kid
 		serverConfig.AccessTokenSigningAlgorithm = alg
 		logger.Info("JWT mode enabled", "alg", alg, "kid", kid)
-		// Local self-issuance uses the same signing material: the server signs the
-		// self-issued exchange tokens with the access-token key configured above,
-		// so no separate exchanger is constructed here.
+
+		// Construct a LocalMintExchanger from the same signing material so that
+		// local-mint broker targets sign tokens with muster's own access-token key.
+		mintCfg := &oauthserver.Config{
+			Issuer:                      cfg.BaseURL,
+			AccessTokenFormat:           oauthserver.AccessTokenFormatJWT,
+			AccessTokenSigningKey:       key,
+			AccessTokenSigningKeyID:     kid,
+			AccessTokenSigningAlgorithm: alg,
+			AccessTokenTTL:              int64(DefaultAccessTokenTTL / time.Second),
+		}
+		localMint, err = oauthserver.NewLocalMintExchanger(mintCfg)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to create local mint exchanger: %w", err)
+		}
 	}
 
-	builtOpts, err := buildOAuthServerOptions(cfg, logger, caPool)
+	builtOpts, err := buildOAuthServerOptions(cfg, logger, localMint, caPool)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/server/oauth_server_config.go
+++ b/internal/server/oauth_server_config.go
@@ -55,26 +55,12 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 		// Only consulted when an Exchanger is registered (see
 		// buildOAuthServerOptions); a miss returns invalid_target.
 		TokenExchangeClientAudiences: cfg.TokenExchangeBroker.ClientAudiences,
+		// Enables the credential-less workload-authenticated exchange on the HTTP
+		// /oauth/token endpoint (the agent STS path), authenticated by the subject
+		// and actor tokens themselves. The in-process localMint path does not
+		// consult this; the HTTP path does.
+		EnableWorkloadTokenExchange: cfg.TokenExchangeBroker.Enabled(),
 	}
-	// Cap the RFC 8707 resource values the credential-less self-issued exchange
-	// (mcp-oauth's Server.SelfIssuedExchange, reachable at /oauth/token without
-	// client credentials) may mint a muster-signed token for.
-	//
-	// This list must never be empty. mcp-oauth treats an empty
-	// TokenExchangeAllowedResources as "any resource accepted" (server/config.go),
-	// so an empty list would let any subject holding a trusted-issuer token mint a
-	// muster-signed JWT bound to an arbitrary aud — bypassing the confidential
-	// client and per-client audience allowlist the brokered path enforces. The
-	// self-issued grant is inherent to JWT mode and cannot be toggled off, so we
-	// always seed the allowlist with muster's own resource identifier (which
-	// SelfIssuedExchange accepts anyway as the default aud) to keep the check
-	// enforced even when no local-mint targets are configured. Declared local-mint
-	// targets extend it; any other resource is rejected with invalid_target.
-	allowedResources := cfg.TokenExchangeBroker.LocalMintResources()
-	if id := result.GetResourceIdentifier(); id != "" {
-		allowedResources = append([]string{id}, allowedResources...)
-	}
-	result.TokenExchangeAllowedResources = allowedResources
 	if cfg.AllowedOrigins != "" {
 		result.CORS.AllowedOrigins = strings.Split(cfg.AllowedOrigins, ",")
 		for i, o := range result.CORS.AllowedOrigins {
@@ -84,13 +70,19 @@ func newOAuthServerConfig(cfg config.OAuthServerConfig, refreshTokenTTL time.Dur
 	if cfg.EnableJWTMode {
 		result.AccessTokenFormat = oauthserver.AccessTokenFormatJWT
 	}
+	if cfg.TokenExchangeBroker.DelegateToSelf {
+		result.DelegationDefaultResource = cfg.ResourceIdentifier
+	}
 	return result
 }
 
 // buildOAuthServerOptions assembles the functional options for the mcp-oauth server.
 // instrumentation.New registers a Prometheus collector on the OTel global
 // provider, so a second call in the same process will race or duplicate-register.
-func buildOAuthServerOptions(cfg config.OAuthServerConfig, logger *slog.Logger, caPool *x509.CertPool) ([]oauth.ServerOption, error) {
+// localMint is non-nil only when JWT mode is enabled; it is forwarded into
+// NewBrokerExchanger so that local-mint broker targets can sign tokens with
+// muster's own access-token key.
+func buildOAuthServerOptions(cfg config.OAuthServerConfig, logger *slog.Logger, localMint *oauthserver.LocalMintExchanger, caPool *x509.CertPool) ([]oauth.ServerOption, error) {
 	inst, err := instrumentation.New(instrumentation.Config{
 		Enabled:         true,
 		ServiceName:     "muster",
@@ -128,23 +120,14 @@ func buildOAuthServerOptions(cfg config.OAuthServerConfig, logger *slog.Logger, 
 		if len(cfg.TrustedIssuers) == 0 {
 			return nil, fmt.Errorf("tokenExchangeBroker requires at least one trustedIssuers entry to validate subject tokens")
 		}
+		opts = append(opts, oauthserver.WithExchanger(musteroauth.NewBrokerExchanger(cfg.TokenExchangeBroker, localMint)))
 		brokerLogger := logger
 		if brokerLogger == nil {
 			brokerLogger = slog.Default()
 		}
-		// Only the downstream OIDC/Dex exchange (oidc-exchange) targets route
-		// through the host Exchanger. Local-mint targets are served by mcp-oauth's
-		// credential-less self-issued path, gated by TokenExchangeAllowedResources
-		// (see newOAuthServerConfig), and never reach the Exchanger.
-		if cfg.TokenExchangeBroker.HasBrokeredTargets() {
-			opts = append(opts, oauthserver.WithExchanger(musteroauth.NewBrokerExchanger(cfg.TokenExchangeBroker)))
-			brokerLogger.Info("Brokered RFC 8693 token exchange enabled",
-				"targets", len(cfg.TokenExchangeBroker.Targets),
-				"brokerClients", len(cfg.TokenExchangeBroker.ClientAudiences))
-		} else {
-			brokerLogger.Info("Self-issued RFC 8693 token exchange enabled",
-				"localMintResources", len(cfg.TokenExchangeBroker.LocalMintResources()))
-		}
+		brokerLogger.Info("Brokered RFC 8693 token exchange enabled",
+			"targets", len(cfg.TokenExchangeBroker.Targets),
+			"brokerClients", len(cfg.TokenExchangeBroker.ClientAudiences))
 	}
 
 	if len(cfg.TrustedProxyCIDRs) > 0 {

--- a/internal/server/oauth_server_config_test.go
+++ b/internal/server/oauth_server_config_test.go
@@ -35,65 +35,30 @@ func TestNewOAuthServerConfig_EnableJWTMode(t *testing.T) {
 	})
 }
 
-func TestNewOAuthServerConfig_TokenExchangeAllowedResources(t *testing.T) {
+func TestNewOAuthServerConfig_DelegateToSelf(t *testing.T) {
 	t.Parallel()
 
-	t.Run("local-mint targets extend the allowlist alongside the resource identifier", func(t *testing.T) {
+	t.Run("enabled binds default resource to ResourceIdentifier", func(t *testing.T) {
 		t.Parallel()
 		cfg := config.OAuthServerConfig{
 			BaseURL:            "https://muster.example.com",
 			ResourceIdentifier: "https://muster.example.com/mcp",
 			TokenExchangeBroker: config.TokenExchangeBrokerConfig{
-				Targets: map[string]config.BrokerTargetConfig{
-					"cluster-b": {Type: config.TargetTypeLocalMint},
-					"cluster-c": {Type: config.TargetTypeLocalMint},
-					// An oidc-exchange target routes through the host Exchanger, not
-					// the self-issued path, so it must not appear in the allowlist.
-					"cluster-oidc": {DexTokenEndpoint: "https://dex.example.com/token", ConnectorID: "main"},
-				},
+				DelegateToSelf: true,
 			},
 		}
 		got := newOAuthServerConfig(cfg, time.Hour)
-		require.ElementsMatch(t, []string{"https://muster.example.com/mcp", "cluster-b", "cluster-c"}, got.TokenExchangeAllowedResources)
+		require.Equal(t, "https://muster.example.com/mcp", got.DelegationDefaultResource)
 	})
 
-	// The self-issued /oauth/token grant is inherent to JWT mode and cannot be
-	// toggled off, and an empty TokenExchangeAllowedResources disables the check
-	// (any resource accepted). The allowlist must therefore never be empty, even
-	// when no local-mint target is configured, so the credential-less endpoint
-	// stays constrained to muster's own resource identifier.
-	t.Run("no local-mint targets still constrains to the resource identifier", func(t *testing.T) {
+	t.Run("disabled leaves default resource empty", func(t *testing.T) {
 		t.Parallel()
 		cfg := config.OAuthServerConfig{
 			BaseURL:            "https://muster.example.com",
 			ResourceIdentifier: "https://muster.example.com/mcp",
 		}
 		got := newOAuthServerConfig(cfg, time.Hour)
-		require.Equal(t, []string{"https://muster.example.com/mcp"}, got.TokenExchangeAllowedResources)
-	})
-
-	t.Run("only oidc-exchange targets still constrains to the resource identifier", func(t *testing.T) {
-		t.Parallel()
-		cfg := config.OAuthServerConfig{
-			BaseURL:            "https://muster.example.com",
-			ResourceIdentifier: "https://muster.example.com/mcp",
-			TokenExchangeBroker: config.TokenExchangeBrokerConfig{
-				Targets: map[string]config.BrokerTargetConfig{
-					"cluster-oidc": {DexTokenEndpoint: "https://dex.example.com/token", ConnectorID: "main"},
-				},
-			},
-		}
-		got := newOAuthServerConfig(cfg, time.Hour)
-		require.Equal(t, []string{"https://muster.example.com/mcp"}, got.TokenExchangeAllowedResources)
-	})
-
-	t.Run("falls back to the issuer when no explicit resource identifier is set", func(t *testing.T) {
-		t.Parallel()
-		cfg := config.OAuthServerConfig{
-			BaseURL: "https://muster.example.com",
-		}
-		got := newOAuthServerConfig(cfg, time.Hour)
-		require.Equal(t, []string{"https://muster.example.com"}, got.TokenExchangeAllowedResources)
+		require.Empty(t, got.DelegationDefaultResource)
 	})
 }
 
@@ -149,7 +114,7 @@ func TestBuildOAuthServerOptions_NoErrorWhenFieldsSet(t *testing.T) {
 		},
 		TrustedProxyCIDRs: []string{"127.0.0.1/32"},
 	}
-	opts, err := buildOAuthServerOptions(cfg, nil, nil)
+	opts, err := buildOAuthServerOptions(cfg, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 }
@@ -167,7 +132,7 @@ func TestBuildOAuthServerOptions_AllowPrivateIPJWKSNoError(t *testing.T) {
 			},
 		},
 	}
-	opts, err := buildOAuthServerOptions(cfg, nil, nil)
+	opts, err := buildOAuthServerOptions(cfg, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 }
@@ -178,7 +143,7 @@ func TestBuildOAuthServerOptions_NoErrorWhenFieldsAbsent(t *testing.T) {
 	cfg := config.OAuthServerConfig{
 		BaseURL: "https://muster.example.com",
 	}
-	opts, err := buildOAuthServerOptions(cfg, nil, nil)
+	opts, err := buildOAuthServerOptions(cfg, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 }
@@ -239,7 +204,7 @@ func TestBuildOAuthServerOptions_BrokerRequiresTrustedIssuers(t *testing.T) {
 			},
 		},
 	}
-	_, err := buildOAuthServerOptions(cfg, nil, nil)
+	_, err := buildOAuthServerOptions(cfg, nil, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "trustedIssuers")
 
@@ -250,7 +215,7 @@ func TestBuildOAuthServerOptions_BrokerRequiresTrustedIssuers(t *testing.T) {
 			AllowedAudiences: []string{"portal-frontend"},
 		},
 	}
-	opts, err := buildOAuthServerOptions(cfg, nil, nil)
+	opts, err := buildOAuthServerOptions(cfg, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 }
@@ -262,7 +227,7 @@ func TestBuildOAuthServerOptions_InvalidCIDRReturnsError(t *testing.T) {
 		BaseURL:           "https://muster.example.com",
 		TrustedProxyCIDRs: []string{"not-a-cidr"},
 	}
-	_, err := buildOAuthServerOptions(cfg, nil, nil)
+	_, err := buildOAuthServerOptions(cfg, nil, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid CIDR")
 }

--- a/internal/testing/muster_manager_broker.go
+++ b/internal/testing/muster_manager_broker.go
@@ -123,7 +123,8 @@ func buildTokenExchangeBrokerConfig(broker *MusterBrokerConfig) map[string]inter
 	}
 
 	return map[string]interface{}{
-		"targets": targets,
+		"targets":        targets,
+		"delegateToSelf": broker.DelegateToSelf,
 	}
 }
 

--- a/internal/testing/scenarios/localmint-broker-downstream-reject.yaml
+++ b/internal/testing/scenarios/localmint-broker-downstream-reject.yaml
@@ -2,8 +2,8 @@ name: "localmint-broker-downstream-reject"
 category: "behavioral"
 concept: "mcpserver"
 description: |
-  A self-issued token bound to resource cluster-c is presented to a backend that
-  only accepts the cluster-b audience. The backend must reject it (401) on the
+  A broker-minted token bound to cluster-c is presented to a backend that only
+  accepts the cluster-b audience. The backend must reject it (401) on the
   audience check, proving downstream audience binding is enforced.
 tags: ["oauth", "broker", "local-mint", "downstream", "negative", "audience-binding"]
 timeout: "2m"
@@ -56,11 +56,11 @@ steps:
       success: true
 
   - id: "exchange-wrong-audience"
-    description: "Mint a token bound to resource cluster-c"
+    description: "Mint a token bound to cluster-c"
     tool: "test_broker_token_exchange"
     args:
       subject_token_ref: "sa-token"
-      resource: "cluster-c"
+      audience: "cluster-c"
       name: "cluster-c-token"
     expected:
       success: true

--- a/internal/testing/scenarios/localmint-broker-negative-audience.yaml
+++ b/internal/testing/scenarios/localmint-broker-negative-audience.yaml
@@ -2,10 +2,9 @@ name: "localmint-broker-negative-audience"
 category: "behavioral"
 concept: "mcpserver"
 description: |
-  Negative self-issued local-mint path. The exchange requests resource cluster-c,
-  which is not a configured local-mint target (only cluster-b is), so it falls
-  outside mcp-oauth's TokenExchangeAllowedResources. muster must reject it with
-  the OAuth error invalid_target and mint no token.
+  Negative local-mint broker path. The exchange requests audience cluster-c,
+  which is not a configured broker target (only cluster-b is). muster's broker
+  must reject it with the OAuth error invalid_target and mint no token.
 tags: ["oauth", "broker", "local-mint", "negative", "token-exchange", "rfc8693"]
 timeout: "2m"
 
@@ -40,12 +39,12 @@ steps:
     expected:
       success: true
 
-  - id: "exchange-disallowed-resource"
-    description: "Request a resource that is not a configured local-mint target"
+  - id: "exchange-disallowed-audience"
+    description: "Request an audience the workload was not granted"
     tool: "test_broker_token_exchange"
     args:
       subject_token_ref: "sa-token"
-      resource: "cluster-c"
+      audience: "cluster-c"
     expected:
       success: false
       error_contains:

--- a/internal/testing/scenarios/localmint-broker-obo-claims.yaml
+++ b/internal/testing/scenarios/localmint-broker-obo-claims.yaml
@@ -2,12 +2,12 @@ name: "localmint-broker-obo-claims"
 category: "behavioral"
 concept: "mcpserver"
 description: |
-  OBO (on-behalf-of) delegated self-issued local-mint path. A human subject token
-  and an agent ServiceAccount actor token are exchanged at muster's /oauth/token
-  self-issued endpoint (credential-less, keyed on the RFC 8707 resource).
+  OBO (on-behalf-of) delegated local-mint broker path. A human subject token and
+  an agent ServiceAccount actor token are exchanged at muster's /oauth/token
+  broker.
 
   Asserts the minted token carries sub = the human, act.sub = the agent SA (the
-  RFC 8693 delegation chain), aud = the requested resource, and the human's groups.
+  RFC 8693 delegation chain), aud = the requested audience, and the human's groups.
 tags: ["oauth", "broker", "local-mint", "obo", "delegation", "token-exchange", "rfc8693"]
 timeout: "2m"
 
@@ -54,16 +54,16 @@ steps:
       success: true
 
   - id: "exchange-obo"
-    description: "Delegated self-issued exchange: agent acts on behalf of the human for cluster-b"
+    description: "Delegated exchange: agent acts on behalf of the human for cluster-b"
     tool: "test_broker_token_exchange"
     args:
       subject_token_ref: "human-token"
       actor_token_ref: "agent-token"
-      resource: "cluster-b"
+      audience: "cluster-b"
     expected:
       success: true
       contains:
         - "alice@giantswarm.io"                       # minted sub == human
         - "system:serviceaccount:kagent:sre-agent"    # act.sub == agent SA
-        - "cluster-b"                                  # minted aud == requested resource
+        - "cluster-b"                                  # minted aud
         - "customer:giantswarm:admins"                # human groups preserved

--- a/internal/testing/scenarios/localmint-broker-obo-downstream.yaml
+++ b/internal/testing/scenarios/localmint-broker-obo-downstream.yaml
@@ -2,7 +2,7 @@ name: "localmint-broker-obo-downstream"
 category: "behavioral"
 concept: "mcpserver"
 description: |
-  End-to-end downstream acceptance of an OBO self-issued token. A human + agent
+  End-to-end downstream acceptance of an OBO broker-minted token. A human + agent
   delegated exchange mints a cluster-b token carrying the act delegation chain,
   which a protected backend (trusting muster's JWKS) accepts and echoes, proving
   the act chain survives to the downstream.
@@ -69,7 +69,7 @@ steps:
     args:
       subject_token_ref: "human-token"
       actor_token_ref: "agent-token"
-      resource: "cluster-b"
+      audience: "cluster-b"
       name: "cluster-b-token"
     expected:
       success: true

--- a/internal/testing/test_tools_broker.go
+++ b/internal/testing/test_tools_broker.go
@@ -170,14 +170,11 @@ func (h *TestToolsHandler) handleMintToken(_ context.Context, args map[string]in
 }
 
 // handleBrokerTokenExchange POSTs an RFC 8693 token-exchange request to muster's
-// /oauth/token self-issued path (credential-less, resource-keyed) and, on
-// success, verifies the minted JWT against muster's JWKS and returns its claims.
-// The request carries no `audience` parameter (that would select the brokered
-// path, which requires an authenticated confidential client); the RFC 8707
-// `resource` selects the target and becomes the minted token's aud. On failure
-// it returns the OAuth error so negative scenarios can assert on it.
-// args: subject_token_ref, resource (required); actor_token_ref,
-// subject_token_type, name optional.
+// /oauth/token broker (workload path, no client credentials) and, on success,
+// verifies the minted JWT against muster's JWKS and returns its claims. On
+// failure it returns the OAuth error so negative scenarios can assert on it.
+// args: subject_token_ref, audience (required); actor_token_ref,
+// subject_token_type, resource, name optional.
 func (h *TestToolsHandler) handleBrokerTokenExchange(ctx context.Context, args map[string]interface{}) (interface{}, error) {
 	if h.currentInstance == nil {
 		return nil, fmt.Errorf("current instance not available")
@@ -191,9 +188,9 @@ func (h *TestToolsHandler) handleBrokerTokenExchange(ctx context.Context, args m
 	if !ok {
 		return nil, fmt.Errorf("no minted token named %q (mint it with test_mint_token first)", subjectRef)
 	}
-	resource, _ := args["resource"].(string)
-	if resource == "" {
-		return nil, fmt.Errorf("resource argument is required")
+	audience, _ := args["audience"].(string)
+	if audience == "" {
+		return nil, fmt.Errorf("audience argument is required")
 	}
 
 	subjectTokenType, _ := args["subject_token_type"].(string)
@@ -205,7 +202,7 @@ func (h *TestToolsHandler) handleBrokerTokenExchange(ctx context.Context, args m
 		"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
 		"subject_token":      {subjectToken},
 		"subject_token_type": {subjectTokenType},
-		"resource":           {resource},
+		"audience":           {audience},
 	}
 	if actorRef, _ := args["actor_token_ref"].(string); actorRef != "" {
 		actorToken, ok := h.mintedTokens[actorRef]
@@ -214,6 +211,9 @@ func (h *TestToolsHandler) handleBrokerTokenExchange(ctx context.Context, args m
 		}
 		form.Set("actor_token", actorToken)
 		form.Set("actor_token_type", jwtTokenTypeURN)
+	}
+	if resource, _ := args["resource"].(string); resource != "" {
+		form.Set("resource", resource)
 	}
 
 	baseURL := pkgoauth.NormalizeServerURL(h.currentInstance.Endpoint)

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -156,9 +156,11 @@ type MusterBrokerConfig struct {
 
 	// Targets maps an audience name to a local-mint target. Value is the target
 	// type; only "local-mint" is meaningful here (empty defaults to local-mint).
-	// Local-mint targets become the allowed RFC 8707 resource values of the
-	// self-issued exchange (mcp-oauth's Config.TokenExchangeAllowedResources).
 	Targets map[string]string `yaml:"targets"`
+
+	// DelegateToSelf lets a delegated exchange omit the RFC 8707 resource; muster
+	// binds the minted token to its own resourceIdentifier.
+	DelegateToSelf bool `yaml:"delegate_to_self,omitempty"`
 }
 
 // BrokerTrustedIssuerConfig references a mock OAuth server as a trusted issuer for


### PR DESCRIPTION
## Summary

Reverts #957. That migration re-implemented the localMint broker path on the mcp-oauth v1.0.1 API — but the team direction is to **remove** localMint entirely (#947, which #957 now sits in the way of). Reverting returns main to mcp-oauth v1.0.0 with the pre-#957 code so #947 can land as written.

`go build ./...` and the oauth/server package tests pass on the revert.

Renovate note: the mcp-oauth v1.0.1 bump (#952) stays closed; the dependency moves forward as part of the localMint removal instead.

Made with [Cursor](https://cursor.com)