### PR TITLE
docs: replace retired agentic-platform names in chart docs and test fixture

### DIFF
--- a/helm/muster-crds/README.md
+++ b/helm/muster-crds/README.md
@@ -14,9 +14,8 @@ This chart contains only the muster CustomResourceDefinitions:
 - `workflows.muster.giantswarm.io` (kind: `Workflow`)
 
 It is a standalone option for managing the CRD lifecycle independently of the
-muster application chart — useful for a downstream `agentic-platform-crds`
-umbrella, or for plain-Helm users who want CRD updates to apply on
-`helm upgrade`.
+muster application chart — useful for a downstream umbrella chart, or for
+plain-Helm users who want CRD updates to apply on `helm upgrade`.
 
 The CRDs are loaded from `files/crds/*.yaml` by `templates/crds.yaml` (regular
 chart templates, not the Helm 3 `crds/` special directory), so they are

--- a/helm/muster-crds/UPGRADE.md
+++ b/helm/muster-crds/UPGRADE.md
@@ -26,7 +26,7 @@ updates `crds/` on `helm upgrade` — that is exactly why this standalone chart
 users instead set `install.crds`/`upgrade.crds: CreateReplace` on the muster
 HelmRelease.
 
-In an umbrella chart (`agentic-platform-crds`), encode the ordering with an
+In an umbrella chart, encode the ordering with an
 explicit dependency ordering or a sync wave so the CRD chart always lands first.
 
 ## CRD schema-deprecation ratchet

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -372,7 +372,7 @@ muster:
       # oversight. The requirement is that every critical record is
       # reconstructable at startup, so a Valkey restart, PVC recreation, or
       # fresh install is non-fatal. Valkey is deployed outside this chart (as a
-      # sibling component of the agentic-platform umbrella), so persistence
+      # sibling component of the agent-platform umbrella), so persistence
       # tuning would live there, not here.
       #
       # Why not AOF (appendonly yes)? It does NOT protect the data that is lost

--- a/internal/server/seed_broker_clients_test.go
+++ b/internal/server/seed_broker_clients_test.go
@@ -59,7 +59,7 @@ func TestSeedBrokerClients(t *testing.T) {
 		t.Cleanup(func() { api.RegisterSecretCredentialsHandler(prev) })
 
 		broker := config.TokenExchangeBrokerConfig{
-			DefaultSecretNamespace: "agentic-platform",
+			DefaultSecretNamespace: "agent-platform",
 			BrokerClients: map[string]config.BrokerClientConfig{
 				clientID: {ClientCredentialsSecretRef: &config.BrokerSecretRefConfig{Name: "muster-broker-clients"}},
 			},


### PR DESCRIPTION
## Problem

Phase 4 of the agent-platform rename (giantswarm/giantswarm#36869): muster still references the old product name and the retired `agentic-platform-crds` chart.

## Change

The valkey persistence comment in `helm/muster/values.yaml` now names the `agent-platform` umbrella, `helm/muster-crds/README.md` and `UPGRADE.md` drop the retired `agentic-platform-crds` chart in favor of a generic umbrella-chart mention, and the broker-seed test fixture namespace moves to `agent-platform`. Historical CHANGELOG entries are left as-is.