### PR TITLE
fix: unregister MCPServer services on delete so re-creates start fresh

### DIFF
--- a/internal/aggregator/event_handler_test.go
+++ b/internal/aggregator/event_handler_test.go
@@ -25,6 +25,7 @@ func newMockOrchestratorAPI() *mockOrchestratorAPI {
 func (m *mockOrchestratorAPI) StartService(name string) error   { return nil }
 func (m *mockOrchestratorAPI) StopService(name string) error    { return nil }
 func (m *mockOrchestratorAPI) RestartService(name string) error { return nil }
+func (m *mockOrchestratorAPI) RemoveService(name string) error  { return nil }
 func (m *mockOrchestratorAPI) GetServiceStatus(name string) (*api.ServiceStatus, error) {
 	return nil, nil
 }

--- a/internal/api/orchestrator.go
+++ b/internal/api/orchestrator.go
@@ -32,6 +32,17 @@ type OrchestratorAPI interface {
 	//   - error: nil on success, or an error describing why the service could not be stopped
 	StopService(name string) error
 
+	// RemoveService stops the specified service and removes it from the service
+	// registry. This is used when the service's definition is deleted, so that a
+	// later re-create with the same name is treated as a fresh service.
+	//
+	// Args:
+	//   - name: The unique name of the service to remove
+	//
+	// Returns:
+	//   - error: nil on success, or an error describing why the service could not be removed
+	RemoveService(name string) error
+
 	// RestartService performs a stop followed by a start operation on the specified service.
 	// This is equivalent to calling StopService followed by StartService, but may be
 	// implemented more efficiently by the underlying service manager.
@@ -107,6 +118,16 @@ func (a *orchestratorAPI) StopService(name string) error {
 		return fmt.Errorf("service manager not registered")
 	}
 	return handler.StopService(name)
+}
+
+// RemoveService stops and unregisters a specific service by delegating to the
+// registered service manager.
+func (a *orchestratorAPI) RemoveService(name string) error {
+	handler := GetServiceManager()
+	if handler == nil {
+		return fmt.Errorf("service manager not registered")
+	}
+	return handler.RemoveService(name)
 }
 
 // RestartService restarts a specific service by delegating to the registered service manager.

--- a/internal/api/orchestrator_test.go
+++ b/internal/api/orchestrator_test.go
@@ -245,6 +245,10 @@ func (m *mockOrchestratorHandler) RestartService(name string) error {
 	return m.restartErr
 }
 
+func (m *mockOrchestratorHandler) RemoveService(name string) error {
+	return m.stopErr
+}
+
 func (m *mockOrchestratorHandler) SubscribeToStateChanges() <-chan ServiceStateChangedEvent {
 	return m.eventChan
 }

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -106,6 +106,11 @@ type ServiceManagerHandler interface {
 	// RestartService restarts a service by name (stop followed by start).
 	RestartService(name string) error
 
+	// RemoveService stops a service and removes it from the service registry.
+	// Used when a service definition is deleted, so a later re-create with
+	// the same name is treated as a fresh service.
+	RemoveService(name string) error
+
 	// GetServiceStatus returns the current status of a service.
 	GetServiceStatus(name string) (*ServiceStatus, error)
 

--- a/internal/orchestrator/api_adapter.go
+++ b/internal/orchestrator/api_adapter.go
@@ -60,6 +60,10 @@ func (a *Adapter) StopService(name string) error {
 	return a.orchestrator.StopService(name)
 }
 
+func (a *Adapter) RemoveService(name string) error {
+	return a.orchestrator.RemoveService(name)
+}
+
 func (a *Adapter) RestartService(name string) error {
 	return a.orchestrator.RestartService(name)
 }

--- a/internal/orchestrator/lazy_registration_test.go
+++ b/internal/orchestrator/lazy_registration_test.go
@@ -88,3 +88,37 @@ func TestStartServiceUnknownServiceStillErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+// TestRemoveServiceUnregistersService verifies the delete-side counterpart of
+// lazy registration: RemoveService must drop the service from the registry so
+// a re-created definition with the same name reconciles as a fresh service.
+func TestRemoveServiceUnregistersService(t *testing.T) {
+	manager := &mockMCPServerManager{servers: map[string]api.MCPServerInfo{}}
+	api.RegisterMCPServerManager(manager)
+	t.Cleanup(func() { api.RegisterMCPServerManager(nil) })
+
+	o := New(Config{Aggregator: config.AggregatorConfig{}})
+	require.NoError(t, o.Start(context.Background()))
+	t.Cleanup(func() { _ = o.Stop() })
+
+	manager.servers["doomed-mcp"] = api.MCPServerInfo{
+		Name:      "doomed-mcp",
+		Type:      "streamable-http",
+		AutoStart: true,
+		URL:       "http://127.0.0.1:1", // closed port: start fails, registration must still happen
+		Timeout:   1,
+	}
+	_ = o.StartService("doomed-mcp")
+	_, exists := o.registry.Get("doomed-mcp")
+	require.True(t, exists, "precondition: service must be registered")
+
+	require.NoError(t, o.RemoveService("doomed-mcp"))
+
+	_, exists = o.registry.Get("doomed-mcp")
+	assert.False(t, exists, "service must be gone from the registry after RemoveService")
+
+	// Removing an unknown service reports not found.
+	err := o.RemoveService("doomed-mcp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -482,6 +482,28 @@ func (o *Orchestrator) StopService(name string) error {
 	return nil
 }
 
+// RemoveService stops a service and removes it from the registry.
+// This is used when a service definition is deleted, so that a later
+// re-create with the same name is reconciled as a fresh service instead
+// of matching the stale registry entry.
+func (o *Orchestrator) RemoveService(name string) error {
+	service, exists := o.registry.Get(name)
+	if !exists {
+		return api.NewServiceNotFoundError(name)
+	}
+
+	if err := service.Stop(o.ctx); err != nil {
+		return fmt.Errorf("failed to stop service %s: %w", name, err)
+	}
+
+	if err := o.registry.Unregister(name); err != nil {
+		return err
+	}
+
+	logging.Info("Orchestrator", "Removed service: %s", name)
+	return nil
+}
+
 // RestartService restarts a specific service by name.
 func (o *Orchestrator) RestartService(name string) error {
 	service, exists := o.registry.Get(name)

--- a/internal/reconciler/mcpserver_reconciler.go
+++ b/internal/reconciler/mcpserver_reconciler.go
@@ -395,14 +395,16 @@ func (r *MCPServerReconciler) reconcileDelete(ctx context.Context, req Reconcile
 		return ReconcileResult{}
 	}
 
-	// Stop the service
-	if err := r.orchestratorAPI.StopService(req.Name); err != nil {
-		// If service not found, it's already stopped
+	// Stop the service and remove it from the registry, so a later re-create
+	// with the same name is reconciled as a fresh service instead of matching
+	// the stale registry entry (which would leave it stopped forever).
+	if err := r.orchestratorAPI.RemoveService(req.Name); err != nil {
+		// If service not found, it's already removed
 		if IsNotFoundError(err) {
 			return ReconcileResult{}
 		}
 		return ReconcileResult{
-			Error:   fmt.Errorf("failed to stop service: %w", err),
+			Error:   fmt.Errorf("failed to remove service: %w", err),
 			Requeue: true,
 		}
 	}

--- a/internal/reconciler/mcpserver_reconciler_test.go
+++ b/internal/reconciler/mcpserver_reconciler_test.go
@@ -119,9 +119,9 @@ func TestMCPServerReconciler_ReconcileDelete(t *testing.T) {
 		t.Errorf("unexpected error for delete: %v", result.Error)
 	}
 
-	// Verify service was stopped
-	if !orchAPI.StoppedServices["deleted-server"] {
-		t.Error("expected service to be stopped on delete")
+	// Verify service was stopped and removed from the registry
+	if !orchAPI.RemovedServices["deleted-server"] {
+		t.Error("expected service to be removed on delete")
 	}
 }
 
@@ -316,8 +316,8 @@ func TestMCPServerReconciler_ReconcileStopError(t *testing.T) {
 		Health:      api.HealthHealthy,
 	})
 
-	// Simulate stop error
-	orchAPI.StopError = fmt.Errorf("failed to stop service")
+	// Simulate remove error
+	orchAPI.RemoveError = fmt.Errorf("failed to stop service")
 
 	reconciler := NewMCPServerReconciler(orchAPI, mgr, registry)
 

--- a/internal/reconciler/test_helpers_test.go
+++ b/internal/reconciler/test_helpers_test.go
@@ -36,11 +36,13 @@ type MockOrchestratorAPI struct {
 	StartedServices   map[string]bool
 	StoppedServices   map[string]bool
 	RestartedServices map[string]bool
+	RemovedServices   map[string]bool
 
 	// Configurable errors for testing error paths
 	StartError   error
 	StopError    error
 	RestartError error
+	RemoveError  error
 
 	// Event channel for state change subscription
 	EventChan chan api.ServiceStateChangedEvent
@@ -55,6 +57,7 @@ func NewMockOrchestratorAPI() *MockOrchestratorAPI {
 		StartedServices:   make(map[string]bool),
 		StoppedServices:   make(map[string]bool),
 		RestartedServices: make(map[string]bool),
+		RemovedServices:   make(map[string]bool),
 		EventChan:         make(chan api.ServiceStateChangedEvent, 100),
 		ServiceStatuses:   make(map[string]*api.ServiceStatus),
 	}
@@ -77,6 +80,16 @@ func (m *MockOrchestratorAPI) StopService(name string) error {
 		return m.StopError
 	}
 	m.StoppedServices[name] = true
+	return nil
+}
+
+func (m *MockOrchestratorAPI) RemoveService(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.RemoveError != nil {
+		return m.RemoveError
+	}
+	m.RemovedServices[name] = true
 	return nil
 }
 

--- a/internal/testing/scenarios/mcpserver-runtime-delete-recreate.yaml
+++ b/internal/testing/scenarios/mcpserver-runtime-delete-recreate.yaml
@@ -1,0 +1,158 @@
+name: "mcpserver-runtime-delete-recreate"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["mcpserver", "delete", "lifecycle", "service-management", "core-api", "regression"]
+timeout: "3m"
+
+# Test Story: Deleted MCPServer definitions can be re-created under the same name
+# Regression test for the delete side of issue #680: deleting an MCPServer
+# definition stopped the service but left a stale entry in the orchestrator's
+# service registry. Re-applying a definition with the same name then matched
+# the stale entry, the reconciler saw "config unchanged", and the service
+# stayed stopped forever instead of starting fresh.
+#
+# Given: A running MCPServer backed by a live mock MCP endpoint
+# When: I delete its definition, wait for the service to be fully removed,
+#       and re-create the same definition under the same name
+# Then: The service is removed from the registry on delete, and the re-created
+#       definition starts fresh (autoStart) and its tools are callable again
+
+pre_configuration:
+  mcp_servers:
+    - name: "recreate-mock"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "recreate_test_tool"
+            description: "A tool used to verify delete/re-create lifecycle"
+            input_schema:
+              type: "object"
+              properties:
+                message: { type: "string" }
+            responses:
+              - response:
+                  message: "{{ .message }}"
+                  server: "recreate-mock"
+                  status: "executed"
+
+steps:
+  # Phase 1: Create the server and bring it up
+  - id: "get-mock-endpoint"
+    description: "Read the pre-configured mock server to obtain its live endpoint URL"
+    tool: "core_mcpserver_get"
+    args:
+      name: "recreate-mock"
+    expected:
+      success: true
+      json_path:
+        name: "recreate-mock"
+        type: "streamable-http"
+
+  - id: "create-mcpserver"
+    description: "Create the MCPServer definition"
+    tool: "core_mcpserver_create"
+    args:
+      name: "recreated-server"
+      type: "streamable-http"
+      autoStart: true
+      url: "{{ get-mock-endpoint.url }}"
+      timeout: 30
+    expected:
+      success: true
+
+  - id: "start-mcpserver"
+    description: "Start the MCPServer service"
+    tool: "core_service_start"
+    args:
+      name: "recreated-server"
+    expected:
+      success: true
+
+  - id: "verify-mcpserver-connected"
+    description: "Verify the server reaches connected state"
+    tool: "core_service_status"
+    args:
+      name: "recreated-server"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        name: "recreated-server"
+        state: "connected"
+
+  # Phase 2: Delete the definition. Before the fix, the reconciler stopped the
+  # service but left it registered, so the status call kept succeeding and this
+  # step timed out.
+  - id: "delete-mcpserver"
+    description: "Delete the MCPServer definition"
+    tool: "core_mcpserver_delete"
+    args:
+      name: "recreated-server"
+    expected:
+      success: true
+
+  - id: "verify-service-removed"
+    description: "Verify the service is removed from the registry, not just stopped"
+    tool: "core_service_status"
+    args:
+      name: "recreated-server"
+    expected:
+      success: false
+      wait_for_state: "30s"
+
+  # Phase 3: Re-create the same definition under the same name. Before the fix,
+  # the stale registry entry made the reconciler treat this as an unchanged
+  # update and the service stayed stopped; now it must start fresh via autoStart
+  # without an explicit core_service_start.
+  - id: "recreate-mcpserver"
+    description: "Re-create the MCPServer definition with the same name"
+    tool: "core_mcpserver_create"
+    args:
+      name: "recreated-server"
+      type: "streamable-http"
+      autoStart: true
+      url: "{{ get-mock-endpoint.url }}"
+      timeout: 30
+    expected:
+      success: true
+
+  - id: "verify-recreated-mcpserver-connected"
+    description: "Verify the re-created server starts fresh and reaches connected state"
+    tool: "core_service_status"
+    args:
+      name: "recreated-server"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      json_path:
+        name: "recreated-server"
+        state: "connected"
+
+  # Phase 4: Prove the re-created server is usable end to end
+  - id: "call-tool-on-recreated-mcpserver"
+    description: "Call a tool exposed by the re-created server"
+    tool: "x_recreated-server_recreate_test_tool"
+    args:
+      message: "recreated-after-delete"
+    expected:
+      success: true
+      contains: ["recreated-after-delete", "executed"]
+
+cleanup:
+  - id: "cleanup-stop-recreated-mcpserver"
+    description: "Stop the re-created MCPServer service"
+    tool: "core_service_stop"
+    args:
+      name: "recreated-server"
+    expected:
+      success: true
+    continue_on_failure: true
+
+  - id: "cleanup-delete-recreated-mcpserver"
+    description: "Delete the re-created MCPServer definition"
+    tool: "core_mcpserver_delete"
+    args:
+      name: "recreated-server"
+    expected:
+      success: true
+    continue_on_failure: true


### PR DESCRIPTION
## What

Deleting an MCPServer definition stopped the service but left a stale entry in the orchestrator's service registry (`reconcileDelete` called `StopService` only — the reconciler had no way to unregister). Re-applying a definition with the same name then matched the stale entry, the reconciler took the update path, saw an unchanged config, and the service stayed stopped forever.

This is the delete-side counterpart of the lazy registration added for #680 (#1012, #1013), which explicitly deferred the delete path.

## How

- Add `RemoveService(name)` (stop + unregister) to the `Orchestrator` and plumb it through the API chain: `ServiceManagerHandler`, orchestrator `Adapter`, and `OrchestratorAPI`.
- `reconcileDelete` now calls `RemoveService` instead of `StopService`, so a later re-create with the same name is reconciled as a fresh service.

## Testing

- Unit: `TestRemoveServiceUnregistersService` (orchestrator) plus updated reconciler delete tests.
- Behavioral scenario `mcpserver-runtime-delete-recreate`: create → connect → delete → assert the service is fully removed (not just stopped) → re-create same name with autoStart → assert it reconnects and its tools are callable.
- Verified the scenario **fails on main** (times out with the service still registered after delete) and **passes with this fix**. Full `--concept mcpserver` (73 scenarios) and `--concept service` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)