### PR TITLE
feat(cli): add auth flags to `muster create mcpserver`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -39,6 +39,18 @@ Examples:
   muster create mcpserver my-http-server --type=streamable-http --url=https://api.example.com/mcp --timeout=30
   muster create mcpserver my-sse-server --type=sse --url=https://sse.example.com/mcp --timeout=60
 
+Authentication (remote server types only):
+  --auth-type oauth                    Enable OAuth 2.0/OIDC authentication
+  --auth-issuer <url>                  Pin the authorization server issuer for servers
+                                       without RFC 9728 metadata (requires --auth-type=oauth)
+  --auth-scopes "<scopes>"             OAuth scopes for the pinned issuer (space-separated)
+  --forward-token                      Forward the session's ID token for SSO (implies oauth)
+  --required-audiences <a1,a2>         Extra audiences to request for the forwarded token
+
+  muster create mcpserver my-oauth-server --type=streamable-http --url=https://api.example.com/mcp --auth-type=oauth
+  muster create mcpserver my-pinned-server --type=streamable-http --url=https://api.example.com/mcp --auth-type=oauth --auth-issuer=https://auth.example.com --auth-scopes="openid profile"
+  muster create mcpserver my-sso-server --type=streamable-http --url=https://mcp.example.com/mcp --forward-token --required-audiences=dex-k8s-authenticator
+
 Note: The aggregator server must be running (use 'muster serve') before using these commands.`,
 	Args: cobra.MinimumNArgs(2),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -114,6 +126,17 @@ func parseMCPServerParameters(mcpServerName string) map[string]interface{} {
 	return result
 }
 
+// getOrCreateObjectMap retrieves an existing map[string]interface{} from args (used for
+// nested objects like auth), or creates one if it doesn't exist.
+func getOrCreateObjectMap(args map[string]interface{}, key string) map[string]interface{} {
+	if m, ok := args[key].(map[string]interface{}); ok {
+		return m
+	}
+	m := make(map[string]interface{})
+	args[key] = m
+	return m
+}
+
 // getOrCreateStringMap retrieves an existing map[string]string from args, or creates one if it doesn't exist.
 // This helper prevents nil map panics when adding key-value pairs to env or headers.
 func getOrCreateStringMap(args map[string]interface{}, key string) map[string]string {
@@ -186,6 +209,32 @@ func processMCPServerFlag(args map[string]interface{}, flagName, flagValue strin
 				headersMap := getOrCreateStringMap(args, "headers")
 				headersMap[parts[0]] = parts[1]
 			}
+		}
+	case "auth-type", "authType":
+		if hasValue {
+			getOrCreateObjectMap(args, "auth")["type"] = flagValue
+		}
+	case "forward-token", "forwardToken":
+		if hasValue {
+			getOrCreateObjectMap(args, "auth")["forwardToken"] = flagValue == stringTrue
+		} else {
+			getOrCreateObjectMap(args, "auth")["forwardToken"] = true
+		}
+	case "required-audiences", "requiredAudiences":
+		if hasValue && flagValue != "" {
+			audiences := strings.Split(flagValue, ",")
+			for j := range audiences {
+				audiences[j] = strings.TrimSpace(audiences[j])
+			}
+			getOrCreateObjectMap(args, "auth")["requiredAudiences"] = audiences
+		}
+	case "auth-issuer", "authIssuer":
+		if hasValue {
+			getOrCreateObjectMap(getOrCreateObjectMap(args, "auth"), "authorizationServer")["issuer"] = flagValue
+		}
+	case "auth-scopes", "authScopes":
+		if hasValue {
+			getOrCreateObjectMap(getOrCreateObjectMap(args, "auth"), "authorizationServer")["scopes"] = flagValue
 		}
 	}
 }

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProcessMCPServerFlagAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		flags    [][3]string // flagName, flagValue, hasValue ("1" = true)
+		expected map[string]interface{}
+	}{
+		{
+			name:  "auth type oauth",
+			flags: [][3]string{{"auth-type", "oauth", "1"}},
+			expected: map[string]interface{}{
+				"auth": map[string]interface{}{"type": "oauth"},
+			},
+		},
+		{
+			name: "oauth with pinned authorization server",
+			flags: [][3]string{
+				{"auth-type", "oauth", "1"},
+				{"auth-issuer", "https://auth.example.com", "1"},
+				{"auth-scopes", "openid profile", "1"},
+			},
+			expected: map[string]interface{}{
+				"auth": map[string]interface{}{
+					"type": "oauth",
+					"authorizationServer": map[string]interface{}{
+						"issuer": "https://auth.example.com",
+						"scopes": "openid profile",
+					},
+				},
+			},
+		},
+		{
+			name:  "bare forward-token defaults to true",
+			flags: [][3]string{{"forward-token", "", ""}},
+			expected: map[string]interface{}{
+				"auth": map[string]interface{}{"forwardToken": true},
+			},
+		},
+		{
+			name:  "forward-token explicit false",
+			flags: [][3]string{{"forward-token", "false", "1"}},
+			expected: map[string]interface{}{
+				"auth": map[string]interface{}{"forwardToken": false},
+			},
+		},
+		{
+			name: "forward-token with required audiences",
+			flags: [][3]string{
+				{"forward-token", "true", "1"},
+				{"required-audiences", "dex-k8s-authenticator, other-audience", "1"},
+			},
+			expected: map[string]interface{}{
+				"auth": map[string]interface{}{
+					"forwardToken":      true,
+					"requiredAudiences": []string{"dex-k8s-authenticator", "other-audience"},
+				},
+			},
+		},
+		{
+			name: "camelCase aliases",
+			flags: [][3]string{
+				{"authType", "oauth", "1"},
+				{"authIssuer", "https://auth.example.com", "1"},
+				{"forwardToken", "true", "1"},
+				{"requiredAudiences", "aud1", "1"},
+			},
+			expected: map[string]interface{}{
+				"auth": map[string]interface{}{
+					"type":              "oauth",
+					"forwardToken":      true,
+					"requiredAudiences": []string{"aud1"},
+					"authorizationServer": map[string]interface{}{
+						"issuer": "https://auth.example.com",
+					},
+				},
+			},
+		},
+		{
+			name:     "no auth flags leaves auth unset",
+			flags:    [][3]string{{"url", "https://api.example.com/mcp", "1"}},
+			expected: map[string]interface{}{"url": "https://api.example.com/mcp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]interface{}{}
+			for _, f := range tt.flags {
+				processMCPServerFlag(args, f[0], f[1], f[2] == "1")
+			}
+			if !reflect.DeepEqual(args, tt.expected) {
+				t.Errorf("got %#v, want %#v", args, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds CLI flags for the supported MCPServer auth modes, so auth is configurable without a full manifest and the CLI journey carries the same guided auth model as the developer-portal registration wizard (epic giantswarm/giantswarm#37434):

- `--auth-type oauth` with optional `--auth-issuer` / `--auth-scopes` (authorizationServer override for servers without RFC 9728 metadata)
- `--forward-token` with optional `--required-audiences` (comma-separated)

camelCase aliases (`--authType`, `--forwardToken`, …) work too, consistent with the existing `--autoStart`/`--auto-start` pattern. Flags map 1:1 to the existing `auth` object of `core_mcpserver_create`; validation (type/mode exclusivity, remote-only) stays server-side where it already lives.

## Testing

- Unit test `TestProcessMCPServerFlagAuth` covers flag→payload composition for all new flags including bare `--forward-token` and aliases.
- Server-side acceptance of the exact payload shapes is already scenario-covered (`mcpserver-authorization-server-override.yaml`, `dex-token-forward.yaml`); this PR changes only client-side flag parsing, which scenarios can't exercise (they call core tools directly), hence the unit test.
- E2E smoke with a fresh build against a local `muster serve`: both flag sets round-trip through `create`/`get`:

```yaml
auth:
    authorizationServer:
        issuer: https://auth.example.com
        scopes: openid profile
    type: oauth
---
auth:
    forwardToken: true
    requiredAudiences:
        - dex-k8s-authenticator
        - other
```

Fixes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)