### PR TITLE
fix: lazily register MCPServer definitions created after boot

### DIFF
--- a/internal/orchestrator/lazy_registration_test.go
+++ b/internal/orchestrator/lazy_registration_test.go
@@ -1,0 +1,90 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+)
+
+// mockMCPServerManager implements api.MCPServerManagerHandler for testing
+// lazy registration of MCPServer definitions created after orchestrator boot.
+type mockMCPServerManager struct {
+	servers map[string]api.MCPServerInfo
+}
+
+func (m *mockMCPServerManager) ListMCPServers() []api.MCPServerInfo {
+	servers := make([]api.MCPServerInfo, 0, len(m.servers))
+	for _, info := range m.servers {
+		servers = append(servers, info)
+	}
+	return servers
+}
+
+func (m *mockMCPServerManager) GetMCPServer(name string) (*api.MCPServerInfo, error) {
+	info, ok := m.servers[name]
+	if !ok {
+		return nil, api.NewMCPServerNotFoundError(name)
+	}
+	return &info, nil
+}
+
+func (m *mockMCPServerManager) GetTools() []api.ToolMetadata { return nil }
+
+func (m *mockMCPServerManager) ExecuteTool(ctx context.Context, toolName string, args map[string]interface{}) (*api.CallToolResult, error) {
+	return nil, nil
+}
+
+// TestStartServiceLazilyRegistersRuntimeMCPServer reproduces issue #680:
+// an MCPServer definition that appears after orchestrator boot (e.g. a CR
+// applied at runtime) must be registered lazily by StartService instead of
+// failing with "service not found" until the process restarts.
+func TestStartServiceLazilyRegistersRuntimeMCPServer(t *testing.T) {
+	manager := &mockMCPServerManager{servers: map[string]api.MCPServerInfo{}}
+	api.RegisterMCPServerManager(manager)
+	t.Cleanup(func() { api.RegisterMCPServerManager(nil) })
+
+	o := New(Config{Aggregator: config.AggregatorConfig{}})
+	require.NoError(t, o.Start(context.Background()))
+	t.Cleanup(func() { _ = o.Stop() })
+
+	// Simulate a CR applied after boot: the definition exists in the manager
+	// but was never registered in the orchestrator's service registry.
+	manager.servers["new-mcp"] = api.MCPServerInfo{
+		Name:      "new-mcp",
+		Type:      "streamable-http",
+		AutoStart: true,
+		URL:       "http://127.0.0.1:1", // closed port: start fails, registration must still happen
+		Timeout:   1,
+	}
+
+	err := o.StartService("new-mcp")
+
+	// The start attempt itself fails (nothing is listening), but the service
+	// must no longer be unknown to the orchestrator.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "service new-mcp not found")
+	}
+	_, exists := o.registry.Get("new-mcp")
+	assert.True(t, exists, "service must be registered in the registry after StartService")
+}
+
+// TestStartServiceUnknownServiceStillErrors verifies that StartService still
+// fails cleanly for names that have no service and no MCPServer definition.
+func TestStartServiceUnknownServiceStillErrors(t *testing.T) {
+	manager := &mockMCPServerManager{servers: map[string]api.MCPServerInfo{}}
+	api.RegisterMCPServerManager(manager)
+	t.Cleanup(func() { api.RegisterMCPServerManager(nil) })
+
+	o := New(Config{Aggregator: config.AggregatorConfig{}})
+	require.NoError(t, o.Start(context.Background()))
+	t.Cleanup(func() { _ = o.Stop() })
+
+	err := o.StartService("does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -130,10 +130,37 @@ func (o *Orchestrator) processAutoStartMCPServers(ctx context.Context) error {
 	return nil
 }
 
-// createMCPServerService creates an MCPServer service from MCPServerInfo and registers it.
+// createMCPServerService creates an MCPServer service from MCPServerInfo,
+// registers it, and starts it asynchronously.
 func (o *Orchestrator) createMCPServerService(ctx context.Context, mcpServerInfo api.MCPServerInfo) error {
 	logging.Info("Orchestrator", "Creating MCPServer service: %s", mcpServerInfo.Name)
 
+	mcpService, err := o.registerMCPServerService(mcpServerInfo)
+	if err != nil {
+		return err
+	}
+
+	// Start the service immediately since the orchestrator's Start() method
+	// has already started static services and won't start newly registered ones
+	go func() {
+		if err := mcpService.Start(ctx); err != nil {
+			if api.IsAuthRequiredError(err) {
+				// Pending auth registration happens in the auth-required hook.
+				return
+			}
+			logging.Error("Orchestrator", err, "Failed to start MCPServer service: %s", mcpServerInfo.Name)
+		} else {
+			logging.Info("Orchestrator", "Started MCPServer service: %s", mcpServerInfo.Name)
+		}
+	}()
+
+	logging.Info("Orchestrator", "Successfully created and registered MCPServer service: %s", mcpServerInfo.Name)
+	return nil
+}
+
+// registerMCPServerService creates an MCPServer service from MCPServerInfo and
+// registers it in the service registry without starting it.
+func (o *Orchestrator) registerMCPServerService(mcpServerInfo api.MCPServerInfo) (services.Service, error) {
 	apiDef := &api.MCPServer{
 		Name:        mcpServerInfo.Name,
 		Type:        api.MCPServerType(mcpServerInfo.Type),
@@ -156,31 +183,36 @@ func (o *Orchestrator) createMCPServerService(ctx context.Context, mcpServerInfo
 	// Auth Required state.
 	mcpService, err := mcpserver.NewService(apiDef, mcpserver.WithAuthRequiredHook(o.handleAuthRequiredServer))
 	if err != nil {
-		return fmt.Errorf("failed to create MCPServer service: %w", err)
+		return nil, fmt.Errorf("failed to create MCPServer service: %w", err)
 	}
 
 	mcpService.SetStateChangeCallback(o.createStateChangeCallback())
 
 	if err := o.registry.Register(mcpService); err != nil {
-		return fmt.Errorf("failed to register MCPServer service: %w", err)
+		return nil, fmt.Errorf("failed to register MCPServer service: %w", err)
 	}
 
-	// Start the service immediately since the orchestrator's Start() method
-	// has already started static services and won't start newly registered ones
-	go func() {
-		if err := mcpService.Start(ctx); err != nil {
-			if api.IsAuthRequiredError(err) {
-				// Pending auth registration happens in the auth-required hook.
-				return
-			}
-			logging.Error("Orchestrator", err, "Failed to start MCPServer service: %s", mcpServerInfo.Name)
-		} else {
-			logging.Info("Orchestrator", "Started MCPServer service: %s", mcpServerInfo.Name)
-		}
-	}()
+	return mcpService, nil
+}
 
-	logging.Info("Orchestrator", "Successfully created and registered MCPServer service: %s", mcpServerInfo.Name)
-	return nil
+// registerMCPServerFromDefinition lazily registers an MCPServer service for a
+// definition that appeared after orchestrator boot (e.g. a CR applied at
+// runtime). Boot-time registration only covers definitions that existed when
+// the orchestrator started; without this, StartService would fail with
+// "service not found" until the process restarts (issue #680).
+func (o *Orchestrator) registerMCPServerFromDefinition(name string) (services.Service, error) {
+	mcpServerMgr := api.GetMCPServerManager()
+	if mcpServerMgr == nil {
+		return nil, fmt.Errorf("service %s not found", name)
+	}
+
+	mcpServerInfo, err := mcpServerMgr.GetMCPServer(name)
+	if err != nil || mcpServerInfo == nil {
+		return nil, fmt.Errorf("service %s not found", name)
+	}
+
+	logging.Info("Orchestrator", "Registering MCPServer service for definition created at runtime: %s", name)
+	return o.registerMCPServerService(*mcpServerInfo)
 }
 
 // handleAuthRequiredServer registers a server that requires OAuth authentication
@@ -384,7 +416,13 @@ func (o *Orchestrator) shouldAttemptRetry(svc services.Service) bool {
 func (o *Orchestrator) StartService(name string) error {
 	service, exists := o.registry.Get(name)
 	if !exists {
-		return fmt.Errorf("service %s not found", name)
+		// MCPServer definitions created after boot are not in the registry
+		// yet; register them lazily before starting.
+		var err error
+		service, err = o.registerMCPServerFromDefinition(name)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := service.Start(o.ctx); err != nil {


### PR DESCRIPTION
## What

`Orchestrator.StartService` now lazily registers an MCPServer service from its definition when the requested name is not in the service registry. The registration logic is extracted from `createMCPServerService` into a shared `registerMCPServerService` helper used by both the boot path and the new lazy path.

## Why

Fixes #680: MCPServer CRs applied at runtime stayed `Disconnected`. Registration only happened at orchestrator boot, so the reconciler's `reconcileCreate` retried `StartService` against a name nothing had registered, exhausted retries, and wedged the CR until the muster Deployment was rolled.

## Testing

- `TestStartServiceLazilyRegistersRuntimeMCPServer` reproduces the issue (verified failing on unfixed code) and passes with the fix.
- `TestStartServiceUnknownServiceStillErrors` keeps the not-found behavior for names with no definition.
- Full `go test ./...` green; golangci-lint clean.

Out of scope (as noted in the issue): symmetric unregistration on CR delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)