### PR TITLE
fix(aggregator): stale deregistration no longer clobbers a concurrent pending-auth registration

### DIFF
--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -233,10 +233,11 @@ func (r *ServerRegistry) Register(ctx context.Context, registration ServerRegist
 	}
 
 	info := &ServerInfo{
-		Name:       registration.Name,
-		Client:     client,
-		ToolPrefix: registration.ToolPrefix,
-		Family:     cloneFamily(registration.Family),
+		Name:         registration.Name,
+		Client:       client,
+		ToolPrefix:   registration.ToolPrefix,
+		Family:       cloneFamily(registration.Family),
+		RegisteredAt: time.Now(),
 	}
 
 	r.applyServerRegistrationLocked(registration.Name, registration.ToolPrefix, registration.Family)
@@ -276,12 +277,29 @@ func (r *ServerRegistry) Register(ctx context.Context, registration ServerRegist
 //
 // Returns an error if the server is not found in the registry.
 func (r *ServerRegistry) Deregister(name string) error {
+	return r.DeregisterRequestedAt(name, time.Now())
+}
+
+// DeregisterRequestedAt removes an MCP server like Deregister, but only if the
+// registry entry was created before requestedAt. Deregistration can be slow
+// (session auth revocation, connection-pool eviction happen first), and a new
+// registration for the same name can land in that window — e.g. the
+// pending-auth entry created right after a 401 while a stale state=starting
+// event is still being processed. Deleting that newer entry would strand the
+// server in a state where core_auth_login reports "server not found" until the
+// process restarts.
+func (r *ServerRegistry) DeregisterRequestedAt(name string, requestedAt time.Time) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	info, exists := r.servers[name]
 	if !exists {
 		return fmt.Errorf("server %s not found", name)
+	}
+
+	if info.RegisteredAt.After(requestedAt) {
+		logging.Info("Aggregator", "Skipping deregistration of %s: entry was re-registered after the deregistration was requested", name)
+		return nil
 	}
 
 	if info.Client != nil {
@@ -1122,12 +1140,13 @@ func (r *ServerRegistry) RegisterPendingAuth(registration PendingAuthRegistratio
 	}
 
 	info := &ServerInfo{
-		Name:       registration.Name,
-		URL:        registration.URL,
-		ToolPrefix: registration.ToolPrefix,
-		Family:     cloneFamily(registration.Family),
-		AuthInfo:   registration.AuthInfo,
-		AuthConfig: authConfig,
+		Name:         registration.Name,
+		URL:          registration.URL,
+		ToolPrefix:   registration.ToolPrefix,
+		Family:       cloneFamily(registration.Family),
+		AuthInfo:     registration.AuthInfo,
+		AuthConfig:   authConfig,
+		RegisteredAt: time.Now(),
 	}
 
 	r.applyServerRegistrationLocked(registration.Name, registration.ToolPrefix, registration.Family)

--- a/internal/aggregator/registry_test.go
+++ b/internal/aggregator/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
@@ -663,5 +664,40 @@ func TestServerRegistry_GetClient(t *testing.T) {
 		client, err := registry.GetClient("live")
 		require.NoError(t, err)
 		require.Same(t, want, client)
+	})
+}
+
+func TestServerRegistry_DeregisterRequestedAt(t *testing.T) {
+	t.Run("skips entries registered after the deregistration was requested", func(t *testing.T) {
+		registry := NewServerRegistry("x")
+		requestedAt := time.Now()
+
+		// A pending-auth registration lands while the (slow) deregistration
+		// triggered by a stale state=starting event is still in flight.
+		require.NoError(t, registry.RegisterPendingAuth(PendingAuthRegistration{
+			ServerRegistration: ServerRegistration{Name: "oauth-server"},
+			URL:                "https://oauth.example.com",
+			AuthInfo:           &AuthInfo{Issuer: "https://dex.example.com"},
+		}))
+
+		require.NoError(t, registry.DeregisterRequestedAt("oauth-server", requestedAt))
+
+		info, exists := registry.GetServerInfo("oauth-server")
+		require.True(t, exists, "newer registration must survive a stale deregistration")
+		require.True(t, info.RequiresSessionAuth())
+	})
+
+	t.Run("removes entries registered before the deregistration was requested", func(t *testing.T) {
+		registry := NewServerRegistry("x")
+		require.NoError(t, registry.RegisterPendingAuth(PendingAuthRegistration{
+			ServerRegistration: ServerRegistration{Name: "oauth-server"},
+			URL:                "https://oauth.example.com",
+			AuthInfo:           &AuthInfo{Issuer: "https://dex.example.com"},
+		}))
+
+		require.NoError(t, registry.DeregisterRequestedAt("oauth-server", time.Now()))
+
+		_, exists := registry.GetServerInfo("oauth-server")
+		require.False(t, exists)
 	})
 }

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1182,6 +1182,13 @@ func (a *AggregatorServer) DeregisterServer(name string) error {
 	logging.InfoWithAttrs("Aggregator", "DeregisterServer called",
 		slog.String("server", name))
 
+	// Snapshot the request time before the slow store cleanup below. The
+	// registry delete at the end only removes entries older than this, so a
+	// registration that lands while cleanup runs (e.g. the pending-auth entry
+	// created right after a 401 while a stale state=starting event is still
+	// being processed) survives instead of being clobbered.
+	requestedAt := time.Now()
+
 	// Remove auth state and capabilities for this server across all sessions.
 	if a.authStore != nil {
 		if err := a.authStore.RevokeServer(context.Background(), name); err != nil {
@@ -1201,7 +1208,7 @@ func (a *AggregatorServer) DeregisterServer(name string) error {
 		a.connPool.EvictServer(name)
 	}
 
-	return a.registry.Deregister(name)
+	return a.registry.DeregisterRequestedAt(name, requestedAt)
 }
 
 // GetRegistry returns the server registry for direct access to backend server information.

--- a/internal/aggregator/types.go
+++ b/internal/aggregator/types.go
@@ -120,6 +120,12 @@ type ServerInfo struct {
 	// LastUpdate tracks when the server information was last refreshed
 	LastUpdate time.Time
 
+	// RegisteredAt records when this registry entry was created (set once by
+	// Register/RegisterPendingAuth, never refreshed). Deregistration requests
+	// skip entries created after the request began, so a concurrent
+	// re-registration is not clobbered by a stale deregister.
+	RegisteredAt time.Time
+
 	// ToolPrefix is the configured prefix for tools from this server.
 	// This is used for name collision resolution.
 	ToolPrefix string


### PR DESCRIPTION
## What

`DeregisterServer` now snapshots the request time before its slow session cleanup (auth-store revoke, capability delete, connection-pool eviction) and the final registry delete skips entries that were (re-)registered after that point. Registry entries carry a new `RegisteredAt` stamp set by `Register`/`RegisterPendingAuth`.

## Why

Found live on gazelle while E2E-testing the Backstage MCP registration wizard's OAuth path (giantswarm/backstage#2095):

1. An OAuth MCPServer is created (or restarted) at runtime → service enters `starting`, the aggregator event handler reacts to the stale `state=starting` event and calls `DeregisterServer`.
2. The backend answers 401 a few ms later → the orchestrator registers the pending-auth entry (`RegisterServerPendingAuth`).
3. The deregistration's session cleanup takes ~150ms against the valkey-backed auth store, so its unconditional `registry.Deregister` lands **after** step 2 and deletes the fresh pending-auth entry.

Result: `core_auth_login` fails with `Server 'X' not found` for every OAuth server registered at runtime, until the muster process restarts. Reproduced deterministically on gazelle (muster 1.7.9, twice: initial create and config-update restart — the log sequence is `DeregisterServer called` → `Registered pending auth server` → `Deregistered MCP server`).

The event handler's existing `waiting`/`auth_required` guards don't help: they run at event-processing start, before the pending-auth entry exists; the delete happens 150ms later.

## Testing

- New deterministic unit test `TestServerRegistry_DeregisterRequestedAt` pins the race (a pending-auth entry registered after the deregistration request survives; older entries are still removed).
- The behavioral scenario `oauth-restart-preserves-pending-auth` covers this end-to-end but cannot reproduce the timing with the in-memory auth store (revoke is instant there); it still passes with a fresh build, as does the full `--category behavioral --concept mcpserver` suite (74/74) and `go test ./internal/aggregator ./internal/orchestrator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)