### PR TITLE
feat(mcpserver): stamp authenticated subject on create (registered-by annotation)

### DIFF
--- a/internal/api/mcpserver.go
+++ b/internal/api/mcpserver.go
@@ -265,6 +265,11 @@ func (t MCPServerType) IsRemote() bool {
 	return t == MCPServerTypeStreamableHTTP || t == MCPServerTypeSSE
 }
 
+// RegisteredByAnnotation records the authenticated subject that registered an
+// MCPServer. Stamped server-side on create so attribution cannot be spoofed or
+// omitted by clients (issue #1021). The key is shared with the developer portal.
+const RegisteredByAnnotation = "ui.giantswarm.io/registered-by"
+
 // MCPServerInfo contains consolidated MCP server information for API responses.
 // This type is used when returning server information through the API, providing
 // a flattened view of server configuration and runtime state that is convenient
@@ -361,6 +366,11 @@ type MCPServerInfo struct {
 	// ConnectedAt indicates when the current session connected to this server.
 	// Only populated if there is an active session connection.
 	ConnectedAt *time.Time `json:"connectedAt,omitempty"`
+
+	// RegisteredBy is the authenticated subject that registered this server,
+	// read from the RegisteredByAnnotation. Empty when the server was created
+	// without an authenticated context (e.g. GitOps-applied CRs).
+	RegisteredBy string `json:"registeredBy,omitempty"`
 }
 
 // MCPServerManagerHandler defines the interface for MCP server management operations.

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	oauthhandler "github.com/giantswarm/mcp-oauth/handler"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -195,7 +196,23 @@ func convertCRDToInfo(server *musterv1alpha1.MCPServer) api.MCPServerInfo {
 	// Generate user-friendly status message based on state and error
 	info.StatusMessage = generateStatusMessage(info.State, info.Error, server.Name)
 
+	info.RegisteredBy = server.Annotations[api.RegisteredByAnnotation]
+
 	return info
+}
+
+// subjectFromContext resolves the authenticated caller's subject, mirroring the
+// aggregator's resolution order: the injector middleware's context key first,
+// then the mcp-oauth UserInfo (which survives middleware early-exit paths).
+// Returns "" for unauthenticated transports (stdio, plain HTTP).
+func subjectFromContext(ctx context.Context) string {
+	if sub := api.GetSubjectFromContext(ctx); sub != "" {
+		return sub
+	}
+	if userInfo, ok := oauthhandler.UserInfoFromContext(ctx); ok && userInfo != nil {
+		return userInfo.ID
+	}
+	return ""
 }
 
 // generateStatusMessage creates a user-friendly, actionable status message
