### PR TITLE
feat(mcpserver): write MCPServer spec mutations with the caller's own identity

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -35,6 +35,12 @@ muster-integration-test: build ## Run the muster integration suite (./muster tes
 	@echo "Running muster integration suite..."
 	./muster test --parallel 50 --base-port 30000
 
+.PHONY: test-envtest
+test-envtest: ## Run the envtest-backed RBAC integration tests (downloads a kube-apiserver via setup-envtest).
+	@echo "Running envtest RBAC integration tests..."
+	KUBEBUILDER_ASSETS="$$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24 use -p path)" \
+		go test ./internal/mcpserver/ -run TestWritesAsCallerEnvtest -count=1 -v
+
 .PHONY: test-vet
 test-vet: ## Run go test and go vet
 	@echo "Running Go tests (with NO_COLOR=true)..."

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -274,6 +274,28 @@ aggregator:
   transport: "streamable-http"
 ```
 
+#### Writes-as-Caller (Transition Flag)
+
+When enabled, session-initiated MCPServer spec mutations
+(`core_mcpserver_create` / `_update` / `_delete`) are written against the
+Kubernetes API with the caller's own OIDC id_token as the bearer instead of
+muster's ServiceAccount: the apiserver authenticates the real user, Kubernetes
+RBAC authorizes the write, and the audit log records the true subject.
+Reads, `core_mcpserver_validate`, and muster's own controller writes (status
+reconciliation, service registration) are unaffected.
+
+```yaml
+writesAsCaller:
+  enabled: true                            # Default: false (legacy SA write path)
+  kubernetesAudience: "dex-k8s-authenticator"  # Audience the session token must carry (default shown)
+```
+
+Preconditions: the login scope set must request the `kubernetesAudience`
+cross-client audience, and the apiserver must trust the OIDC issuer. Sessions
+whose token lacks the audience receive an actionable re-login error; callers
+without RBAC permission receive a permission error naming the missing verb,
+resource, and namespace.
+
 ## MCP Server Configuration
 
 MCP servers can be configured through YAML files or Kubernetes CRDs. Each server requires:

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -17,6 +17,8 @@ import (
 	"github.com/giantswarm/muster/internal/services"
 	"github.com/giantswarm/muster/internal/workflow"
 	"github.com/giantswarm/muster/pkg/logging"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // Services holds all initialized services and APIs used by the application.
@@ -166,6 +168,20 @@ func InitializeServices(cfg *Config) (*Services, error) {
 
 	// Initialize and register MCPServer adapter using the muster client
 	mcpServerAdapter := mcpserverPkg.NewAdapterWithClient(musterClient, namespace)
+	if cfg.MusterConfig.WritesAsCaller.Enabled {
+		// Transition flag (issue #1056): session-initiated MCPServer spec
+		// mutations write with the caller's own dex id_token so k8s RBAC
+		// decides and the audit log records the real user. When no Kubernetes
+		// config is reachable the factory stays nil and mutations fail with an
+		// explicit configuration error rather than falling back to the SA.
+		var factory mcpserverPkg.CallerClientFactory
+		if restConfig, err := ctrl.GetConfig(); err == nil {
+			factory = mcpserverPkg.NewKubernetesCallerClientFactory(restConfig)
+		} else {
+			logging.Warn("Services", "writesAsCaller is enabled but no Kubernetes config is available: %v", err)
+		}
+		mcpServerAdapter.EnableWritesAsCaller(factory, cfg.MusterConfig.WritesAsCaller.KubernetesAudience)
+	}
 	mcpServerAdapter.Register()
 
 	// Initialize and register credentials adapter for loading OAuth client credentials from secrets

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -4,9 +4,29 @@ import "strings"
 
 // MusterConfig is the top-level configuration structure for muster.
 type MusterConfig struct {
-	Aggregator AggregatorConfig `yaml:"aggregator"`
-	Namespace  string           `yaml:"namespace,omitempty"`  // Namespace for MCPServer and Workflow discovery
-	Kubernetes bool             `yaml:"kubernetes,omitempty"` // Enable Kubernetes CRD mode (uses CRDs instead of filesystem)
+	Aggregator     AggregatorConfig     `yaml:"aggregator"`
+	Namespace      string               `yaml:"namespace,omitempty"`      // Namespace for MCPServer and Workflow discovery
+	Kubernetes     bool                 `yaml:"kubernetes,omitempty"`     // Enable Kubernetes CRD mode (uses CRDs instead of filesystem)
+	WritesAsCaller WritesAsCallerConfig `yaml:"writesAsCaller,omitempty"` // Transition flag: MCPServer spec mutations write with the caller's identity
+}
+
+// WritesAsCallerConfig is the transition flag for the writes-as-caller
+// rollout: when enabled, session-initiated MCPServer spec mutations
+// (create/update/delete) are written against the Kubernetes API with the
+// caller's own dex id_token as the bearer, so the apiserver authenticates the
+// real user, k8s RBAC authorizes the write, and the audit log records the
+// true subject. Muster's own controllers (status reconciliation, service
+// registration, startup sync) keep using the ServiceAccount client. The flag
+// is transitional: it is deleted once every installation has flipped.
+type WritesAsCallerConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// KubernetesAudience is the audience the session's dex id_token must carry
+	// to be accepted by the local kube-apiserver (requested via the login scope
+	// set's cross-client audience mechanism). Defaults to
+	// "dex-k8s-authenticator". A session token without this audience gets an
+	// actionable re-login error instead of a generic apiserver 401.
+	KubernetesAudience string `yaml:"kubernetesAudience,omitempty"`
 }
 
 // MCPServerType defines the type of MCP server.

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -73,6 +73,22 @@ func convertAPISecretRefToCRD(src *api.ClientCredentialsSecretRef) *musterv1alph
 type Adapter struct {
 	client    client.MusterClient
 	namespace string
+
+	// writesAsCaller switches session-initiated spec mutations
+	// (create/update/delete) from the shared SA-backed client to a per-call
+	// client bearing the caller's own dex id_token (issue #1056). Reads,
+	// validation, and muster's own controller writes are unaffected.
+	writesAsCaller     bool
+	kubernetesAudience string
+	callerClients      CallerClientFactory
+}
+
+// mcpServerWriter is the write surface the mutation handlers go through. The
+// SA-backed MusterClient and the per-call caller-bearer client both satisfy it.
+type mcpServerWriter interface {
+	CreateMCPServer(ctx context.Context, server *musterv1alpha1.MCPServer) error
+	UpdateMCPServer(ctx context.Context, server *musterv1alpha1.MCPServer) error
+	DeleteMCPServer(ctx context.Context, name, namespace string) error
 }
 
 // NewAdapterWithClient creates a new adapter with a specific client (for testing)
@@ -84,6 +100,71 @@ func NewAdapterWithClient(musterClient client.MusterClient, namespace string) *A
 		client:    musterClient,
 		namespace: namespace,
 	}
+}
+
+// EnableWritesAsCaller turns on the writes-as-caller transition flag.
+// factory may be nil when muster has no Kubernetes API access; mutations then
+// fail with an explicit configuration error instead of silently falling back
+// to the SA path. An empty kubernetesAudience selects the default.
+func (a *Adapter) EnableWritesAsCaller(factory CallerClientFactory, kubernetesAudience string) {
+	a.writesAsCaller = true
+	if kubernetesAudience == "" {
+		kubernetesAudience = DefaultKubernetesAudience
+	}
+	a.kubernetesAudience = kubernetesAudience
+	a.callerClients = factory
+}
+
+// mutationWriter resolves the write client a mutation must use. With
+// writes-as-caller off it is the shared SA-backed client (legacy path). With
+// it on, the session's dex id_token becomes the bearer of a per-call client,
+// so the apiserver authenticates the real user and k8s RBAC decides. A nil
+// writer is returned together with a ready-to-return tool error when the
+// session cannot produce a usable bearer.
+func (a *Adapter) mutationWriter(ctx context.Context) (mcpServerWriter, *api.CallToolResult) {
+	if !a.writesAsCaller {
+		return a.client, nil
+	}
+
+	token := callerTokenFromContext(ctx)
+	if token == "" {
+		result, _ := simpleError(reloginError(
+			"This installation writes MCP server changes with your own identity, but your session carries no token."))
+		return nil, result
+	}
+	if tokenMissingAudience(token, a.kubernetesAudience) {
+		result, _ := simpleError(reloginError(fmt.Sprintf(
+			"Your session token does not carry the %q audience required by the Kubernetes API.", a.kubernetesAudience)))
+		return nil, result
+	}
+	if a.callerClients == nil {
+		result, _ := simpleError("writes-as-caller is enabled but muster has no Kubernetes API access to perform the write with — check the muster deployment configuration")
+		return nil, result
+	}
+
+	callerClient, err := a.callerClients(token)
+	if err != nil {
+		result, _ := simpleError(fmt.Sprintf("Failed to prepare a Kubernetes client with your identity: %v", err))
+		return nil, result
+	}
+	return &callerWriter{client: callerClient, namespace: a.namespace}, nil
+}
+
+// describeWriteAuthError maps apiserver authn/authz failures on
+// caller-identity writes to actionable tool errors: 403 names the verb,
+// resource, and namespace; 401 asks for a re-login. Returns "" for every
+// other error so callers fall through to their existing handling.
+func (a *Adapter) describeWriteAuthError(err error, verb, name string) string {
+	switch {
+	case errors.IsForbidden(err):
+		return fmt.Sprintf(
+			"Permission denied: your user may not %s MCPServer %q (mcpservers.muster.giantswarm.io) in namespace %q. "+
+				"Ask a platform admin to grant you the mcpserver-editor role. API server response: %v",
+			verb, name, a.namespace, err)
+	case errors.IsUnauthorized(err):
+		return reloginError("The Kubernetes API rejected your session token.")
+	}
+	return ""
 }
 
 // Register registers the adapter with the API
@@ -567,9 +648,9 @@ func (a *Adapter) ExecuteTool(ctx context.Context, toolName string, args map[str
 	case "mcpserver_create":
 		return a.handleMCPServerCreate(ctx, args)
 	case "mcpserver_update":
-		return a.handleMCPServerUpdate(args)
+		return a.handleMCPServerUpdate(ctx, args)
 	case "mcpserver_delete":
-		return a.handleMCPServerDelete(args)
+		return a.handleMCPServerDelete(ctx, args)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", toolName)
 	}
@@ -710,6 +791,11 @@ func (a *Adapter) handleMCPServerCreate(ctx context.Context, args map[string]int
 		}, nil
 	}
 
+	writer, errResult := a.mutationWriter(ctx)
+	if errResult != nil {
+		return errResult, nil
+	}
+
 	// Convert request to CRD once for reuse
 	serverCRD := a.convertRequestToCRD(&req)
 
@@ -730,10 +816,13 @@ func (a *Adapter) handleMCPServerCreate(ctx context.Context, args map[string]int
 		return simpleError(fmt.Sprintf("Invalid MCP server definition: %v", err))
 	}
 
-	// Create the new MCP server using the unified client
-	if err := a.client.CreateMCPServer(ctx, serverCRD); err != nil {
+	// Create the new MCP server with the resolved write identity
+	if err := writer.CreateMCPServer(ctx, serverCRD); err != nil {
 		if errors.IsAlreadyExists(err) {
 			return simpleError(fmt.Sprintf("MCP server '%s' already exists", req.Name))
+		}
+		if msg := a.describeWriteAuthError(err, "create", req.Name); msg != "" {
+			return simpleError(msg)
 		}
 		// Generate failure event
 		a.generateCRDEvent(req.Name, events.ReasonMCPServerFailed, events.EventData{
@@ -751,7 +840,7 @@ func (a *Adapter) handleMCPServerCreate(ctx context.Context, args map[string]int
 	return simpleOK(fmt.Sprintf("MCP server '%s' created successfully", req.Name))
 }
 
-func (a *Adapter) handleMCPServerUpdate(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleMCPServerUpdate(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	var req api.MCPServerUpdateRequest
 	if err := api.ParseRequest(args, &req); err != nil {
 		return &api.CallToolResult{
@@ -760,8 +849,13 @@ func (a *Adapter) handleMCPServerUpdate(args map[string]interface{}) (*api.CallT
 		}, nil
 	}
 
-	// Get existing server first
-	ctx := context.Background()
+	writer, errResult := a.mutationWriter(ctx)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	// Get existing server first. The read stays on the SA client — only the
+	// spec mutation itself switches to the caller's identity.
 	existing, err := a.client.GetMCPServer(ctx, req.Name, a.namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -837,8 +931,11 @@ func (a *Adapter) handleMCPServerUpdate(args map[string]interface{}) (*api.CallT
 		return simpleError(fmt.Sprintf("Invalid MCP server definition: %v", err))
 	}
 
-	// Update the MCP server using the unified client
-	if err := a.client.UpdateMCPServer(ctx, existing); err != nil {
+	// Update the MCP server with the resolved write identity
+	if err := writer.UpdateMCPServer(ctx, existing); err != nil {
+		if msg := a.describeWriteAuthError(err, "update", req.Name); msg != "" {
+			return simpleError(msg)
+		}
 		// Generate failure event
 		a.generateCRDEvent(req.Name, events.ReasonMCPServerFailed, events.EventData{
 			Error:     err.Error(),
@@ -855,17 +952,24 @@ func (a *Adapter) handleMCPServerUpdate(args map[string]interface{}) (*api.CallT
 	return simpleOK(fmt.Sprintf("MCP server '%s' updated successfully", req.Name))
 }
 
-func (a *Adapter) handleMCPServerDelete(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleMCPServerDelete(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
 		return simpleError("name argument is required")
 	}
 
-	// Delete the MCP server using the unified client
-	ctx := context.Background()
-	if err := a.client.DeleteMCPServer(ctx, name, a.namespace); err != nil {
+	writer, errResult := a.mutationWriter(ctx)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	// Delete the MCP server with the resolved write identity
+	if err := writer.DeleteMCPServer(ctx, name, a.namespace); err != nil {
 		if errors.IsNotFound(err) {
 			return api.HandleErrorWithPrefix(api.NewMCPServerNotFoundError(name), "Failed to delete MCP server"), nil
+		}
+		if msg := a.describeWriteAuthError(err, "delete", name); msg != "" {
+			return simpleError(msg)
 		}
 		// Generate failure event
 		a.generateCRDEvent(name, events.ReasonMCPServerFailed, events.EventData{

--- a/internal/mcpserver/caller_client.go
+++ b/internal/mcpserver/caller_client.go
@@ -1,0 +1,118 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	"github.com/giantswarm/muster/internal/server"
+)
+
+// DefaultKubernetesAudience is the audience the local kube-apiserver trusts on
+// dex id_tokens (the dex-k8s-authenticator cross-client audience). Overridable
+// via writesAsCaller.kubernetesAudience in the muster config.
+const DefaultKubernetesAudience = "dex-k8s-authenticator"
+
+// CallerClientFactory builds a Kubernetes client authenticated with the
+// caller's own bearer token. Each session-initiated MCPServer spec mutation
+// gets a per-call client so the apiserver authenticates the real user and
+// k8s RBAC decides — never muster's ServiceAccount, never impersonation
+// headers (dex-only ruling).
+type CallerClientFactory func(bearerToken string) (ctrlclient.Client, error)
+
+// NewKubernetesCallerClientFactory returns a factory deriving per-call clients
+// from the given base REST config: same apiserver host and CA, all ambient
+// credentials stripped, the caller's bearer as the only authentication.
+func NewKubernetesCallerClientFactory(base *rest.Config) CallerClientFactory {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(musterv1alpha1.AddToScheme(scheme))
+
+	return func(bearerToken string) (ctrlclient.Client, error) {
+		cfg := rest.AnonymousClientConfig(base)
+		cfg.BearerToken = bearerToken
+		return ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
+	}
+}
+
+// callerTokenFromContext returns the session's dex id_token carried on the
+// request context by the OAuth middleware, or "" for unauthenticated
+// transports.
+func callerTokenFromContext(ctx context.Context) string {
+	token, _ := server.GetIDTokenFromContext(ctx)
+	return token
+}
+
+// tokenMissingAudience reports whether token is a JWT whose aud claim
+// verifiably lacks want. The payload is decoded without signature
+// verification — the apiserver is the verifier; this precheck only exists to
+// turn a doomed write into an actionable re-login error. Tokens that don't
+// parse as JWTs (e.g. opaque test tokens) are passed through to the apiserver.
+func tokenMissingAudience(token, want string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims struct {
+		Aud json.RawMessage `json:"aud"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Aud == nil {
+		return true
+	}
+	var single string
+	if err := json.Unmarshal(claims.Aud, &single); err == nil {
+		return single != want
+	}
+	var many []string
+	if err := json.Unmarshal(claims.Aud, &many); err == nil {
+		for _, aud := range many {
+			if aud == want {
+				return false
+			}
+		}
+		return true
+	}
+	return true
+}
+
+// callerWriter adapts a per-call controller-runtime client to the write
+// surface the mutation handlers use.
+type callerWriter struct {
+	client    ctrlclient.Client
+	namespace string
+}
+
+func (w *callerWriter) CreateMCPServer(ctx context.Context, obj *musterv1alpha1.MCPServer) error {
+	return w.client.Create(ctx, obj)
+}
+
+func (w *callerWriter) UpdateMCPServer(ctx context.Context, obj *musterv1alpha1.MCPServer) error {
+	return w.client.Update(ctx, obj)
+}
+
+func (w *callerWriter) DeleteMCPServer(ctx context.Context, name, namespace string) error {
+	obj := &musterv1alpha1.MCPServer{}
+	obj.Name = name
+	obj.Namespace = namespace
+	return w.client.Delete(ctx, obj)
+}
+
+// reloginError is the actionable error for sessions whose token cannot
+// authenticate at the apiserver (missing audience, or rejected outright).
+func reloginError(reason string) (msg string) {
+	return fmt.Sprintf("%s A re-login is required: sign in again to get a fresh session token, then retry.", reason)
+}

