### PR TITLE
fix(helm): allow muster to update/patch Events

### DIFF
--- a/helm/muster/templates/rbac.yaml
+++ b/helm/muster/templates/rbac.yaml
@@ -37,10 +37,11 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch"]
 
-  # Events - required for the core_events tool
+  # Events - required for the core_events tool; update/patch let the
+  # EventBroadcaster bump the count on repeated events instead of failing.
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/muster/tests/rbac_test.yaml
+++ b/helm/muster/tests/rbac_test.yaml
@@ -65,7 +65,7 @@ tests:
           path: rules
           content:
             apiGroups: ["muster.giantswarm.io"]
-            resources: ["mcpservers", "workflows"]
+            resources: ["mcpservers", "workflows", "workflowexecutions"]
             verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
         documentIndex: 0
 
@@ -113,7 +113,7 @@ tests:
           content:
             apiGroups: [""]
             resources: ["events"]
-            verbs: ["get", "list", "watch", "create"]
+            verbs: ["get", "list", "watch", "create", "update", "patch"]
         documentIndex: 0
 
   # ==========================================


### PR DESCRIPTION
## What
Adds `update` and `patch` verbs for core-group `events` to the muster ClusterRole.

## Why
The client-go EventBroadcaster patches an existing Event to bump its count on repeats. With only `create` allowed, repeat events fail — seen on graveler (muster 1.4.12):

```
Server rejected event (will not retry!) err="events \"issue-680-verify...\" is forbidden: User \"system:serviceaccount:agentic-platform:muster\" cannot patch resource \"events\" in API group \"\" in the namespace \"agentic-platform\""
```

Muster uses only the core v1 events API (`record.NewBroadcaster` → `CoreV1().Events`), so no `events.k8s.io` rule is needed.

Also fixes the pre-existing rbac unittest that was missing `workflowexecutions` in the expected CRD rule.

## Verified
- `helm unittest ./helm/muster`: 91 passed
- `helm template` renders the new verbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)