### PR TITLE
fix(reconciler): break status-sync write loop that swallowed MCPServer deletes

### DIFF
--- a/internal/client/filesystem/client.go
+++ b/internal/client/filesystem/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +33,13 @@ const defaultNamespace = "default"
 // interface methods, shared helpers, and the sub-resource writer types.
 type Client struct {
 	basePath string
+
+	// mu serializes all resource file mutations (create/update/delete/status).
+	// Without it, a status sync's read-modify-write races a concurrent delete:
+	// the sync reads the definition, the delete removes the file, and the
+	// sync's rename resurrects it — the definition comes back as a zombie and
+	// the service is never torn down (delete-recreate CI flake).
+	mu sync.Mutex
 }
 
 // New returns a filesystem-backed Client rooted at basePath. An empty

--- a/internal/client/filesystem/mcpserver.go
+++ b/internal/client/filesystem/mcpserver.go
@@ -34,8 +34,13 @@ func (f *Client) DeleteMCPServer(_ context.Context, name, _ string) error {
 	return f.deleteResource(name, mcpServerMeta)
 }
 
-// UpdateMCPServerStatus rewrites the entire YAML — filesystem mode embeds
-// status alongside spec, so there is no separate status sub-resource.
-func (f *Client) UpdateMCPServerStatus(ctx context.Context, server *musterv1alpha1.MCPServer) error {
-	return f.UpdateMCPServer(ctx, server)
+// UpdateMCPServerStatus applies only the status onto the current on-disk
+// definition — filesystem mode embeds status alongside spec, so this must not
+// rewrite the caller's (possibly stale) spec, and must not resurrect a
+// definition that was deleted after the caller read it.
+func (f *Client) UpdateMCPServerStatus(_ context.Context, server *musterv1alpha1.MCPServer) error {
+	var current musterv1alpha1.MCPServer
+	return f.updateResourceStatus(server.Name, &current, func() {
+		current.Status = server.Status
+	}, mcpServerMeta)
 }

--- a/internal/client/filesystem/store.go
+++ b/internal/client/filesystem/store.go
@@ -99,9 +99,30 @@ func (f *Client) listResources(list client.ObjectList, factory func() client.Obj
 	return meta.SetList(list, items)
 }
 
+// writeResourceLocked marshals obj and atomically writes its YAML file.
+// Caller must hold f.mu.
+func (f *Client) writeResourceLocked(obj client.Object, m resourceMeta) error {
+	if obj.GetNamespace() == "" {
+		obj.SetNamespace(defaultNamespace)
+	}
+
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s %s: %w", m.gr.Resource, obj.GetName(), err)
+	}
+	filePath := m.filePath(f.basePath, obj.GetName())
+	if err := atomicWriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write %s file %s: %w", m.gr.Resource, filePath, err)
+	}
+	return nil
+}
+
 // createResource writes obj to its YAML file. Returns AlreadyExists if the
 // file is already present.
 func (f *Client) createResource(obj client.Object, m resourceMeta) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	filePath := m.filePath(f.basePath, obj.GetName())
 	if _, err := os.Stat(filePath); err == nil {
 		return errors.NewAlreadyExists(m.gr, obj.GetName())
@@ -112,44 +133,62 @@ func (f *Client) createResource(obj client.Object, m resourceMeta) error {
 		return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
 	}
 
-	if obj.GetNamespace() == "" {
-		obj.SetNamespace(defaultNamespace)
-	}
-
-	data, err := yaml.Marshal(obj)
-	if err != nil {
-		return fmt.Errorf("failed to marshal %s %s: %w", m.gr.Resource, obj.GetName(), err)
-	}
-	if err := atomicWriteFile(filePath, data, 0644); err != nil {
-		return fmt.Errorf("failed to write %s file %s: %w", m.gr.Resource, filePath, err)
-	}
-	return nil
+	return f.writeResourceLocked(obj, m)
 }
 
 // updateResource rewrites obj's YAML file. Returns NotFound if the file is
 // missing.
 func (f *Client) updateResource(obj client.Object, m resourceMeta) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	filePath := m.filePath(f.basePath, obj.GetName())
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return errors.NewNotFound(m.gr, obj.GetName())
 	}
 