--- a/internal/mcpserver/writes_as_caller_envtest_test.go
+++ b/internal/mcpserver/writes_as_caller_envtest_test.go
@@ -1,0 +1,202 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	kubernetesclient "github.com/giantswarm/muster/internal/client/kubernetes"
+	"github.com/giantswarm/muster/internal/server"
+)
+
+// TestWritesAsCallerEnvtest runs the writes-as-caller path against a real
+// kube-apiserver with RBAC: an allowed user (bound to an mcpserver-editor
+// style Role) creates, updates, and deletes through the adapter; a denied
+// user gets the mapped permission error and no write occurs; muster's own
+// SA-equivalent client still reconciles status on a CR it did not create.
+//
+// Requires envtest binaries: run via `make test-envtest`, which resolves
+// KUBEBUILDER_ASSETS with setup-envtest. Skipped otherwise.
+func TestWritesAsCallerEnvtest(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; run via `make test-envtest`")
+	}
+
+	// Static token authentication: bearer → user. The tokens are JWT-shaped
+	// and carry the kubernetes audience so the adapter's audience precheck —
+	// the same code the dex path runs — passes and the apiserver decides.
+	allowedToken := testJWT(t, DefaultKubernetesAudience)
+	deniedToken := testJWT(t, []string{DefaultKubernetesAudience, "muster"})
+	tokenFile := filepath.Join(t.TempDir(), "tokens.csv")
+	tokens := fmt.Sprintf("%s,allowed-user,1000,\n%s,denied-user,1001,\n", allowedToken, deniedToken)
+	if err := os.WriteFile(tokenFile, []byte(tokens), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "helm", "muster", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+	// envtest's apiserver already runs --authorization-mode=RBAC by default.
+	testEnv.ControlPlane.GetAPIServer().Configure().Set("token-auth-file", tokenFile)
+
+	adminCfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Errorf("stop envtest: %v", err)
+		}
+	})
+
+	// The admin config plays muster's ServiceAccount: it backs the shared
+	// MusterClient (reads, status reconciliation) exactly like production.
+	saClient, err := kubernetesclient.New(adminCfg)
+	if err != nil {
+		t.Fatalf("create kubernetes muster client: %v", err)
+	}
+	t.Cleanup(func() { _ = saClient.Close() })
+
+	ctx := context.Background()
+
+	// mcpserver-editor equivalent, bound to allowed-user only (issue #1058
+	// ships the chart's default binding; the Role shape is the same).
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcpserver-editor", Namespace: "default"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"muster.giantswarm.io"},
+			Resources: []string{"mcpservers"},
+			Verbs:     []string{"create", "update", "patch", "delete"},
+		}},
+	}
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcpserver-editor", Namespace: "default"},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "allowed-user"}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "mcpserver-editor"},
+	}
+	if err := saClient.Create(ctx, role); err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	if err := saClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create rolebinding: %v", err)
+	}
+
+	adapter := NewAdapterWithClient(saClient, "default")
+	adapter.EnableWritesAsCaller(NewKubernetesCallerClientFactory(adminCfg), "")
+
+	allowedCtx := server.ContextWithIDToken(ctx, allowedToken)
+	deniedCtx := server.ContextWithIDToken(ctx, deniedToken)
+
+	createArgs := func(name string) map[string]interface{} {
+		return map[string]interface{}{"name": name, "type": "stdio", "command": "echo"}
+	}
+
+	t.Run("allowed user create-update-delete", func(t *testing.T) {
+		result, err := adapter.ExecuteTool(allowedCtx, "mcpserver_create", createArgs("allowed-server"))
+		if err != nil || result.IsError {
+			t.Fatalf("create: err=%v result=%s", err, resultText(t, result))
+		}
+		created, err := saClient.GetMCPServer(ctx, "allowed-server", "default")
+		if err != nil {
+			t.Fatalf("created CR not found: %v", err)
+		}
+		if created.Spec.Command != "echo" {
+			t.Fatalf("unexpected spec: %+v", created.Spec)
+		}
+
+		result, err = adapter.ExecuteTool(allowedCtx, "mcpserver_update",
+			map[string]interface{}{"name": "allowed-server", "command": "echo2"})
+		if err != nil || result.IsError {
+			t.Fatalf("update: err=%v result=%s", err, resultText(t, result))
+		}
+		updated, err := saClient.GetMCPServer(ctx, "allowed-server", "default")
+		if err != nil {
+			t.Fatalf("get after update: %v", err)
+		}
+		if updated.Spec.Command != "echo2" {
+			t.Fatalf("update did not land: %+v", updated.Spec)
+		}
+
+		// Muster's SA still reconciles status on the user-created CR: the
+		// controllers keep their identity, only spec mutations switched.
+		updated.Status.State = musterv1alpha1.MCPServerStateRunning
+		if err := saClient.UpdateMCPServerStatus(ctx, updated); err != nil {
+			t.Fatalf("SA status update on caller-created CR: %v", err)
+		}
+
+		result, err = adapter.ExecuteTool(allowedCtx, "mcpserver_delete",
+			map[string]interface{}{"name": "allowed-server"})
+		if err != nil || result.IsError {
+			t.Fatalf("delete: err=%v result=%s", err, resultText(t, result))
+		}
+		if _, err := saClient.GetMCPServer(ctx, "allowed-server", "default"); !apierrors.IsNotFound(err) {
+			t.Fatalf("CR still present after delete: %v", err)
+		}
+	})
+
+	t.Run("denied user create", func(t *testing.T) {
+		result, err := adapter.ExecuteTool(deniedCtx, "mcpserver_create", createArgs("denied-server"))
+		if err != nil {
+			t.Fatalf("ExecuteTool: %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("expected permission error")
+		}
+		text := resultText(t, result)
+		for _, want := range []string{"Permission denied", "create", "mcpservers.muster.giantswarm.io", `"default"`} {
+			if !strings.Contains(text, want) {
+				t.Errorf("error %q does not mention %q", text, want)
+			}
+		}
+		if _, err := saClient.GetMCPServer(ctx, "denied-server", "default"); !apierrors.IsNotFound(err) {
+			t.Fatalf("denied create still wrote the CR: %v", err)
+		}
+	})
+
+	t.Run("denied user update and delete", func(t *testing.T) {
+		// A CR the denied user did not create and may not touch.
+		result, err := adapter.ExecuteTool(allowedCtx, "mcpserver_create", createArgs("victim-server"))
+		if err != nil || result.IsError {
+			t.Fatalf("setup create: err=%v result=%s", err, resultText(t, result))
+		}
+
+		result, err = adapter.ExecuteTool(deniedCtx, "mcpserver_update",
+			map[string]interface{}{"name": "victim-server", "command": "evil"})
+		if err != nil {
+			t.Fatalf("ExecuteTool: %v", err)
+		}
+		if !result.IsError || !strings.Contains(resultText(t, result), "Permission denied") {
+			t.Fatalf("expected permission error on update, got: %s", resultText(t, result))
+		}
+		after, err := saClient.GetMCPServer(ctx, "victim-server", "default")
+		if err != nil {
+			t.Fatalf("get victim: %v", err)
+		}
+		if after.Spec.Command != "echo" {
+			t.Fatalf("denied update still changed the spec: %+v", after.Spec)
+		}
+
+		result, err = adapter.ExecuteTool(deniedCtx, "mcpserver_delete",
+			map[string]interface{}{"name": "victim-server"})
+		if err != nil {
+			t.Fatalf("ExecuteTool: %v", err)
+		}
+		if !result.IsError || !strings.Contains(resultText(t, result), "Permission denied") {
+			t.Fatalf("expected permission error on delete, got: %s", resultText(t, result))
+		}
+		if _, err := saClient.GetMCPServer(ctx, "victim-server", "default"); err != nil {
+			t.Fatalf("denied delete still removed the CR: %v", err)
+		}
+	})
+}