@@ -496,7 +513,7 @@ func (a *Adapter) ExecuteTool(ctx context.Context, toolName string, args map[str
 	case "mcpserver_validate":
 		return a.handleMCPServerValidate(args)
 	case "mcpserver_create":
-		return a.handleMCPServerCreate(args)
+		return a.handleMCPServerCreate(ctx, args)
 	case "mcpserver_update":
 		return a.handleMCPServerUpdate(args)
 	case "mcpserver_delete":
@@ -632,7 +649,7 @@ func (a *Adapter) handleMCPServerValidate(args map[string]interface{}) (*api.Cal
 	}, nil
 }
 
-func (a *Adapter) handleMCPServerCreate(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleMCPServerCreate(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	var req api.MCPServerCreateRequest
 	if err := api.ParseRequest(args, &req); err != nil {
 		return &api.CallToolResult{
@@ -644,13 +661,19 @@ func (a *Adapter) handleMCPServerCreate(args map[string]interface{}) (*api.CallT
 	// Convert request to CRD once for reuse
 	serverCRD := a.convertRequestToCRD(&req)
 
+	// Stamp the authenticated subject so registration is attributable even for
+	// clients that don't stamp it themselves (issue #1021). Update preserves it
+	// via its get-modify-update flow.
+	if subject := subjectFromContext(ctx); subject != "" {
+		serverCRD.Annotations = map[string]string{api.RegisteredByAnnotation: subject}
+	}
+
 	// Validate the definition
 	if err := a.validateMCPServer(serverCRD); err != nil {
 		return simpleError(fmt.Sprintf("Invalid MCP server definition: %v", err))
 	}
 
 	// Create the new MCP server using the unified client
-	ctx := context.Background()
 	if err := a.client.CreateMCPServer(ctx, serverCRD); err != nil {
 		if errors.IsAlreadyExists(err) {
 			return simpleError(fmt.Sprintf("MCP server '%s' already exists", req.Name))

--- a/internal/testing/scenarios/mcpserver-registered-by-stamp.yaml
+++ b/internal/testing/scenarios/mcpserver-registered-by-stamp.yaml
@@ -1,0 +1,101 @@
+name: "mcpserver-registered-by-stamp"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  Verify that core_mcpserver_create stamps the authenticated subject into the
+  ui.giantswarm.io/registered-by annotation server-side (issue #1021), exposed
+  as registeredBy on core_mcpserver_get, and that core_mcpserver_update
+  preserves it. Registration is open (no authorization on mcpserver mutation
+  tools), so the server-side stamp is the only durable attribution for who
+  changed the shared tool surface — client-side stamping is spoofable.
+tags: ["mcpserver", "create", "oauth", "attribution", "core-api"]
+timeout: "2m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "muster-idp"
+      scopes: ["openid", "profile", "email"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "muster-client"
+      client_secret: "muster-secret"
+      use_as_muster_oauth_server: true
+
+steps:
+  - id: "auth-as-registrar"
+    description: "Authenticate to muster with a distinct subject"
+    tool: "test_muster_auth_login"
+    args:
+      subject: "registrar-user"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: "create-registrar-session"
+    description: "Create an authenticated user session"
+    tool: "test_create_user"
+    args:
+      name: "registrar"
+    expected:
+      success: true
+
+  - id: "switch-to-registrar"
+    description: "Switch to the authenticated session"
+    tool: "test_switch_user"
+    args:
+      name: "registrar"
+    expected:
+      success: true
+
+  - id: "create-mcpserver"
+    description: "Create an MCP server as the authenticated user"
+    tool: "core_mcpserver_create"
+    args:
+      name: "stamped-server"
+      type: "stdio"
+      command: "echo"
+      args: ["stamped"]
+      autoStart: false
+    expected:
+      success: true
+
+  - id: "verify-registered-by-stamped"
+    description: "registeredBy carries the authenticated subject"
+    tool: "core_mcpserver_get"
+    args:
+      name: "stamped-server"
+    expected:
+      success: true
+      json_path:
+        name: "stamped-server"
+        registeredBy: "registrar-user"
+
+  - id: "update-mcpserver"
+    description: "Update the server definition"
+    tool: "core_mcpserver_update"
+    args:
+      name: "stamped-server"
+      description: "updated description"
+    expected:
+      success: true
+
+  - id: "verify-registered-by-preserved"
+    description: "registeredBy survives the update"
+    tool: "core_mcpserver_get"
+    args:
+      name: "stamped-server"
+    expected:
+      success: true
+      json_path:
+        registeredBy: "registrar-user"
+
+cleanup:
+  - id: "delete-mcpserver"
+    description: "Delete the test MCP server"
+    tool: "core_mcpserver_delete"
+    args:
+      name: "stamped-server"
+    expected:
+      success: true


### PR DESCRIPTION
## What

`core_mcpserver_create` now stamps the authenticated caller's subject into the `ui.giantswarm.io/registered-by` annotation server-side. `core_mcpserver_update` preserves it via its existing get-modify-update flow. The value is exposed as `registeredBy` on `mcpserver_get`/`mcpserver_list` responses so clients (developer portal) can display attribution.

Subject resolution mirrors the aggregator's: `api.SubjectContextKey` first, then mcp-oauth `UserInfo.ID` (survives middleware early-exit paths). Unauthenticated transports (stdio, plain HTTP) stamp nothing.

## Why

Registration is open (no authorization on mcpserver mutation tools, deliberately deferred to the permission plan), so a server-side stamp is the only durable attribution for who changed the shared tool surface. Client-side stamping is trivially spoofable/omittable by non-portal clients.

Fixes #1021 (surfaced by the MCP-registration-wizard plan, epic giantswarm/giantswarm#37434).

## Testing

- New behavioral scenario `mcpserver-registered-by-stamp`: OAuth-protected muster, authenticated session with subject `registrar-user`, create → `registeredBy` stamped, update → preserved. Passes locally with a fresh build.
- `mcpserver-crud` scenario, unit tests for `internal/mcpserver` + `internal/api`, and `make lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)