### PR TITLE
fix(chart): reopen free-form value maps closed by the generated schema

### DIFF
--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -20,6 +20,7 @@ A Helm chart for muster - Universal Control Plane for AI Agents built on MCP
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| enabled | bool | `true` |  |
 | replicaCount | int | `1` |  |
 | image.registry | string | `"gsoci.azurecr.io"` |  |
 | image.repository | string | `"giantswarm/muster"` |  |

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -43,6 +43,9 @@
                 }
             }
         },
+        "enabled": {
+            "type": "boolean"
+        },
         "fullnameOverride": {
             "type": "string"
         },
@@ -368,7 +371,7 @@
                                 },
                                 "tokenExchangeBroker": {
                                     "type": "object",
-                                    "additionalProperties": false
+                                    "additionalProperties": true
                                 },
                                 "trustedAudiences": {
                                     "type": "array"
@@ -419,7 +422,7 @@
                                                 },
                                                 "labels": {
                                                     "type": "object",
-                                                    "additionalProperties": false
+                                                    "additionalProperties": true
                                                 }
                                             }
                                         }
@@ -531,11 +534,11 @@
         },
         "nodeSelector": {
             "type": "object",
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "podAnnotations": {
             "type": "object",
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "podDisruptionBudget": {
             "type": "object",
@@ -551,7 +554,7 @@
         },
         "podLabels": {
             "type": "object",
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "podSecurityContext": {
             "type": "object",

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -2,6 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Umbrella-chart toggle. App-of-apps meta-charts (agent-platform) forward their
+# component values block verbatim, including this on/off key. The muster chart
+# itself ignores it; it exists so the values schema accepts such forwarded blocks.
+enabled: true
+
 replicaCount: 1
 
 image:
@@ -42,8 +47,8 @@ rbac:
   # A Role/RoleBinding granting `get` on secrets is created in each listed namespace.
   additionalSecretNamespaces: []
 
-podAnnotations: {}
-podLabels: {}
+podAnnotations: {}  # @schema additionalProperties: true
+podLabels: {}  # @schema additionalProperties: true
 
 podSecurityContext:
   runAsUser: 1000
@@ -208,7 +213,7 @@ volumes: []
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
 
-nodeSelector: {}
+nodeSelector: {}  # @schema additionalProperties: true
 
 tolerations: []
 
@@ -580,7 +585,7 @@ muster:
       #     portal-backend:
       #       clientCredentialsSecretRef:
       #         name: muster-broker-clients   # keys default to client-id/client-secret
-      tokenExchangeBroker: {}
+      tokenExchangeBroker: {}  # @schema additionalProperties: true
 
       # CIDRs from which X-Forwarded-Proto and X-Forwarded-Host headers are
       # trusted for DPoP htu URL reconstruction. Required when muster runs
@@ -648,7 +653,7 @@ muster:
           # Extra labels applied to the ServiceMonitor — useful for
           # selecting the right Prometheus instance in a multi-tenant
           # cluster.
-          labels: {}
+          labels: {}  # @schema additionalProperties: true
 
 # CRD ownership. The muster application chart ships the MCPServer and Workflow
 # CustomResourceDefinitions in the Helm 3 `crds/` directory (helm/muster/crds/),


### PR DESCRIPTION
## Problem

muster v1.7.11 ([#1049](https://github.com/giantswarm/muster/pull/1049), align-files) replaced the hand-maintained `values.schema.json` with a generated one (`noAdditionalProperties: true`). Every object not fully described in `values.yaml` became closed. All fleet MCs float on `1.x` via the agent-platform umbrella, so every muster HelmRelease is now `UpgradeFailed` (paging bumblebee oncall via `FluxGiantswarmHelmReleaseFailed`):

```
- at '/podAnnotations': additional properties 'application.giantswarm.io/team' not allowed
- at '/muster/oauth/server/tokenExchangeBroker': additional properties 'targets', 'allowPrivateIP', 'brokerClients', 'clientAudiences' not allowed
- at '/muster/observability/.../serviceMonitor/labels': additional properties 'observability.giantswarm.io/tenant' not allowed
- at '': additional properties 'enabled' not allowed
```

## Fix

Annotate the genuinely free-form maps with `# @schema additionalProperties: true` (podAnnotations, podLabels, nodeSelector, tokenExchangeBroker, serviceMonitor labels) and restore the root `enabled` key (the umbrella forwards its component block verbatim; the pre-#1049 schema had it).

Validated by rendering the chart with gazelle's live HelmRelease values: passes with this schema, minus the separately-stale `enableJWTMode` key (removed from giantswarm-configs installation patches in a follow-up).

Not fixed here: `enableJWTMode` stays rejected — it was removed in muster v1.0.0 and must not come back (per shared-configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)