-	if obj.GetNamespace() == "" {
-		obj.SetNamespace(defaultNamespace)
-	}
+	return f.writeResourceLocked(obj, m)
+}
 
-	data, err := yaml.Marshal(obj)
+// updateResourceStatus applies only a status change onto the CURRENT on-disk
+// definition, under the mutation lock. current must be a freshly allocated
+// object of the right type; applyStatus copies the caller's status onto it
+// after the re-read. Re-reading under the lock prevents two races inherent in
+// status sync's read-modify-write: resurrecting a definition that was deleted
+// after the caller read it (the delete-recreate CI flake), and clobbering a
+// concurrent spec update with the caller's stale spec.
+func (f *Client) updateResourceStatus(name string, current client.Object, applyStatus func(), m resourceMeta) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if err := f.getResource(name, current, m); err != nil {
+		return err // NotFound: definition was deleted — never resurrect it
+	}
+	before, err := yaml.Marshal(current)
 	if err != nil {
-		return fmt.Errorf("failed to marshal %s %s: %w", m.gr.Resource, obj.GetName(), err)
+		return fmt.Errorf("failed to marshal %s %s: %w", m.gr.Resource, name, err)
 	}
-	if err := atomicWriteFile(filePath, data, 0644); err != nil {
-		return fmt.Errorf("failed to write %s file %s: %w", m.gr.Resource, filePath, err)
+	applyStatus()
+	after, err := yaml.Marshal(current)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s %s: %w", m.gr.Resource, name, err)
 	}
-	return nil
+	// Skip no-change writes. Every write fires a filesystem watch event that
+	// schedules another reconcile, whose status sync writes again: an
+	// unconditional write here turns the reconciler into a self-feeding loop
+	// (one rewrite per debounce interval per resource, forever) and keeps a
+	// permanent write-vs-delete race window open.
+	if string(before) == string(after) {
+		return nil
+	}
+	return f.writeResourceLocked(current, m)
 }
 
 // deleteResource removes the YAML file. Returns NotFound if missing.
 func (f *Client) deleteResource(name string, m resourceMeta) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	filePath := m.filePath(f.basePath, name)
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return errors.NewNotFound(m.gr, name)

