### PR TITLE
fix(oauth): persist reconnect ID token to stop SSO re-exchange rotation storm

### DIFF
--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -369,6 +369,24 @@ func (a *AggregatorServer) initSSOForSession(sso ssoSession) {
 		return
 	}
 
+	// Persist the caller's ID token into the OAuth-proxy store so the background
+	// re-exchange/forwarding closures can resolve a subject after the request
+	// context is gone. getIDTokenForForwarding runs on a detached
+	// context.Background() and can only read the store; it is populated
+	// otherwise only at fresh login (SessionCreationHandler) or on an upstream
+	// refresh that returns an ID token (TokenRefreshHandler). A session that
+	// reconnects after its login-time ID token expired (e.g. after a pod
+	// restart) re-inits SSO here from the live request context but would
+	// otherwise leave the store empty -- so every background re-exchange fails
+	// with "no subject ID token available for re-exchange" and the fallback
+	// refresher rotates the client's refresh token in a tight retry loop until
+	// OAuth 2.1 reuse detection revokes the family. Storing it here keeps the
+	// store fresh for as long as the session keeps making authenticated
+	// requests. storeIDTokenForSSO no-ops on empty/unparseable tokens.
+	if sso.tokens.IDToken != "" {
+		a.storeIDTokenForSSO(sso.sessionID, sso.userID, sso.tokens.IDToken)
+	}
+
 	// Build a detached context with a timeout -- the token-exchange request
 	// context may be cancelled before SSO work finishes.
 	bgCtx, cancel := context.WithTimeout(context.Background(), initSSOTimeout)

--- a/internal/aggregator/auth_resource_test.go
+++ b/internal/aggregator/auth_resource_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/config"
+	"github.com/giantswarm/muster/internal/server"
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -725,6 +726,63 @@ func TestStoreIDTokenForSSO_SetsExpiresAtFromJWT(t *testing.T) {
 		token := &pkgoauth.Token{ExpiresAt: stored.ExpiresAt}
 		if !token.IsExpiredWithMargin(0) {
 			t.Errorf("stored entry should be IsExpiredWithMargin(0)-expired; ExpiresAt=%v", stored.ExpiresAt)
+		}
+	})
+}
+
+// TestInitSSOForSession_PersistsIDToken locks in the fix for the garm
+// re-exchange rotation-storm deauth. A session that reconnects after its
+// login-time ID token expired (e.g. after a pod restart) re-inits SSO here from
+// the live request-context ID token; that token MUST be persisted to the
+// OAuth-proxy store so the background re-exchange closure
+// (getIDTokenForForwarding, which runs on a detached context and can only read
+// the store) can resolve a subject. Without this, every background re-exchange
+// fails with "no subject ID token available for re-exchange" and the fallback
+// refresher rotates the client's refresh token in a tight retry loop until
+// OAuth 2.1 reuse detection revokes the family and deauths the session.
+func TestInitSSOForSession_PersistsIDToken(t *testing.T) {
+	mock := newMockOAuthHandler(true)
+	api.RegisterOAuthHandler(mock)
+	t.Cleanup(func() { api.RegisterOAuthHandler(nil) })
+
+	a := &AggregatorServer{
+		registry: NewServerRegistry("x"),
+		config: AggregatorConfig{
+			OAuthServer: OAuthServerConfig{
+				Enabled: true,
+				Config: config.OAuthServerConfig{
+					Provider: "generic",
+					BaseURL:  "https://muster.example",
+				},
+			},
+		},
+	}
+
+	// JWT payload: {"sub":"alice","exp":9999999999} (year 2286).
+	idToken := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSIsImV4cCI6OTk5OTk5OTk5OX0.sig"
+	a.initSSOForSession(ssoSession{
+		userID:    "alice",
+		sessionID: "family-reconnect",
+		tokens:    server.CallerTokens{IDToken: idToken},
+	})
+
+	stored := mock.GetFullTokenByIssuer("family-reconnect", "https://muster.example")
+	if stored == nil {
+		t.Fatal("initSSOForSession must persist the request-context ID token to the proxy store so background re-exchange can resolve it")
+	}
+	if stored.IDToken != idToken {
+		t.Errorf("stored IDToken = %q, want %q", stored.IDToken, idToken)
+	}
+
+	t.Run("no-ops when the caller carries no ID token", func(t *testing.T) {
+		mock.tokens = map[string]*api.OAuthToken{}
+		a.initSSOForSession(ssoSession{
+			userID:    "bob",
+			sessionID: "family-no-idtoken",
+			tokens:    server.CallerTokens{},
+		})
+		if stored := mock.GetFullTokenByIssuer("family-no-idtoken", "https://muster.example"); stored != nil {
+			t.Fatalf("must not store anything when the caller has no ID token, got %+v", stored)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

A long-lived SSO session (human dex login) got **deauthed** on a management cluster despite the mcp-oauth rotation-race work. Root cause is a **muster** lifecycle gap, independent of the mcp-oauth provider-token rotation race (giantswarm/giantswarm#37164):

1. A session reconnects after its **login-time ID token expired** (e.g. after a pod restart). `onAuthenticated` takes the `authAlive` branch and re-inits SSO via `initSSOForSession` using the ID token from the **live request context** — but never persists it to the OAuth-proxy store.
2. The **background** re-exchange/forwarding closure `getIDTokenForForwarding` runs on a detached `context.Background()` and can only read that store, so it finds nothing → logs `no subject ID token available for re-exchange` → falls back to the in-process refresher `RefreshSession` → `RefreshAccessToken`, **which rotates the client's mcp refresh token**.
3. On a token-exchange backend whose continuous-listen retries every ~1s, this rotated the refresh-token family **~56×/min** for ~15 min until two rotations collided → **OAuth 2.1 refresh-token reuse detection** revoked the whole family (all user+client tokens) → session deauthed.

Connect-time token exchange kept succeeding the whole time (it reads the live request context), which is why the failure looked intermittent.

## Fix

Persist the request-context ID token in `initSSOForSession` (via the existing `storeIDTokenForSSO`, which already no-ops on empty/unparseable tokens). Because `onAuthenticated` re-inits on active requests, the proxy store now stays fresh for as long as the session keeps making authenticated requests, so the background re-exchange resolves a subject from the store and never hits the rotating refresher.

## Scope / follow-up

This kills the trigger. It does **not** remove the underlying hazard that the background SSO re-exchange refresher (`RefreshSession`) rotates the **client-facing** refresh token at all. A proper follow-up is an mcp-oauth **provider-only refresh** entry point that fires `TokenRefreshHandler` (repopulating the ID token) **without** rotating the client's mcp refresh token; muster's re-exchange path would use that instead. Tracked as a follow-up so this safe, well-scoped fix can land first.

Not fixed by bumping mcp-oauth to v1.1.1 — that coordinates the upstream **provider** token, not muster's SSO ID-token lifecycle or the client-refresh-token rotation.

## Tests

- New `TestInitSSOForSession_PersistsIDToken` (+ no-op-on-empty subtest).
- Full `internal/aggregator` package passes with `-race`; `go vet` clean.