### PR TITLE
test: fast-retry env overrides to fix delete-recreate CI flake

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -23,8 +24,22 @@ const (
 	StopReasonDependency
 )
 
-// RetryInterval is the interval at which the orchestrator checks for failed servers to retry.
-const RetryInterval = 30 * time.Second
+// RetryInterval is the interval at which the orchestrator checks for failed
+// servers to retry. Overridable via MUSTER_ORCHESTRATOR_RETRY_INTERVAL (a Go
+// duration, e.g. "1s") so the integration test harness can pick up expired
+// backoffs promptly instead of waiting for the next production-length tick.
+var RetryInterval = durationFromEnv("MUSTER_ORCHESTRATOR_RETRY_INTERVAL", 30*time.Second)
+
+// durationFromEnv reads a Go duration from the named environment variable,
+// falling back to def when unset or unparsable.
+func durationFromEnv(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
+}
 
 // MaxConcurrentRetries limits the number of MCPServers that can be retried simultaneously.
 // This prevents a "thundering herd" scenario where many failed servers retry at once,

--- a/internal/services/mcpserver/service.go
+++ b/internal/services/mcpserver/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -29,13 +30,28 @@ const UnreachableThreshold = 3
 
 // Exponential backoff configuration for unreachable servers.
 const (
-	// InitialBackoff is the initial retry interval after first failure (30 seconds)
-	InitialBackoff = 30 * time.Second
 	// MaxBackoff is the maximum retry interval (30 minutes)
 	MaxBackoff = 30 * time.Minute
 	// BackoffMultiplier is the factor by which backoff increases on each failure
 	BackoffMultiplier = 2.0
 )
+
+// InitialBackoff is the initial retry interval after the first connection
+// failure. Overridable via MUSTER_MCPSERVER_INITIAL_BACKOFF (a Go duration,
+// e.g. "1s") so the integration test harness can recover from transient
+// connect failures without waiting out production backoff.
+var InitialBackoff = durationFromEnv("MUSTER_MCPSERVER_INITIAL_BACKOFF", 30*time.Second)
+
+// durationFromEnv reads a Go duration from the named environment variable,
+// falling back to def when unset or unparsable.
+func durationFromEnv(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
+}
 
 // RestartGracePeriod is the pause between stop and start during a restart.
 // This allows time for:

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -980,6 +980,16 @@ func (m *musterInstanceManager) startMusterProcess(ctx context.Context, configPa
 
 	cmd := exec.CommandContext(ctx, musterPath, args...) //nolint:gosec
 
+	// Under parallel load a first connect to a mock endpoint can fail
+	// transiently; with production timing that costs 30s initial backoff plus
+	// up to a 30s orchestrator tick before the retry, blowing past scenario
+	// wait_for_state budgets. Fast-retry inside the harness so transient
+	// failures recover in seconds.
+	cmd.Env = append(os.Environ(),
+		"MUSTER_MCPSERVER_INITIAL_BACKOFF=1s",
+		"MUSTER_ORCHESTRATOR_RETRY_INTERVAL=1s",
+	)
+
 	// Configure the process attributes (platform-specific)
 	configureProcAttr(cmd)
 


### PR DESCRIPTION
## Problem

`mcpserver-runtime-delete-recreate` keeps failing CI at ~62s under `muster test --parallel 50` — most recently on #1026's go-build job — even after #1024 extended its `wait_for_state` budgets to 60s.

## Root cause

The flake is structural, not a too-short wait. When a first connect to a scenario's mock endpoint fails transiently under parallel startup load:

- the service enters exponential backoff with `InitialBackoff = 30s`, and
- the orchestrator's reconnect loop only ticks every `RetryInterval = 30s`, with arbitrary phase relative to the failure.

So a single transient failure recovers anywhere between t+30s and t+60s, and a second failure pushes past t+90s. No per-step wait budget survives that; bumping waits again is whack-a-mole.

## Fix

Make both timings overridable via env (`MUSTER_MCPSERVER_INITIAL_BACKOFF`, `MUSTER_ORCHESTRATOR_RETRY_INTERVAL`, parsed as Go durations; production defaults unchanged at 30s), and have the integration test harness spawn `muster serve` with both set to `1s`. Transient connect failures now recover in ~1–2s for every scenario, fixing this class of flake rather than this one symptom.

## Testing

- `go test ./internal/services/mcpserver/ ./internal/orchestrator/` green (backoff tests use the var relatively, unaffected).
- Fresh build, `./muster test --scenario mcpserver-runtime-delete-recreate` green (3.4s).
- Fresh build, full CI invocation `./muster test --parallel 50 --base-port 30000`: **181/181 passed in 5.6s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)