--- a/internal/client/filesystem/store_test.go
+++ b/internal/client/filesystem/store_test.go
@@ -1,0 +1,97 @@
+package filesystem
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+)
+
+func newTestServer(name string) *musterv1alpha1.MCPServer {
+	return &musterv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       musterv1alpha1.MCPServerSpec{Type: "streamable-http", URL: "http://localhost:1/mcp"},
+	}
+}
+
+// TestUpdateMCPServerStatus_DoesNotResurrectDeleted pins the fix for the
+// delete-recreate CI flake: a status sync that read the definition before a
+// concurrent delete must NOT write the file back into existence. A
+// resurrected definition reconciles as "existing and up to date", so the
+// service teardown never happens.
+func TestUpdateMCPServerStatus_DoesNotResurrectDeleted(t *testing.T) {
+	ctx := context.Background()
+	c := New(t.TempDir())
+
+	server := newTestServer("doomed")
+	if err := c.CreateMCPServer(ctx, server); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Status syncer reads the definition (pre-delete snapshot)...
+	stale, err := c.GetMCPServer(ctx, "doomed", "default")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	stale.Status.State = musterv1alpha1.MCPServerStateConnected
+
+	// ...the definition is deleted concurrently...
+	if err := c.DeleteMCPServer(ctx, "doomed", "default"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// ...and the syncer's status write must fail NotFound, not resurrect.
+	if err := c.UpdateMCPServerStatus(ctx, stale); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound from status update after delete, got %v", err)
+	}
+	if _, err := os.Stat(mcpServerMeta.filePath(c.basePath, "doomed")); !os.IsNotExist(err) {
+		t.Fatal("status update resurrected the deleted definition file")
+	}
+}
+
+// TestUpdateMCPServerStatus_PreservesConcurrentSpec verifies a status write
+// applies only status onto the current on-disk spec instead of clobbering it
+// with the (stale) spec the status writer read earlier.
+func TestUpdateMCPServerStatus_PreservesConcurrentSpec(t *testing.T) {
+	ctx := context.Background()
+	c := New(t.TempDir())
+
+	if err := c.CreateMCPServer(ctx, newTestServer("shared")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	stale, err := c.GetMCPServer(ctx, "shared", "default")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	stale.Status.State = musterv1alpha1.MCPServerStateConnected
+
+	// Concurrent spec update lands after the status writer's read.
+	updated, err := c.GetMCPServer(ctx, "shared", "default")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	updated.Spec.URL = "http://localhost:2/mcp"
+	if err := c.UpdateMCPServer(ctx, updated); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if err := c.UpdateMCPServerStatus(ctx, stale); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	final, err := c.GetMCPServer(ctx, "shared", "default")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if final.Spec.URL != "http://localhost:2/mcp" {
+		t.Errorf("status write clobbered concurrent spec update: url=%s", final.Spec.URL)
+	}
+	if final.Status.State != musterv1alpha1.MCPServerStateConnected {
+		t.Errorf("status not applied: state=%s", final.Status.State)
+	}
+}

--- a/internal/client/filesystem/workflow.go
+++ b/internal/client/filesystem/workflow.go
@@ -34,8 +34,13 @@ func (f *Client) DeleteWorkflow(_ context.Context, name, _ string) error {
 	return f.deleteResource(name, workflowMeta)
 }
 
-// UpdateWorkflowStatus rewrites the entire YAML — filesystem mode embeds
-// status alongside spec, so there is no separate status sub-resource.
-func (f *Client) UpdateWorkflowStatus(ctx context.Context, w *musterv1alpha1.Workflow) error {
-	return f.UpdateWorkflow(ctx, w)
+// UpdateWorkflowStatus applies only the status onto the current on-disk
+// definition — filesystem mode embeds status alongside spec, so this must not
+// rewrite the caller's (possibly stale) spec, and must not resurrect a
+// definition that was deleted after the caller read it.
+func (f *Client) UpdateWorkflowStatus(_ context.Context, w *musterv1alpha1.Workflow) error {
+	var current musterv1alpha1.Workflow
+	return f.updateResourceStatus(w.Name, &current, func() {
+		current.Status = w.Status
+	}, workflowMeta)
 }

--- a/internal/reconciler/manager.go
+++ b/internal/reconciler/manager.go
@@ -70,6 +70,9 @@ func NewManager(config ManagerConfig) *Manager {
 	if config.ReconcileTimeout == 0 {
 		config.ReconcileTimeout = 30 * time.Second
 	}
+	if config.ResyncInterval == 0 {
+		config.ResyncInterval = 30 * time.Second
+	}
 	if config.DisabledResourceTypes == nil {
 		config.DisabledResourceTypes = make(map[ResourceType]bool)
 	}
@@ -144,6 +147,10 @@ func (m *Manager) Start(ctx context.Context) error {
 	// Start event processor
 	m.wg.Add(1)
 	go m.processChangeEvents()
+
+	// Start periodic resync (level-based safety net for lost change events)
+	m.wg.Add(1)
+	go m.periodicResync()
 
 	// Start workers
 	for i := 0; i < m.config.WorkerCount; i++ {
@@ -222,6 +229,52 @@ func (m *Manager) processChangeEvents() {
 				return
 			}
 			m.handleChangeEvent(event)
+		}
+	}
+}
+
+// periodicResync enqueues a reconcile for every resource known to each
+// registered ResyncLister, on a fixed interval. Change detection alone is
+// edge-triggered: a dropped or coalesced event (fsnotify on overlayfs, watch
+// hiccups) leaves the system permanently diverged — most visibly a re-created
+// MCPServer definition whose service is never started. Resync makes any such
+// divergence self-heal within one interval; in-sync resources reconcile as
+// cheap no-ops. The queue deduplicates, so resync never piles up requests.
+func (m *Manager) periodicResync() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.config.ResyncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.resyncAll()
+		}
+	}
+}
+
+// resyncAll enqueues reconcile requests for all resources enumerated by
+// reconcilers that implement ResyncLister.
+func (m *Manager) resyncAll() {
+	m.mu.RLock()
+	listers := make(map[ResourceType]ResyncLister)
+	for resourceType, reconciler := range m.reconcilers {
+		if lister, ok := reconciler.(ResyncLister); ok && !m.config.DisabledResourceTypes[resourceType] {
+			listers[resourceType] = lister
+		}
+	}
+	m.mu.RUnlock()
+
+	for resourceType, lister := range listers {
+		for _, name := range lister.ResyncNames() {
+			m.queue.Add(ReconcileRequest{
+				Type:    resourceType,
+				Name:    name,
+				Attempt: 1,
+			})
 		}
 	}
 }