--- a/internal/mcpserver/writes_as_caller_test.go
+++ b/internal/mcpserver/writes_as_caller_test.go
@@ -1,0 +1,335 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/client"
+	"github.com/giantswarm/muster/internal/server"
+)
+
+// stubMusterClient is the SA-backed client stand-in. Only the methods the
+// mutation handlers touch are implemented; anything else panics via the
+// embedded nil interface, which is exactly what we want — the caller path
+// must never fall back to the SA client for writes.
+type stubMusterClient struct {
+	client.MusterClient
+	existing *musterv1alpha1.MCPServer
+	created  []string
+	updated  []string
+	deleted  []string
+}
+
+func (s *stubMusterClient) GetMCPServer(_ context.Context, name, namespace string) (*musterv1alpha1.MCPServer, error) {
+	if s.existing != nil && s.existing.Name == name {
+		return s.existing.DeepCopy(), nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "muster.giantswarm.io", Resource: "mcpservers"}, name)
+}
+
+func (s *stubMusterClient) CreateMCPServer(_ context.Context, obj *musterv1alpha1.MCPServer) error {
+	s.created = append(s.created, obj.Name)
+	return nil
+}
+
+func (s *stubMusterClient) UpdateMCPServer(_ context.Context, obj *musterv1alpha1.MCPServer) error {
+	s.updated = append(s.updated, obj.Name)
+	return nil
+}
+
+func (s *stubMusterClient) DeleteMCPServer(_ context.Context, name, _ string) error {
+	s.deleted = append(s.deleted, name)
+	return nil
+}
+
+// testJWT builds an unsigned-but-JWT-shaped token with the given aud claim
+// (string or []string). The write path never verifies signatures — the
+// apiserver does — so a fake signature part suffices.
+func testJWT(t *testing.T, aud interface{}) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := map[string]interface{}{"sub": "alice@example.com", "iss": "https://dex.example.com"}
+	if aud != nil {
+		claims["aud"] = aud
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+// callerHarness wires an adapter with writes-as-caller on: the factory
+// records the bearer it was handed, and the returned client records writes
+// through interceptors (optionally failing them with injectErr).
+type callerHarness struct {
+	adapter    *Adapter
+	sa         *stubMusterClient
+	tokensSeen []string
+	created    []string
+	updated    []string
+	deleted    []string
+}
+
+func newCallerHarness(t *testing.T, existing *musterv1alpha1.MCPServer, injectErr error) *callerHarness {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(musterv1alpha1.AddToScheme(scheme))
+
+	h := &callerHarness{sa: &stubMusterClient{existing: existing}}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(context.Context, ctrlclient.WithWatch, ctrlclient.Object, ...ctrlclient.CreateOption) error {
+			if injectErr != nil {
+				return injectErr
+			}
+			h.created = append(h.created, "create")
+			return nil
+		},
+		Update: func(context.Context, ctrlclient.WithWatch, ctrlclient.Object, ...ctrlclient.UpdateOption) error {
+			if injectErr != nil {
+				return injectErr
+			}
+			h.updated = append(h.updated, "update")
+			return nil
+		},
+		Delete: func(context.Context, ctrlclient.WithWatch, ctrlclient.Object, ...ctrlclient.DeleteOption) error {
+			if injectErr != nil {
+				return injectErr
+			}
+			h.deleted = append(h.deleted, "delete")
+			return nil
+		},
+	}).Build()
+
+	h.adapter = NewAdapterWithClient(h.sa, "test-ns")
+	h.adapter.EnableWritesAsCaller(func(bearerToken string) (ctrlclient.Client, error) {
+		h.tokensSeen = append(h.tokensSeen, bearerToken)
+		return fakeClient, nil
+	}, "")
+	return h
+}
+
+func resultText(t *testing.T, result *api.CallToolResult) string {
+	t.Helper()
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%v", result.Content[0])
+}
+
+func existingServer() *musterv1alpha1.MCPServer {
+	obj := &musterv1alpha1.MCPServer{}
+	obj.Name = "test-server"
+	obj.Namespace = "test-ns"
+	obj.Spec.Type = "stdio"
+	obj.Spec.Command = "echo"
+	return obj
+}
+
+// TestWritesAsCaller_IdentityReachesWrite is the regression guard against the
+// context.Background() pattern: the id_token on the request context must be
+// the exact bearer handed to the per-call client factory, for all three
+// mutations.
+func TestWritesAsCaller_IdentityReachesWrite(t *testing.T) {
+	token := testJWT(t, DefaultKubernetesAudience)
+
+	cases := []struct {
+		tool string
+		args map[string]interface{}
+	}{
+		{"mcpserver_create", map[string]interface{}{"name": "test-server", "type": "stdio", "command": "echo"}},
+		{"mcpserver_update", map[string]interface{}{"name": "test-server", "command": "echo2"}},
+		{"mcpserver_delete", map[string]interface{}{"name": "test-server"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			h := newCallerHarness(t, existingServer(), nil)
+			ctx := server.ContextWithIDToken(context.Background(), token)
+
+			result, err := h.adapter.ExecuteTool(ctx, tc.tool, tc.args)
+			if err != nil {
+				t.Fatalf("ExecuteTool: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected tool error: %s", resultText(t, result))
+			}
+			if len(h.tokensSeen) != 1 || h.tokensSeen[0] != token {
+				t.Fatalf("caller bearer did not reach the write: factory saw %v", h.tokensSeen)
+			}
+			if writes := len(h.created) + len(h.updated) + len(h.deleted); writes != 1 {
+				t.Fatalf("expected exactly one caller-client write, got %d", writes)
+			}
+			if len(h.sa.created)+len(h.sa.updated)+len(h.sa.deleted) != 0 {
+				t.Fatalf("SA client performed a write on the caller path")
+			}
+		})
+	}
+}
+
+func TestWritesAsCaller_MissingAudience(t *testing.T) {
+	for name, aud := range map[string]interface{}{
+		"wrong-string-aud": "muster-client",
+		"wrong-list-aud":   []string{"muster-client", "other"},
+		"no-aud":           nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newCallerHarness(t, existingServer(), nil)
+			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, aud))
+
+			result, err := h.adapter.ExecuteTool(ctx, "mcpserver_create",
+				map[string]interface{}{"name": "test-server", "type": "stdio", "command": "echo"})
+			if err != nil {
+				t.Fatalf("ExecuteTool: %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("expected a tool error for a token without the kubernetes audience")
+			}
+			text := resultText(t, result)
+			for _, want := range []string{DefaultKubernetesAudience, "re-login"} {
+				if !strings.Contains(text, want) {
+					t.Errorf("error %q does not mention %q", text, want)
+				}
+			}
+			if len(h.tokensSeen) != 0 {
+				t.Fatal("factory must not be called for a token without the audience")
+			}
+		})
+	}
+}
+
+func TestWritesAsCaller_NoSessionToken(t *testing.T) {
+	h := newCallerHarness(t, existingServer(), nil)
+
+	result, err := h.adapter.ExecuteTool(context.Background(), "mcpserver_delete",
+		map[string]interface{}{"name": "test-server"})
+	if err != nil {
+		t.Fatalf("ExecuteTool: %v", err)
+	}
+	if !result.IsError || !strings.Contains(resultText(t, result), "re-login") {
+		t.Fatalf("expected a re-login error, got: %s", resultText(t, result))
+	}
+}
+
+func TestWritesAsCaller_ForbiddenMapsToPermissionError(t *testing.T) {
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "muster.giantswarm.io", Resource: "mcpservers"},
+		"test-server", fmt.Errorf(`User "alice" cannot create resource "mcpservers"`))
+
+	cases := []struct {
+		tool string
+		verb string
+		args map[string]interface{}
+	}{
+		{"mcpserver_create", "create", map[string]interface{}{"name": "test-server", "type": "stdio", "command": "echo"}},
+		{"mcpserver_update", "update", map[string]interface{}{"name": "test-server", "command": "echo2"}},
+		{"mcpserver_delete", "delete", map[string]interface{}{"name": "test-server"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			h := newCallerHarness(t, existingServer(), forbidden)
+			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+			result, err := h.adapter.ExecuteTool(ctx, tc.tool, tc.args)
+			if err != nil {
+				t.Fatalf("ExecuteTool: %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("expected a tool error on 403")
+			}
+			text := resultText(t, result)
+			for _, want := range []string{"Permission denied", tc.verb, "mcpservers.muster.giantswarm.io", `"test-ns"`, "mcpserver-editor"} {
+				if !strings.Contains(text, want) {
+					t.Errorf("403 mapping %q does not mention %q", text, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWritesAsCaller_UnauthorizedMapsToRelogin(t *testing.T) {
+	h := newCallerHarness(t, existingServer(), apierrors.NewUnauthorized("token expired"))
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+	result, err := h.adapter.ExecuteTool(ctx, "mcpserver_create",
+		map[string]interface{}{"name": "test-server", "type": "stdio", "command": "echo"})
+	if err != nil {
+		t.Fatalf("ExecuteTool: %v", err)
+	}
+	if !result.IsError || !strings.Contains(resultText(t, result), "re-login") {
+		t.Fatalf("expected a re-login error on 401, got: %s", resultText(t, result))
+	}
+}
+
+// TestWritesAsCaller_FlagOff pins the legacy behavior: with the flag off the
+// SA client performs the write even when the session carries a token.
+func TestWritesAsCaller_FlagOff(t *testing.T) {
+	sa := &stubMusterClient{existing: existingServer()}
+	adapter := NewAdapterWithClient(sa, "test-ns")
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+	result, err := adapter.ExecuteTool(ctx, "mcpserver_create",
+		map[string]interface{}{"name": "another-server", "type": "stdio", "command": "echo"})
+	if err != nil {
+		t.Fatalf("ExecuteTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %s", resultText(t, result))
+	}
+	if len(sa.created) != 1 || sa.created[0] != "another-server" {
+		t.Fatalf("SA client did not perform the write with the flag off: %v", sa.created)
+	}
+}
+
+// TestWritesAsCaller_ValidateUntouched pins that validation stays available to
+// callers who cannot write: no token, flag on, validate still succeeds.
+func TestWritesAsCaller_ValidateUntouched(t *testing.T) {
+	h := newCallerHarness(t, nil, nil)
+
+	result, err := h.adapter.ExecuteTool(context.Background(), "mcpserver_validate",
+		map[string]interface{}{"name": "test-server", "type": "stdio", "command": "echo"})
+	if err != nil {
+		t.Fatalf("ExecuteTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("validate must not require a write identity: %s", resultText(t, result))
+	}
+}
+
+func TestTokenMissingAudience(t *testing.T) {
+	jwtWith := func(aud interface{}) string { return testJWT(t, aud) }
+	cases := []struct {
+		name    string
+		token   string
+		missing bool
+	}{
+		{"string-match", jwtWith(DefaultKubernetesAudience), false},
+		{"list-match", jwtWith([]string{"x", DefaultKubernetesAudience}), false},
+		{"string-mismatch", jwtWith("other"), true},
+		{"list-mismatch", jwtWith([]string{"a", "b"}), true},
+		{"absent", jwtWith(nil), true},
+		{"opaque-token-passes-through", "not-a-jwt", false},
+	}
+	for _, tc := range cases {
+		if got := tokenMissingAudience(tc.token, DefaultKubernetesAudience); got != tc.missing {
+			t.Errorf("%s: tokenMissingAudience=%v, want %v", tc.name, got, tc.missing)
+		}
+	}
+}

--- a/internal/testing/scenarios/mcpserver-writes-as-caller.yaml
+++ b/internal/testing/scenarios/mcpserver-writes-as-caller.yaml
@@ -1,0 +1,135 @@
+name: "mcpserver-writes-as-caller"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  Writes-as-caller transition flag (issue #1056). With writesAsCaller enabled,
+  session-initiated MCPServer spec mutations are written with the caller's own
+  dex id_token so the kube-apiserver authenticates the real user and k8s RBAC
+  decides. A session whose token does not carry the kubernetes audience
+  (dex-k8s-authenticator) gets an actionable re-login error on every mutation
+  — before anything is written — while core_mcpserver_validate stays available
+  to callers who cannot write (the registration wizard validates before the
+  permission gate matters) and reads are untouched. The allowed/denied RBAC
+  matrix itself runs against a real apiserver in TestWritesAsCallerEnvtest;
+  the SA path with the flag off is pinned by mcpserver-crud.
+tags: ["mcpserver", "oauth", "writes-as-caller", "rbac", "negative"]
+timeout: "2m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "muster-idp"
+      scopes: ["openid", "profile", "email", "groups"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "muster-client"
+      client_secret: "muster-secret"
+      use_as_muster_oauth_server: true
+
+    - name: "workload-idp"
+
+  muster_broker:
+    trusted_issuers:
+      - oauth_server_ref: "workload-idp"
+        accepted_typ_headers: [""]
+
+  main_config:
+    config:
+      writesAsCaller:
+        enabled: true
+
+steps:
+  - id: "mint-session-token"
+    description: |
+      Mint a session token WITHOUT the dex-k8s-authenticator audience — the
+      shape of a session predating the audience configuration. Its default
+      audience is muster's own issuer, so muster accepts it as a bearer, but
+      the kube-apiserver would not.
+    tool: "test_mint_token"
+    args:
+      server: "workload-idp"
+      name: "no-k8s-audience-token"
+      sub: "alice@giantswarm.io"
+      email: "alice@giantswarm.io"
+      email_verified: true
+    expected:
+      success: true
+
+  - id: "connect-session"
+    description: "Authenticate the MCP session with that token"
+    tool: "test_reconnect_with_token"
+    args:
+      token_ref: "no-k8s-audience-token"
+    expected:
+      success: true
+    retry:
+      count: 5
+      delay: "1s"
+
+  - id: "validate-still-works"
+    description: |
+      core_mcpserver_validate is untouched by the write gate: it has no side
+      effects and must keep working for callers who cannot write.
+    tool: "core_mcpserver_validate"
+    args:
+      name: "wac-server"
+      type: "stdio"
+      command: "echo"
+    expected:
+      success: true
+
+  - id: "create-denied-re-login"
+    description: |
+      Create is refused with an actionable re-login error naming the missing
+      audience — not a silent failure, not a generic 401.
+    tool: "core_mcpserver_create"
+    args:
+      name: "wac-server"
+      type: "stdio"
+      command: "echo"
+      autoStart: false
+    expected:
+      success: false
+      error_contains:
+        - "dex-k8s-authenticator"
+        - "re-login"
+
+  - id: "no-write-occurred"
+    description: "The refused create wrote nothing"
+    tool: "core_mcpserver_list"
+    args:
+      showAll: true
+    expected:
+      success: true
+      json_path:
+        total: 0
+
+  - id: "update-denied-re-login"
+    description: "Update is gated identically, before the server lookup"
+    tool: "core_mcpserver_update"
+    args:
+      name: "wac-server"
+      command: "echo2"
+    expected:
+      success: false
+      error_contains:
+        - "dex-k8s-authenticator"
+        - "re-login"
+
+  - id: "delete-denied-re-login"
+    description: "Delete is gated identically"
+    tool: "core_mcpserver_delete"
+    args:
+      name: "wac-server"
+    expected:
+      success: false
+      error_contains:
+        - "dex-k8s-authenticator"
+        - "re-login"
+
+  - id: "reads-untouched"
+    description: "Reads keep working for sessions that cannot write"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true


### PR DESCRIPTION
Closes #1056.

## What

Behind the new `writesAsCaller` transition flag (default **off**), `core_mcpserver_create` / `_update` / `_delete` perform the Kubernetes write **as the caller**: a per-call client is built with the session's dex id_token as the bearer (`rest.Config{BearerToken: …}`, ambient credentials stripped), so the apiserver authenticates the real user, k8s RBAC decides, and the audit log records the true subject. No impersonation headers, nothing minted or exchanged — forward-only, per the same-cluster ruling.

- The request context (and with it the session identity) is now threaded through `ExecuteTool` into all three mutation handlers — the manufactured `context.Background()` in update/delete is gone.
- 403 maps to a human-readable error naming the verb, resource (`mcpservers.muster.giantswarm.io`), and namespace, and pointing at the `mcpserver-editor` role.
- A session token without the kubernetes audience (`dex-k8s-authenticator`, configurable via `writesAsCaller.kubernetesAudience`) gets an actionable re-login error **before** any write is attempted; apiserver 401s map to re-login as well.
- `core_mcpserver_validate`, reads, and muster's own controller writes (status reconciliation, service registration, startup sync) are untouched.
- Flag off: byte-for-byte legacy SA path.

#1058 ships the chart's `mcpserver-editor` Role + default binding and exposes the flag; #1057 reuses the mechanism for the CR-driven lifecycle tools.

## Testing

- **Unit** (`writes_as_caller_test.go`): regression guard that the identity on the request context is the exact bearer reaching the write for all three mutations; audience-missing → re-login (factory never called); 403/401 mapping; flag-off SA path; validate needs no write identity.
- **envtest** (`make test-envtest`, skips without `KUBEBUILDER_ASSETS`): real apiserver with static-token users and RBAC fixtures — allowed user creates/updates/deletes; denied user gets the permission error and **no write occurs**; the SA still reconciles status on a CR it did not create. Passing locally (3/3 subtests).
- **Behavioral scenario** (`mcpserver-writes-as-caller`): flag on, session token without the kubernetes audience → every mutation returns the re-login error naming the audience, nothing is written, validate and reads keep working. The RBAC allowed/denied matrix needs a real apiserver and lives in the envtest suite; the flag-off SA path is pinned by the existing `mcpserver-crud` scenario.
- Full `go test ./...` green; full integration suite 185/185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
