### PR TITLE
feat(oauth): inject agent exchange audience for apiserver-valid backend tokens

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -373,6 +373,17 @@ type TokenExchangeBrokerConfig struct {
 	// secret refs that do not set an explicit namespace. Populated from the
 	// muster namespace by the serve command; not user-facing config.
 	DefaultSecretNamespace string `yaml:"-"`
+
+	// DefaultAgentAudience is a TEMPORARY WORKAROUND (giantswarm/muster#965).
+	// When an agent on-behalf-of exchange (grant_type=token-exchange with an
+	// actor_token) arrives with no `audience`, muster injects this audience so
+	// the exchange routes to the matching Targets entry and mints a Dex-signed
+	// token (e.g. aud=dex-k8s-authenticator) the kube-apiserver accepts, letting
+	// mcp-kubernetes pass it through without impersonation. kagent passes a nil
+	// audience today; once kagent-dev/kagent#2106 (Go) + #2107 (Python) add
+	// KAGENT_STS_AUDIENCE, kagent scopes the token itself and this field plus its
+	// injection middleware must be deleted. Empty disables the injection.
+	DefaultAgentAudience string `yaml:"defaultAgentAudience,omitempty"`
 }
 
 // Enabled reports whether brokered token exchange is configured.

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -8,9 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -217,7 +220,63 @@ func (s *OAuthHTTPServer) CreateMux() http.Handler {
 	// Setup MCP endpoint with OAuth protection
 	s.setupMCPRoutes(mux)
 
-	return mux
+	return s.withAgentExchangeAudience(mux)
+}
+
+// grantTypeTokenExchange is the RFC 8693 token-exchange grant.
+const grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+// maxTokenExchangeBody bounds the request body the audience-injection middleware
+// reads. Token-exchange requests are a handful of form fields; this only guards
+// against an unbounded read.
+const maxTokenExchangeBody = 1 << 20
+
+// withAgentExchangeAudience is a TEMPORARY WORKAROUND (giantswarm/muster#965).
+//
+// The glean apiserver trusts Dex only (aud=dex-k8s-authenticator). kagent's STS
+// exchange presents subject+actor but passes a nil audience, so muster self-issues
+// aud=<resourceIdentifier>, which the apiserver cannot validate — forcing
+// mcp-kubernetes to impersonate. Injecting the configured broker audience here
+// routes the exchange to the matching Targets entry, so muster mints a Dex-signed
+// dex-k8s-authenticator token that mcp-kubernetes passes through natively (no
+// impersonation). Once kagent-dev/kagent#2106 (Go) + #2107 (Python) add
+// KAGENT_STS_AUDIENCE, kagent scopes the token itself and this middleware plus
+// TokenExchangeBrokerConfig.DefaultAgentAudience must be deleted.
+//
+// The injection is scoped to on-behalf-of exchanges (an actor_token is present)
+// that carry no audience of their own, so a caller that requests an explicit
+// audience is never overridden.
+func (s *OAuthHTTPServer) withAgentExchangeAudience(next http.Handler) http.Handler {
+	audience := s.config.TokenExchangeBroker.DefaultAgentAudience
+	if audience == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isTokenExchangePost(r) {
+			raw, err := io.ReadAll(io.LimitReader(r.Body, maxTokenExchangeBody))
+			_ = r.Body.Close()
+			if err == nil {
+				body := raw
+				if values, parseErr := url.ParseQuery(string(raw)); parseErr == nil &&
+					values.Get("grant_type") == grantTypeTokenExchange &&
+					values.Get("actor_token") != "" &&
+					values.Get("audience") == "" {
+					values.Set("audience", audience)
+					body = []byte(values.Encode())
+				}
+				r.Body = io.NopCloser(bytes.NewReader(body))
+				r.ContentLength = int64(len(body))
+				r.Header.Set("Content-Length", strconv.Itoa(len(body)))
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isTokenExchangePost reports whether r is a form-encoded POST to the token endpoint.
+func isTokenExchangePost(r *http.Request) bool {
+	return r.Method == http.MethodPost && r.URL.Path == "/oauth/token" &&
+		strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
 }
 
 // setupOAuthRoutes registers OAuth 2.1 endpoints on the mux.

--- a/internal/server/oauth_http_agent_audience_test.go
+++ b/internal/server/oauth_http_agent_audience_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/config"
+)
+
+// serveExchange runs a form-encoded POST through withAgentExchangeAudience and
+// returns the audience the downstream handler observed after re-parsing the body.
+func serveExchange(t *testing.T, defaultAudience string, form url.Values) (seenAudience string, downstreamHit bool) {
+	t.Helper()
+	s := &OAuthHTTPServer{config: config.OAuthServerConfig{
+		TokenExchangeBroker: config.TokenExchangeBrokerConfig{DefaultAgentAudience: defaultAudience},
+	}}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamHit = true
+		require.NoError(t, r.ParseForm())
+		seenAudience = r.PostForm.Get("audience")
+	})
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.withAgentExchangeAudience(next).ServeHTTP(httptest.NewRecorder(), req)
+	return seenAudience, downstreamHit
+}
+
+func TestWithAgentExchangeAudience(t *testing.T) {
+	obo := url.Values{
+		"grant_type":    {grantTypeTokenExchange},
+		"subject_token": {"user.jwt"},
+		"actor_token":   {"agent.jwt"},
+	}
+
+	t.Run("injects audience for an on-behalf-of exchange with none", func(t *testing.T) {
+		seen, hit := serveExchange(t, "glean", obo)
+		require.True(t, hit)
+		require.Equal(t, "glean", seen)
+	})
+
+	t.Run("does not override an explicit audience", func(t *testing.T) {
+		form := url.Values{
+			"grant_type":    {grantTypeTokenExchange},
+			"subject_token": {"user.jwt"},
+			"actor_token":   {"agent.jwt"},
+			"audience":      {"explicit"},
+		}
+		seen, _ := serveExchange(t, "glean", form)
+		require.Equal(t, "explicit", seen)
+	})
+
+	t.Run("does not inject without an actor token", func(t *testing.T) {
+		form := url.Values{
+			"grant_type":    {grantTypeTokenExchange},
+			"subject_token": {"user.jwt"},
+		}
+		seen, _ := serveExchange(t, "glean", form)
+		require.Empty(t, seen)
+	})
+
+	t.Run("no-op when DefaultAgentAudience is empty", func(t *testing.T) {
+		seen, hit := serveExchange(t, "", obo)
+		require.True(t, hit)
+		require.Empty(t, seen)
+	})
+}


