### PR TITLE
feat(auth): return sign-in URL as structuredContent.authUrl on core_auth_login

### DIFF
--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -294,6 +294,13 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 	}
 
 	// Return the auth challenge as a tool result with the sign-in link
+	return authChallengeResult(serverName, challenge), nil
+}
+
+// authChallengeResult builds the tool result for a pending auth challenge.
+// The sign-in URL is carried both in the prose and as structuredContent.authUrl
+// so clients can read it without parsing the text.
+func authChallengeResult(serverName string, challenge *api.AuthChallenge) *api.CallToolResult {
 	return &api.CallToolResult{
 		Content: []any{fmt.Sprintf(
 			"Authentication Required\n\n"+
@@ -307,7 +314,10 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 			challenge.AuthURL,
 		)},
 		IsError: false,
-	}, nil
+		StructuredContent: map[string]any{
+			"authUrl": challenge.AuthURL,
+		},
+	}
 }
 
 // handleAuthLogout clears authentication for a specific MCP server.

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/muster/internal/api"
@@ -280,5 +281,30 @@ func TestGetMusterIssuer_NoFallbackToken(t *testing.T) {
 
 	if issuer != "" {
 		t.Errorf("expected empty issuer, got '%s'", issuer)
+	}
+}
+
+func TestAuthChallengeResult_StructuredAuthURL(t *testing.T) {
+	result := authChallengeResult("github", &api.AuthChallenge{
+		AuthURL: "https://example.com/oauth/start?state=abc",
+		Message: "authentication required",
+	})
+
+	if result.IsError {
+		t.Fatal("expected non-error result")
+	}
+
+	sc, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected structured content map, got %T", result.StructuredContent)
+	}
+	if sc["authUrl"] != "https://example.com/oauth/start?state=abc" {
+		t.Errorf("expected authUrl in structured content, got %v", sc["authUrl"])
+	}
+
+	// Prose must keep carrying the URL for text-only consumers.
+	text, ok := result.Content[0].(string)
+	if !ok || !strings.Contains(text, "https://example.com/oauth/start?state=abc") {
+		t.Errorf("expected sign-in URL in prose content, got %v", result.Content[0])
 	}
 }


### PR DESCRIPTION
## What

The auth challenge from `core_auth_login` carried the downstream sign-in URL only in prose, so clients (e.g. Backstage `muster-backend/src/authLogin.ts`) regex-parse the text and are coupled to the output format.

The challenge result now also sets the MCP `structuredContent` field:

```json
{ "authUrl": "https://..." }
```

The prose is unchanged, so text-only consumers keep working.

## How

Extracted the challenge return into `authChallengeResult()` and set `StructuredContent`, which `convertToMCPResult` already propagates to the MCP layer. Unit test asserts the URL appears in both the structured field and the prose.

Fixes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)