--- a/internal/reconciler/manager_test.go
+++ b/internal/reconciler/manager_test.go
@@ -369,3 +369,60 @@ func TestManager_GetWatchMode(t *testing.T) {
 		t.Errorf("expected watch mode %s, got %s", WatchModeFilesystem, mode)
 	}
 }
+
+// mockResyncReconciler is a mockReconciler that also implements ResyncLister.
+type mockResyncReconciler struct {
+	mockReconciler
+	names []string
+}
+
+func (m *mockResyncReconciler) ResyncNames() []string {
+	return m.names
+}
+
+// TestManager_PeriodicResync verifies that resources enumerated by a
+// ResyncLister are reconciled periodically without any change event. This is
+// the safety net for lost filesystem events (issue: delete-recreate CI flake):
+// an edge-triggered-only reconciler never recovers from a dropped event.
+func TestManager_PeriodicResync(t *testing.T) {
+	config := ManagerConfig{
+		Mode:           WatchModeFilesystem,
+		FilesystemPath: t.TempDir(),
+		WorkerCount:    1,
+		ResyncInterval: 20 * time.Millisecond,
+	}
+	manager := NewManager(config)
+
+	reconciled := make(chan ReconcileRequest, 16)
+	reconciler := &mockResyncReconciler{
+		mockReconciler: mockReconciler{
+			resourceType: ResourceTypeMCPServer,
+			reconcileFunc: func(ctx context.Context, req ReconcileRequest) ReconcileResult {
+				select {
+				case reconciled <- req:
+				default:
+				}
+				return ReconcileResult{}
+			},
+		},
+		names: []string{"lost-event-server"},
+	}
+
+	if err := manager.RegisterReconciler(reconciler); err != nil {
+		t.Fatalf("failed to register reconciler: %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start manager: %v", err)
+	}
+	defer func() { _ = manager.Stop() }()
+
+	// No change event is ever emitted; the resync loop alone must reconcile.
+	select {
+	case req := <-reconciled:
+		if req.Name != "lost-event-server" {
+			t.Errorf("expected resync reconcile for lost-event-server, got %s", req.Name)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("periodic resync never reconciled the resource")
+	}
+}

--- a/internal/reconciler/mcpserver_reconciler.go
+++ b/internal/reconciler/mcpserver_reconciler.go
@@ -71,6 +71,27 @@ func (r *MCPServerReconciler) GetResourceType() ResourceType {
 	return ResourceTypeMCPServer
 }
 
+// ResyncNames implements ResyncLister: the union of all MCPServer definition
+// names and all registered MCPServer service names. Including registry-only
+// names lets resync heal a lost delete event (service running without a
+// definition); definition names heal lost create/update events.
+func (r *MCPServerReconciler) ResyncNames() []string {
+	seen := make(map[string]struct{})
+	for _, info := range r.mcpServerManager.ListMCPServers() {
+		seen[info.Name] = struct{}{}
+	}
+	for _, svc := range r.serviceRegistry.GetAll() {
+		if svc.GetType() == api.TypeMCPServer {
+			seen[svc.GetName()] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	return names
+}
+
 // Reconcile processes a single MCPServer reconciliation request.
 //
 // After successful reconciliation, this returns RequeueAfter to enable periodic

--- a/internal/reconciler/types.go
+++ b/internal/reconciler/types.go
@@ -146,6 +146,16 @@ type Reconciler interface {
 	GetResourceType() ResourceType
 }
 
+// ResyncLister is an optional interface a Reconciler can implement to
+// participate in periodic full resync. It enumerates the names of all
+// resources that should be reconciled on each resync tick: both resources
+// that currently have a definition (heals lost create/update events) and
+// resources whose runtime state still exists without a definition (heals
+// lost delete events).
+type ResyncLister interface {
+	ResyncNames() []string
+}
+
 // ChangeDetector is the interface for components that detect changes in resources.
 //
 // Different implementations exist for filesystem watching and Kubernetes informers.
@@ -227,6 +237,15 @@ type ManagerConfig struct {
 	// If a reconciler takes longer than this, the context will be cancelled.
 	// Defaults to 30 seconds if not specified.
 	ReconcileTimeout time.Duration
+
+	// ResyncInterval is how often the manager enqueues a full reconcile of all
+	// known resources, independent of change events. This is the level-based
+	// safety net: change detection (fsnotify, watches) can drop or coalesce
+	// events — most visibly on overlayfs (CI containers) — and a purely
+	// edge-triggered reconciler never recovers from a lost event. Resync makes
+	// any divergence self-heal within one interval. In-sync resources reconcile
+	// as cheap no-ops. Defaults to 30 seconds if not specified.
+	ResyncInterval time.Duration
 
 	// Debug enables debug logging for reconciliation operations.
 	Debug bool

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -778,6 +778,24 @@ func capturedLogTail(mp *managedProcess) string {
 	return "\n--- captured muster output ---\n" + out
 }
 
+// InstanceExitStatus reports whether the instance's muster serve process has
+// already exited, and with what result. Reading waitErr is safe only after
+// observing the closed exited channel.
+func (m *musterInstanceManager) InstanceExitStatus(instance *MusterInstance) (bool, error) {
+	m.mu.RLock()
+	managedProc := m.processes[instance.ID]
+	m.mu.RUnlock()
+	if managedProc == nil {
+		return false, nil
+	}
+	select {
+	case <-managedProc.exited:
+		return true, managedProc.waitErr
+	default:
+		return false, nil
+	}
+}
+
 // processExitedError builds the standard error returned from WaitForReady when
 // the muster serve process terminates before the instance becomes ready. It
 // surfaces the wait result and a bounded tail of the captured output, and shows

--- a/internal/testing/test_reporter.go
+++ b/internal/testing/test_reporter.go
@@ -315,17 +315,42 @@ func (r *testReporter) ReportScenarioResult(scenarioResult TestScenarioResult) {
 			}
 			r.bufferMutex.Unlock()
 
+			line := fmt.Sprintf("🎯 %s... %s (%v)", scenarioResult.Scenario.Name, symbol, scenarioResult.Duration)
 			if exists {
-				fmt.Printf("%s%s (%v)\n", bufferedStart, symbol, scenarioResult.Duration)
-			} else {
-				// Fallback if buffer missing (shouldn't happen)
-				fmt.Printf("🎯 %s... %s (%v)\n", scenarioResult.Scenario.Name, symbol, scenarioResult.Duration)
+				line = fmt.Sprintf("%s%s (%v)", bufferedStart, symbol, scenarioResult.Duration)
 			}
+			// On failure, append the failing step and error so CI logs are
+			// diagnosable without re-running with --verbose.
+			line += r.failureSummary(scenarioResult)
+			fmt.Printf("%s\n", line)
 		} else {
 			// Sequential mode - just print the result (start was already printed)
 			fmt.Printf("%s (%v)\n", symbol, scenarioResult.Duration)
 		}
 	}
+}
+
+// failureSummary renders a compact multi-line diagnosis of a failed scenario
+// for the parallel-mode one-liner: the failing step (id, tool, error) and the
+// scenario error. Returns "" for passing scenarios.
+func (r *testReporter) failureSummary(scenarioResult TestScenarioResult) string {
+	if scenarioResult.Result == ResultPassed {
+		return ""
+	}
+	var b strings.Builder
+	for _, sr := range scenarioResult.StepResults {
+		if sr.Result == ResultFailed || sr.Result == ResultError {
+			fmt.Fprintf(&b, "\n   ↳ failed step: %s (tool: %s)", sr.Step.ID, sr.Step.Tool)
+			if sr.Error != "" {
+				fmt.Fprintf(&b, ": %s", r.trimLogs(sr.Error, 300))
+			}
+			break
+		}
+	}
+	if scenarioResult.Error != "" {
+		fmt.Fprintf(&b, "\n   ↳ scenario error: %s", r.trimLogs(scenarioResult.Error, 300))
+	}
+	return b.String()
 }
 
 // trimLogs trims logs to a reasonable length for display

--- a/internal/testing/test_runner.go
+++ b/internal/testing/test_runner.go
@@ -446,6 +446,20 @@ func (r *testRunner) runScenario(ctx context.Context, scenario TestScenario, con
 	result.EndTime = time.Now()
 	result.Duration = result.EndTime.Sub(result.StartTime)
 
+	// A failing step against a dead instance is a different bug class than a
+	// failing step against a live one. Surface an unexpected instance death
+	// prominently so CI failures are diagnosable from the summary line alone.
+	if result.Result != ResultPassed {
+		if exited, waitErr := r.instanceManager.InstanceExitStatus(instance); exited {
+			death := fmt.Sprintf("muster instance process died mid-scenario (wait result: %v)", waitErr)
+			if result.Error != "" {
+				result.Error = death + "; " + result.Error
+			} else {
+				result.Error = death
+			}
+		}
+	}
+
 	// Collect instance logs by triggering the destroy process early
 	// The defer cleanup will handle the actual cleanup, but we need logs now
 	r.collectInstanceLogs(instance, &result)

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -392,6 +392,11 @@ type MusterInstanceManager interface {
 	// WaitForReady waits for an instance to be ready to accept connections.
 	// The logger parameter allows scenario-specific logging with prefixes for parallel execution.
 	WaitForReady(ctx context.Context, instance *MusterInstance, logger TestLogger) error
+	// InstanceExitStatus reports whether the instance's muster serve process has
+	// already exited, and with what result. Used to distinguish "step failed
+	// against a live instance" from "the instance died mid-scenario" in failure
+	// reports.
+	InstanceExitStatus(instance *MusterInstance) (exited bool, waitErr error)
 }
 
 // TestStep defines a single step within a test scenario


### PR DESCRIPTION
## The flake

`mcpserver-runtime-delete-recreate` failed ~3x today in CI (always alone, always ~62s), surviving three prior fixes (#1016 stale registry entry, #1024 longer waits, #1027 faster retries). Those addressed symptoms; this PR removes the actual mechanism.

## Root cause

**The reconciler fed itself.** In filesystem mode, every reconcile's status sync rewrote the whole definition YAML. Each rewrite fired a fsnotify Create event, which scheduled another reconcile 500ms later — an infinite write loop per resource (visible in instance logs as `Emitted change event: Create MCPServer/<name>` every ~501ms, forever).

`core_mcpserver_delete` raced this loop two ways:
1. an in-flight status write (definition read before the delete) **resurrected the deleted file**;
2. the debouncer **merged the Remove event with the loop's next Create into a plain Create**, so `reconcileDelete` never ran.

Either way the service survived teardown, `verify-service-removed` starved its full 60s window, and the scenario died at ~62s. Waiting longer or retrying faster can't help — the delete is *gone*, not slow.

## Why it never failed locally

Reproduction requires slow filesystem timing: **40% failure rate per suite run in a Docker container (overlayfs /tmp, 4 cpus, 8g)** — the CI executor profile — vs **0 failures in 230 host runs on tmpfs**.

## Fix

- **filesystem client**: mutations serialized with a lock; status writes re-read the current on-disk definition, apply only status, **skip no-change writes** (kills the loop), and return NotFound instead of resurrecting a deleted definition. Unit tests pin resurrection and stale-spec-clobber.
- **reconciler**: periodic full resync (level-based reconciliation, 30s) — any lost/coalesced watch event now self-heals within one interval. Unit test pins it.
- **test harness**: failed scenarios print the failing step + error in parallel (CI) output, and report when the muster serve instance died mid-scenario — no more undiagnosable bare ❌ lines.

## Validation

| Environment | Before | After |
|---|---|---|
| Container (overlayfs, CI-like) | **6/15 suite runs failed** | **0/40 failed** (P(luck) ≈ 1.3e-9) |
| Host (tmpfs) | 0/230 | 182/182 scenarios green |

Also: full unit tests + `make lint` green. Note for posterity: the harness resolves `muster` from PATH before the workspace build — early validation rounds unknowingly tested the old binary until the fixed one was installed as PATH `muster`.

Fixes the recurring go-build CI failures (e.g. [19684](https://circleci.com/gh/giantswarm/muster/19684), [19715](https://circleci.com/gh/giantswarm/muster/19715), [19609](https://circleci.com/gh/giantswarm/muster/19609)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)