### PR TITLE
fix: let core_service_start reach lazy MCPServer registration

### DIFF
--- a/internal/orchestrator/api_adapter.go
+++ b/internal/orchestrator/api_adapter.go
@@ -221,15 +221,10 @@ func (a *Adapter) handleServiceStart(args map[string]interface{}) (*api.CallTool
 		}, nil
 	}
 
-	status, err := a.GetServiceStatus(name)
-	if err != nil {
-		return &api.CallToolResult{
-			Content: []interface{}{fmt.Sprintf("Failed to start service: %v", err)},
-			IsError: true,
-		}, nil
-	}
-
-	if status.State == "running" {
+	// A missing status is not fatal: StartService lazily registers MCPServer
+	// definitions created after boot (issue #680), so only short-circuit when
+	// the service exists and is already running.
+	if status, err := a.GetServiceStatus(name); err == nil && status.State == "running" {
 		return &api.CallToolResult{
 			Content: []interface{}{fmt.Sprintf("Service '%s' is already running", name)},
 			IsError: false,

--- a/internal/testing/scenarios/mcpserver-runtime-create-start.yaml
+++ b/internal/testing/scenarios/mcpserver-runtime-create-start.yaml
@@ -1,0 +1,114 @@
+name: "mcpserver-runtime-create-start"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["mcpserver", "create", "lifecycle", "service-management", "core-api", "regression"]
+timeout: "3m"
+
+# Test Story: MCPServer definitions created at runtime become startable services
+# Regression test for issue #680: MCPServer CRs applied while muster was running
+# were never registered in the orchestrator's service registry (registration only
+# happened at boot), so starting them failed with "service not found" until the
+# process was restarted.
+#
+# Given: A live mock MCP endpoint (from a pre-configured server)
+# When: I create a brand-new MCPServer definition at runtime pointing at that
+#       endpoint and start it
+# Then: The service starts, connects, and its tools are callable -- without a
+#       muster restart
+
+pre_configuration:
+  mcp_servers:
+    - name: "runtime-reg-mock"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "runtime_test_tool"
+            description: "A tool used to verify runtime-created server connectivity"
+            input_schema:
+              type: "object"
+              properties:
+                message: { type: "string" }
+            responses:
+              - response:
+                  message: "{{ .message }}"
+                  server: "runtime-reg-mock"
+                  status: "executed"
+
+steps:
+  # Phase 1: Grab the live mock endpoint URL from the pre-configured server
+  - id: "get-mock-endpoint"
+    description: "Read the pre-configured mock server to obtain its live endpoint URL"
+    tool: "core_mcpserver_get"
+    args:
+      name: "runtime-reg-mock"
+    expected:
+      success: true
+      json_path:
+        name: "runtime-reg-mock"
+        type: "streamable-http"
+
+  # Phase 2: Create a brand-new MCPServer definition at runtime (simulates a CR
+  # applied via kubectl while muster serve is already running)
+  - id: "create-runtime-mcpserver"
+    description: "Create a new MCPServer definition after muster has booted"
+    tool: "core_mcpserver_create"
+    args:
+      name: "runtime-created-server"
+      type: "streamable-http"
+      autoStart: true
+      url: "{{ get-mock-endpoint.url }}"
+      timeout: 30
+    expected:
+      success: true
+
+  # Phase 3: Start it. Before the #680 fix this failed with
+  # "service runtime-created-server not found" because the service was never
+  # registered in the orchestrator's registry.
+  - id: "start-runtime-mcpserver"
+    description: "Start the runtime-created MCPServer service"
+    tool: "core_service_start"
+    args:
+      name: "runtime-created-server"
+    expected:
+      success: true
+
+  - id: "verify-runtime-mcpserver-connected"
+    description: "Verify the runtime-created server reaches connected state"
+    tool: "core_service_status"
+    args:
+      name: "runtime-created-server"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        name: "runtime-created-server"
+        state: "connected"
+
+  # Phase 4: Prove the server is actually usable end to end
+  - id: "call-tool-on-runtime-mcpserver"
+    description: "Call a tool exposed by the runtime-created server"
+    tool: "x_runtime-created-server_runtime_test_tool"
+    args:
+      message: "created-after-boot"
+    expected:
+      success: true
+      contains: ["created-after-boot", "executed"]
+
+cleanup:
+  - id: "cleanup-stop-runtime-mcpserver"
+    description: "Stop the runtime-created MCPServer service"
+    tool: "core_service_stop"
+    args:
+      name: "runtime-created-server"
+    expected:
+      success: true
+    continue_on_failure: true
+
+  - id: "cleanup-delete-runtime-mcpserver"
+    description: "Delete the runtime-created MCPServer definition"
+    tool: "core_mcpserver_delete"
+    args:
+      name: "runtime-created-server"
+    expected:
+      success: true
+    continue_on_failure: true


### PR DESCRIPTION
## What

- `handleServiceStart` in the orchestrator API adapter no longer aborts when `GetServiceStatus` returns "service not found"; it only short-circuits when the service exists and is already running. This lets the call reach `Orchestrator.StartService`, which since #1012 lazily registers MCPServer definitions created after boot.
- Adds behavioral scenario `mcpserver-runtime-create-start`: creates an MCPServer definition at runtime (simulating a CR applied via kubectl while muster is running), starts it via `core_service_start`, waits for `connected`, and calls one of its tools.

## Why

Follow-up to #1012 / #680. The unit-level fix covered the reconciler path, but the `core_service_start` tool path was still blocked by the handler's pre-check — the new behavioral scenario caught this.

## Testing

- Scenario verified failing on aa558d62 (main with only #1012) and passing with this change.
- Full mcpserver concept suite (72 scenarios) and service concept suite (6 scenarios) pass.
- `service-start-non-existent` still passes (unknown names keep erroring with "not found").

🤖 Generated with [Claude Code](https://claude.com/claude-code)