### PR TITLE
feat(mcpserver): stamp email claim alongside subject in registered-by

### DIFF
--- a/internal/api/mcpserver.go
+++ b/internal/api/mcpserver.go
@@ -270,6 +270,12 @@ func (t MCPServerType) IsRemote() bool {
 // omitted by clients (issue #1021). The key is shared with the developer portal.
 const RegisteredByAnnotation = "ui.giantswarm.io/registered-by"
 
+// RegisteredByEmailAnnotation records the email claim of the authenticated
+// identity that registered an MCPServer, when the token carried one. Display
+// metadata only — RegisteredByAnnotation holds the stable identifier
+// (issue #1048). The key is shared with the developer portal.
+const RegisteredByEmailAnnotation = "ui.giantswarm.io/registered-by-email"
+
 // MCPServerInfo contains consolidated MCP server information for API responses.
 // This type is used when returning server information through the API, providing
 // a flattened view of server configuration and runtime state that is convenient
@@ -371,6 +377,12 @@ type MCPServerInfo struct {
 	// read from the RegisteredByAnnotation. Empty when the server was created
 	// without an authenticated context (e.g. GitOps-applied CRs).
 	RegisteredBy string `json:"registeredBy,omitempty"`
+
+	// RegisteredByEmail is the email claim of the identity that registered
+	// this server, read from the RegisteredByEmailAnnotation. Display metadata
+	// only — RegisteredBy is the stable identifier. Empty when the token
+	// carried no email claim (e.g. Kubernetes ServiceAccount identities).
+	RegisteredByEmail string `json:"registeredByEmail,omitempty"`
 }
 
 // MCPServerManagerHandler defines the interface for MCP server management operations.

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -197,6 +197,7 @@ func convertCRDToInfo(server *musterv1alpha1.MCPServer) api.MCPServerInfo {
 	info.StatusMessage = generateStatusMessage(info.State, info.Error, server.Name)
 
 	info.RegisteredBy = server.Annotations[api.RegisteredByAnnotation]
+	info.RegisteredByEmail = server.Annotations[api.RegisteredByEmailAnnotation]
 
 	return info
 }
@@ -211,6 +212,17 @@ func subjectFromContext(ctx context.Context) string {
 	}
 	if userInfo, ok := oauthhandler.UserInfoFromContext(ctx); ok && userInfo != nil {
 		return userInfo.ID
+	}
+	return ""
+}
+
+// emailFromContext resolves the authenticated caller's email claim, if the
+// token carried one. Display metadata only — the subject is the stable
+// identifier. Returns "" for identities without an email (e.g. Kubernetes
+// ServiceAccounts) and unauthenticated transports.
+func emailFromContext(ctx context.Context) string {
+	if userInfo, ok := oauthhandler.UserInfoFromContext(ctx); ok && userInfo != nil {
+		return userInfo.Email
 	}
 	return ""
 }
@@ -663,9 +675,14 @@ func (a *Adapter) handleMCPServerCreate(ctx context.Context, args map[string]int
 
 	// Stamp the authenticated subject so registration is attributable even for
 	// clients that don't stamp it themselves (issue #1021). Update preserves it
-	// via its get-modify-update flow.
+	// via its get-modify-update flow. The email claim, when present, is stamped
+	// alongside as display metadata (issue #1048) — the subject stays the
+	// stable identifier.
 	if subject := subjectFromContext(ctx); subject != "" {
 		serverCRD.Annotations = map[string]string{api.RegisteredByAnnotation: subject}
+		if email := emailFromContext(ctx); email != "" {
+			serverCRD.Annotations[api.RegisteredByEmailAnnotation] = email
+		}
 	}
 
 	// Validate the definition

--- a/internal/testing/scenarios/mcpserver-registered-by-stamp.yaml
+++ b/internal/testing/scenarios/mcpserver-registered-by-stamp.yaml
@@ -3,11 +3,14 @@ category: "behavioral"
 concept: "mcpserver"
 description: |
   Verify that core_mcpserver_create stamps the authenticated subject into the
-  ui.giantswarm.io/registered-by annotation server-side (issue #1021), exposed
-  as registeredBy on core_mcpserver_get, and that core_mcpserver_update
-  preserves it. Registration is open (no authorization on mcpserver mutation
-  tools), so the server-side stamp is the only durable attribution for who
-  changed the shared tool surface — client-side stamping is spoofable.
+  ui.giantswarm.io/registered-by annotation server-side (issue #1021) and the
+  token's email claim into ui.giantswarm.io/registered-by-email (issue #1048),
+  exposed as registeredBy/registeredByEmail on core_mcpserver_get, and that
+  core_mcpserver_update preserves both. Registration is open (no authorization
+  on mcpserver mutation tools), so the server-side stamp is the only durable
+  attribution for who changed the shared tool surface — client-side stamping
+  is spoofable. The subject is the stable identifier; the email is display
+  metadata for UIs.
 tags: ["mcpserver", "create", "oauth", "attribution", "core-api"]
 timeout: "2m"
 
@@ -62,7 +65,7 @@ steps:
       success: true
 
   - id: "verify-registered-by-stamped"
-    description: "registeredBy carries the authenticated subject"
+    description: "registeredBy carries the subject, registeredByEmail the email claim"
     tool: "core_mcpserver_get"
     args:
       name: "stamped-server"
@@ -71,6 +74,7 @@ steps:
       json_path:
         name: "stamped-server"
         registeredBy: "registrar-user"
+        registeredByEmail: "test@example.com"
 
   - id: "update-mcpserver"
     description: "Update the server definition"
@@ -82,7 +86,7 @@ steps:
       success: true
 
   - id: "verify-registered-by-preserved"
-    description: "registeredBy survives the update"
+    description: "registeredBy and registeredByEmail survive the update"
     tool: "core_mcpserver_get"
     args:
       name: "stamped-server"
@@ -90,6 +94,7 @@ steps:
       success: true
       json_path:
         registeredBy: "registrar-user"
+        registeredByEmail: "test@example.com"
 
 cleanup:
   - id: "delete-mcpserver"


### PR DESCRIPTION
Closes #1048.

`core_mcpserver_create` now stamps the authenticated identity's email claim into a second annotation, `ui.giantswarm.io/registered-by-email`, whenever the token carries one, and `core_mcpserver_get` returns it as `registeredByEmail`. The raw dex sub in `ui.giantswarm.io/registered-by` stays untouched as the stable identifier — the email is display metadata so UIs (e.g. Backstage) can show the actual person instead of a decoded numeric connector user id.

The email comes from the mcp-oauth `UserInfo` already in the request context on every authenticated HTTP path; identities without an email claim (e.g. Kubernetes ServiceAccounts on the trusted-issuer path) simply get no email annotation. `preferred_username` fallback was skipped — mcp-oauth's `UserInfo` doesn't surface that claim; can be added there first if ever needed.

Update preserves both annotations via its existing get-modify-update flow (it only touches `Spec`).

Tested: extended the `mcpserver-registered-by-stamp` behavioral scenario to assert `registeredByEmail` after create and after update (mock IdP issues `test@example.com`); passes locally with a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)