### PR DESCRIPTION
Temporary workaround so we can remove MC impersonation now, without waiting for kagent.

## Problem

The glean apiserver trusts Dex only (`aud=dex-k8s-authenticator`). kagent's STS exchange presents subject+actor but passes a **nil audience** (`kagent-dev/kagent` `sts/plugin.go:183`), so muster self-issues `aud=<resourceIdentifier>`, which the apiserver can't validate, forcing mcp-kubernetes to impersonate.

## Change

For an on-behalf-of token-exchange request (grant_type=token-exchange with an `actor_token`) that arrives with **no `audience`**, muster injects `TokenExchangeBroker.DefaultAgentAudience`. That routes the exchange to the matching broker target, so muster mints a **Dex-signed `dex-k8s-authenticator`** token. mcp-kubernetes passes it through natively (`--downstream-oauth`), so impersonation on the MC can be removed. `act` is still logged at the broker exchange.

The injection only fires when an `actor_token` is present and no explicit `audience` was requested, so a caller that scopes its own token is never overridden. Disabled when `DefaultAgentAudience` is empty.

## Temporary — tracked by #965

kagent-dev/kagent#2106 (Go) + #2107 (Python) add `KAGENT_STS_AUDIENCE`. Once merged, kagent scopes the token itself; set that env var and delete this middleware + the `DefaultAgentAudience` field.

Depends on the forward-token stack (#947); based on `obo/forward-token`.

gazelle already runs this passthrough model live for the human path.