### PR TITLE
feat(mcpserver): CR-driven service lifecycle writes with the caller's identity

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -284,6 +284,14 @@ RBAC authorizes the write, and the audit log records the true subject.
 Reads, `core_mcpserver_validate`, and muster's own controller writes (status
 reconciliation, service registration) are unaffected.
 
+Service lifecycle actions on MCPServer-backed services are covered the same
+way: `core_service_stop` writes `spec.suspended: true`, `core_service_start`
+clears it (or writes `spec.restartRequestedAt` for a server that is down
+without being suspended), and `core_service_restart` writes
+`spec.restartRequestedAt` — all as the caller, with the reconciler performing
+the actual start/stop/restart. Lifecycle of muster's own internal services
+(e.g. the aggregator) keeps the imperative path.
+
 ```yaml
 writesAsCaller:
   enabled: true                            # Default: false (legacy SA write path)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -286,11 +286,11 @@ reconciliation, service registration) are unaffected.
 
 Service lifecycle actions on MCPServer-backed services are covered the same
 way: `core_service_stop` writes `spec.suspended: true`, `core_service_start`
-clears it (or writes `spec.restartRequestedAt` for a server that is down
-without being suspended), and `core_service_restart` writes
-`spec.restartRequestedAt` — all as the caller, with the reconciler performing
-the actual start/stop/restart. Lifecycle of muster's own internal services
-(e.g. the aggregator) keeps the imperative path.
+clears it (and also writes `spec.restartRequestedAt` when the service is
+down), and `core_service_restart` writes `spec.restartRequestedAt` — all as
+the caller, with the reconciler performing the actual start/stop/restart.
+Lifecycle of muster's own internal services (e.g. the aggregator) keeps the
+imperative path.
 
 ```yaml
 writesAsCaller:

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -559,10 +559,11 @@ Start a specific service.
 **⚠️ Note:** Static services (aggregator) may not support start operations.
 
 **Writes-as-caller:** With `writesAsCaller` enabled, start on an MCPServer-backed
-service is a CR write with your own identity — it clears `spec.suspended` (or
-writes `spec.restartRequestedAt` when the server is down without being
-suspended) and the reconciler starts the service. Kubernetes RBAC authorizes
-the write and the apiserver audit log records you as the subject.
+service is a CR write with your own identity — it clears `spec.suspended` and,
+whenever the service is down, also writes `spec.restartRequestedAt` (the
+one-shot "make it run now" request), and the reconciler starts the service.
+Kubernetes RBAC authorizes the write and the apiserver audit log records you
+as the subject.
 
 ### `core_service_stop`
 Stop a specific service.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -558,6 +558,12 @@ Start a specific service.
 
 **⚠️ Note:** Static services (aggregator) may not support start operations.
 
+**Writes-as-caller:** With `writesAsCaller` enabled, start on an MCPServer-backed
+service is a CR write with your own identity — it clears `spec.suspended` (or
+writes `spec.restartRequestedAt` when the server is down without being
+suspended) and the reconciler starts the service. Kubernetes RBAC authorizes
+the write and the apiserver audit log records you as the subject.
+
 ### `core_service_stop`
 Stop a specific service.
 
@@ -583,6 +589,10 @@ Stop a specific service.
 
 **⚠️ Warning:** Stopping critical services (aggregator, MCP servers) may disrupt tool availability.
 
+**Writes-as-caller:** With `writesAsCaller` enabled, stop on an MCPServer-backed
+service writes `spec.suspended: true` with your own identity; the reconciler
+stops the service and keeps it stopped until it is resumed.
+
 ### `core_service_restart`
 Restart a specific service (stop then start operation).
 
@@ -605,6 +615,11 @@ Restart a specific service (stop then start operation).
 - Apply configuration changes that require restart
 - Recover from service errors or hangs
 - Refresh connections or reinitialize state
+
+**Writes-as-caller:** With `writesAsCaller` enabled, restart on an
+MCPServer-backed service writes `spec.restartRequestedAt` with your own
+identity; the reconciler restarts the service once and mirrors the processed
+value into `status.lastRestartedAt`.
 
 ### `core_service_status`
 Get current status information for a specific service.

--- a/internal/api/mcpserver.go
+++ b/internal/api/mcpserver.go
@@ -1,6 +1,9 @@
 package api
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // MCPServer represents a single MCP (Model Context Protocol) server definition and runtime state.
 // It consolidates MCPServerDefinition, MCPServerInfo, and MCPServerConfig into a unified type
@@ -432,4 +435,22 @@ type MCPServerManagerHandler interface {
 	// This allows MCP server operations to be performed through the aggregator
 	// tool system, enabling programmatic and user-driven server management.
 	ToolProvider
+}
+
+// MCPServerLifecycleAsCaller is the optional capability the registered
+// MCPServer manager gains when writes-as-caller is enabled (issue #1057):
+// lifecycle actions on MCPServer-backed services become CR spec writes
+// performed with the caller's own identity — authorized by k8s RBAC and
+// audited by the apiserver — instead of orchestrator mutations with muster's
+// privilege. handled=false means the caller must fall back to the imperative
+// path (flag off, or the name is a non-MCPServer service such as muster's own
+// aggregator); it is always accompanied by a nil result and a nil error.
+//
+// The implementing adapter pins this interface at compile time so a signature
+// drift cannot silently fail the type assertion and reopen the privileged
+// imperative path.
+type MCPServerLifecycleAsCaller interface {
+	StartMCPServerAsCaller(ctx context.Context, name string) (result *CallToolResult, handled bool, err error)
+	StopMCPServerAsCaller(ctx context.Context, name string) (result *CallToolResult, handled bool, err error)
+	RestartMCPServerAsCaller(ctx context.Context, name string) (result *CallToolResult, handled bool, err error)
 }

--- a/internal/api/requests.go
+++ b/internal/api/requests.go
@@ -137,9 +137,10 @@ type MCPServerUpdateRequest struct {
 	Auth *MCPServerAuth `json:"auth,omitempty"`
 
 	// Suspended declares the desired lifecycle state of the server's service.
-	// Like AutoStart, this uses replace semantics: omitting it resumes a
-	// suspended server (issue #1055).
-	Suspended bool `json:"suspended,omitempty"`
+	// Tri-state: omitting it keeps the current value, so an unrelated update
+	// (description, headers) does not silently resume a server that was
+	// stopped through the CR-driven core_service_stop (issue #1057).
+	Suspended *bool `json:"suspended,omitempty"`
 
 	// RestartRequestedAt requests a one-shot restart of the server's service
 	// (RFC 3339 timestamp). Only applied when set (issue #1055).

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -207,6 +207,20 @@ func IsActiveState(state ServiceState) bool {
 	return state == StateRunning || state == StateConnected
 }
 
+// IsDownState returns true if the given state means the service is not running
+// and not on its way up — the states from which an explicit start request must
+// actively start the service. Transitional states (starting, connecting,
+// retrying) and StateAuthRequired are not down: acting on them would interrupt
+// an in-flight start or a reachable server waiting for session authentication.
+func IsDownState(state ServiceState) bool {
+	switch state {
+	case StateStopped, StateDisconnected, StateFailed, StateError, StateUnreachable, StateUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
 // ServiceStateChangedEvent represents a service state transition event.
 // These events are published whenever a service changes state, allowing
 // components to react to service lifecycle changes.

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -622,7 +622,7 @@ func (a *Adapter) GetTools() []api.ToolMetadata {
 			// type is optional for update; suspended/restartRequestedAt are the
 			// CR-driven lifecycle fields (issue #1055) and only settable here.
 			Args: append(mcpServerArgs(false),
-				api.ArgMetadata{Name: "suspended", Type: api.ArgTypeBoolean, Required: false, Description: "Desired lifecycle state: true stops the server's service and keeps it stopped; false (or omitted) resumes it"},
+				api.ArgMetadata{Name: "suspended", Type: api.ArgTypeBoolean, Required: false, Description: "Desired lifecycle state: true stops the server's service and keeps it stopped; false resumes it; omitted keeps the current value"},
 				api.ArgMetadata{Name: "restartRequestedAt", Type: api.ArgTypeString, Required: false, Description: "RFC 3339 timestamp requesting a one-shot restart; processed once by the reconciler"},
 			),
 		},
@@ -878,8 +878,11 @@ func (a *Adapter) handleMCPServerUpdate(ctx context.Context, args map[string]int
 		existing.Spec.Description = req.Description
 	}
 	existing.Spec.AutoStart = req.AutoStart
-	// Replace semantics like AutoStart: omitting suspended resumes the server.
-	existing.Spec.Suspended = req.Suspended
+	// Tri-state: only an explicit suspended value changes the lifecycle state,
+	// so unrelated updates don't silently resume a stopped server (issue #1057).
+	if req.Suspended != nil {
+		existing.Spec.Suspended = *req.Suspended
+	}
 	if req.RestartRequestedAt != nil {
 		existing.Spec.RestartRequestedAt = &metav1.Time{Time: *req.RestartRequestedAt}
 	}

--- a/internal/mcpserver/api_adapter_protocol_test.go
+++ b/internal/mcpserver/api_adapter_protocol_test.go
@@ -22,15 +22,21 @@ func (f *fakeServiceRegistry) GetAll() []api.ServiceInfo { return nil }
 
 func (f *fakeServiceRegistry) GetByType(api.ServiceType) []api.ServiceInfo { return nil }
 
-// fakeServiceInfo reports a fixed service data map and state.
+// fakeServiceInfo reports a fixed service data map, state, and type.
 type fakeServiceInfo struct {
 	name  string
 	data  map[string]any
 	state api.ServiceState
+	typ   api.ServiceType
 }
 
-func (f *fakeServiceInfo) GetName() string          { return f.name }
-func (f *fakeServiceInfo) GetType() api.ServiceType { return api.TypeMCPServer }
+func (f *fakeServiceInfo) GetName() string { return f.name }
+func (f *fakeServiceInfo) GetType() api.ServiceType {
+	if f.typ == "" {
+		return api.TypeMCPServer
+	}
+	return f.typ
+}
 func (f *fakeServiceInfo) GetState() api.ServiceState {
 	if f.state == "" {
 		return api.StateRunning

--- a/internal/mcpserver/api_adapter_protocol_test.go
+++ b/internal/mcpserver/api_adapter_protocol_test.go
@@ -22,15 +22,21 @@ func (f *fakeServiceRegistry) GetAll() []api.ServiceInfo { return nil }
 
 func (f *fakeServiceRegistry) GetByType(api.ServiceType) []api.ServiceInfo { return nil }
 
-// fakeServiceInfo reports a fixed service data map.
+// fakeServiceInfo reports a fixed service data map and state.
 type fakeServiceInfo struct {
-	name string
-	data map[string]any
+	name  string
+	data  map[string]any
+	state api.ServiceState
 }
 
-func (f *fakeServiceInfo) GetName() string                { return f.name }
-func (f *fakeServiceInfo) GetType() api.ServiceType       { return api.TypeMCPServer }
-func (f *fakeServiceInfo) GetState() api.ServiceState     { return api.StateRunning }
+func (f *fakeServiceInfo) GetName() string          { return f.name }
+func (f *fakeServiceInfo) GetType() api.ServiceType { return api.TypeMCPServer }
+func (f *fakeServiceInfo) GetState() api.ServiceState {
+	if f.state == "" {
+		return api.StateRunning
+	}
+	return f.state
+}
 func (f *fakeServiceInfo) GetHealth() api.HealthStatus    { return api.HealthHealthy }
 func (f *fakeServiceInfo) GetLastError() error            { return nil }
 func (f *fakeServiceInfo) GetServiceData() map[string]any { return f.data }

--- a/internal/mcpserver/lifecycle.go
+++ b/internal/mcpserver/lifecycle.go
@@ -6,10 +6,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
 
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/events"
 )
 
 // Lifecycle actions as CR writes (issue #1057). With writes-as-caller enabled,
@@ -22,7 +24,31 @@ import (
 //
 // Each method returns handled=false when the action must fall back to the
 // orchestrator's imperative path: the writesAsCaller flag is off, or the name
-// is not an MCPServer definition (e.g. muster's own aggregator service).
+// is one of muster's own internal services (e.g. the aggregator). MCPServer
+// and unknown names never fall back — a deleted CR with a lingering registry
+// entry would otherwise reopen the privileged side door this feature closes.
+
+// The compile-time pin: if these method signatures drift from the api
+// contract, the orchestrator's type assertion would silently fail and
+// lifecycle would fall back to the privileged imperative path. Fail the build
+// instead.
+var _ api.MCPServerLifecycleAsCaller = (*Adapter)(nil)
+
+// OAuthLoginGuidance is the user-facing guidance for services that require
+// session-scoped OAuth authentication: starting or restarting them cannot
+// authenticate a session, only core_auth_login can. Shared with the
+// imperative path's formatOAuthAuthenticationError so both paths answer the
+// same tool call with the same words.
+func OAuthLoginGuidance(name string) string {
+	return fmt.Sprintf(
+		"Service '%s' requires OAuth authentication.\n\n"+
+			"To connect to this server, use the core_auth_login tool:\n"+
+			"  core_auth_login(server=\"%s\")\n\n"+
+			"The service start/restart command cannot be used for OAuth-protected servers "+
+			"because authentication is session-scoped.",
+		name, name,
+	)
+}
 
 // lifecycleTarget resolves the MCPServer definition a lifecycle action targets.
 // handled=false means the caller must fall back to the imperative path. A
@@ -31,12 +57,25 @@ func (a *Adapter) lifecycleTarget(ctx context.Context, name string) (*musterv1al
 	if !a.writesAsCaller {
 		return nil, nil, false
 	}
+
+	// Muster's own internal services (e.g. the aggregator) are not
+	// user-mutable CR surface: they keep the imperative path and must not
+	// depend on a Kubernetes read.
+	if registry := api.GetServiceRegistry(); registry != nil {
+		if service, exists := registry.Get(name); exists && service.GetType() != api.TypeMCPServer {
+			return nil, nil, false
+		}
+	}
+
 	// The read stays on the SA client — only the spec mutation itself switches
 	// to the caller's identity, same as create/update/delete.
 	existing, err := a.client.GetMCPServer(ctx, name, a.namespace)
 	if err != nil {
+		// Fail closed on every lookup error, NotFound included: MCPServer and
+		// unknown names must not reach the imperative path with muster's
+		// privilege, even during an apiserver hiccup.
 		if errors.IsNotFound(err) {
-			return nil, nil, false
+			return nil, api.HandleErrorWithPrefix(api.NewMCPServerNotFoundError(name), "Failed to look up MCP server"), true
 		}
 		result, _ := simpleError(fmt.Sprintf("Failed to look up MCP server '%s': %v", name, err))
 		return nil, result, true
@@ -44,14 +83,56 @@ func (a *Adapter) lifecycleTarget(ctx context.Context, name string) (*musterv1al
 	return existing, nil, true
 }
 
-// lifecycleWriteError maps a failed caller-identity lifecycle write to a tool
-// error: 403 and 401 map exactly like create/update/delete, everything else
-// is reported verbatim.
-func (a *Adapter) lifecycleWriteError(err error, action, name string) (*api.CallToolResult, error) {
-	if msg := a.describeWriteAuthError(err, action, name); msg != "" {
-		return simpleError(msg)
+// commitLifecycleWrite is the shared tail of the three lifecycle tools: it
+// resolves the caller's write identity, applies mutate to the object, retries
+// the read-modify-write on conflicts (status syncs bump resourceVersion
+// continuously), maps authn/authz failures exactly like create/update/delete,
+// and emits the CRD events operators look for in `kubectl describe`.
+func (a *Adapter) commitLifecycleWrite(ctx context.Context, existing *musterv1alpha1.MCPServer, action, okMsg string, mutate func(*musterv1alpha1.MCPServer)) (*api.CallToolResult, error) {
+	writer, gateResult := a.mutationWriter(ctx)
+	if gateResult != nil {
+		return gateResult, nil
 	}
-	return simpleError(fmt.Sprintf("Failed to request %s of service '%s': %v", action, name, err))
+
+	name := existing.Name
+	mutate(existing)
+	err := writer.UpdateMCPServer(ctx, existing)
+	if errors.IsConflict(err) {
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			fresh, getErr := a.client.GetMCPServer(ctx, name, a.namespace)
+			if getErr != nil {
+				return getErr
+			}
+			mutate(fresh)
+			return writer.UpdateMCPServer(ctx, fresh)
+		})
+	}
+	if err != nil {
+		if msg := a.describeWriteAuthError(err, action, name); msg != "" {
+			return simpleError(msg)
+		}
+		a.generateCRDEvent(name, events.ReasonMCPServerFailed, events.EventData{
+			Error:     err.Error(),
+			Operation: action,
+		})
+		return simpleError(fmt.Sprintf("Failed to request %s of service '%s': %v", action, name, err))
+	}
+
+	a.generateCRDEvent(name, events.ReasonMCPServerUpdated, events.EventData{
+		Operation: action,
+	})
+	return simpleOK(okMsg)
+}
+
+// requestedMessage is the success message for an accepted lifecycle request.
+// OAuth-backed servers get a pointer at core_auth_login up front, because the
+// reconciler treats Auth Required as a stable state and cannot report it back
+// through this (asynchronous) tool result.
+func requestedMessage(server *musterv1alpha1.MCPServer, base string) string {
+	if server.Spec.Auth != nil && server.Spec.Auth.Type == "oauth" {
+		return base + ". This server uses OAuth: if it comes up auth-required, authenticate with core_auth_login"
+	}
+	return base
 }
 
 // registryState returns the runtime state of the named service, or ok=false
@@ -69,9 +150,13 @@ func registryState(name string) (api.ServiceState, bool) {
 }
 
 // StartMCPServerAsCaller handles core_service_start as a CR write: it clears
-// spec.suspended on a suspended server, and writes spec.restartRequestedAt for
-// a server that is down without being suspended (autoStart=false servers,
-// failed servers) — for a down service that request is a plain start.
+// spec.suspended and, whenever the service is down, also writes
+// spec.restartRequestedAt — the one-shot "make it run now" request. The
+// restart request is what starts autoStart=false and failed servers, and it
+// makes a resume level-reconstructable even when the reconciler's in-memory
+// suspension marker was lost to a muster restart. Timestamps have second
+// granularity, so repeated starts within one second collapse into one request
+// — the service was just started anyway.
 func (a *Adapter) StartMCPServerAsCaller(ctx context.Context, name string) (*api.CallToolResult, bool, error) {
 	existing, errResult, handled := a.lifecycleTarget(ctx, name)
 	if !handled {
@@ -81,43 +166,42 @@ func (a *Adapter) StartMCPServerAsCaller(ctx context.Context, name string) (*api
 		return errResult, true, nil
 	}
 
-	// No mutation is intended for a server that is already up or on its way up,
-	// so no write identity is required either.
-	if state, exists := registryState(name); exists && !api.IsDownState(state) && !existing.Spec.Suspended {
-		if state == api.StateAuthRequired {
-			result, err := simpleError(fmt.Sprintf(
-				"Service '%s' requires OAuth authentication.\n\n"+
-					"To connect to this server, use the core_auth_login tool:\n"+
-					"  core_auth_login(server=\"%s\")\n\n"+
-					"The service start/restart command cannot be used for OAuth-protected servers "+
-					"because authentication is session-scoped.",
-				name, name))
+	state, exists := registryState(name)
+	down := !exists || api.IsDownState(state)
+
+	// No mutation is intended for an unsuspended server that is up or on its
+	// way up, so no write identity is required either.
+	if !down && !existing.Spec.Suspended {
+		switch {
+		case state == api.StateAuthRequired:
+			result, err := simpleError(OAuthLoginGuidance(name))
 			return result, true, err
-		}
-		if api.IsActiveState(state) {
+		case api.IsActiveState(state):
 			result, err := simpleOK(fmt.Sprintf("Service '%s' is already running", name))
 			return result, true, err
+		default:
+			// Transitional states (starting, connecting, stopping, ...): acting
+			// on them would interrupt an in-flight transition, so report the
+			// actual state instead of pretending.
+			result, err := simpleOK(fmt.Sprintf(
+				"Service '%s' is in state %q; no start request was written — check core_service_status and retry if it does not come up", name, state))
+			return result, true, err
 		}
-		result, err := simpleOK(fmt.Sprintf("Service '%s' is already starting", name))
-		return result, true, err
 	}
 
-	writer, gateResult := a.mutationWriter(ctx)
-	if gateResult != nil {
-		return gateResult, true, nil
-	}
-
-	if existing.Spec.Suspended {
-		existing.Spec.Suspended = false
-	} else {
+	var restartRequestedAt *metav1.Time
+	if down {
 		now := metav1.Now()
-		existing.Spec.RestartRequestedAt = &now
+		restartRequestedAt = &now
 	}
-	if err := writer.UpdateMCPServer(ctx, existing); err != nil {
-		result, retErr := a.lifecycleWriteError(err, "start", name)
-		return result, true, retErr
-	}
-	result, err := simpleOK(fmt.Sprintf("Start of service '%s' requested; the reconciler will start it", name))
+	result, err := a.commitLifecycleWrite(ctx, existing, "start",
+		requestedMessage(existing, fmt.Sprintf("Start of service '%s' requested; the reconciler will start it", name)),
+		func(server *musterv1alpha1.MCPServer) {
+			server.Spec.Suspended = false
+			if restartRequestedAt != nil {
+				server.Spec.RestartRequestedAt = restartRequestedAt
+			}
+		})
 	return result, true, err
 }
 
@@ -134,28 +218,27 @@ func (a *Adapter) StopMCPServerAsCaller(ctx context.Context, name string) (*api.
 	}
 
 	if existing.Spec.Suspended {
+		if state, exists := registryState(name); exists && !api.IsDownState(state) {
+			result, err := simpleOK(fmt.Sprintf("Service '%s' is already suspended; its service is still %q while the reconciler brings it down", name, state))
+			return result, true, err
+		}
 		result, err := simpleOK(fmt.Sprintf("Service '%s' is already suspended", name))
 		return result, true, err
 	}
 
-	writer, gateResult := a.mutationWriter(ctx)
-	if gateResult != nil {
-		return gateResult, true, nil
-	}
-
-	existing.Spec.Suspended = true
-	if err := writer.UpdateMCPServer(ctx, existing); err != nil {
-		result, retErr := a.lifecycleWriteError(err, "stop", name)
-		return result, true, retErr
-	}
-	result, err := simpleOK(fmt.Sprintf("Stop of service '%s' requested (spec.suspended=true); the reconciler will stop it and keep it stopped", name))
+	result, err := a.commitLifecycleWrite(ctx, existing, "stop",
+		fmt.Sprintf("Stop of service '%s' requested (spec.suspended=true); the reconciler will stop it and keep it stopped", name),
+		func(server *musterv1alpha1.MCPServer) {
+			server.Spec.Suspended = true
+		})
 	return result, true, err
 }
 
 // RestartMCPServerAsCaller handles core_service_restart as a CR write: it sets
 // spec.restartRequestedAt with the caller's identity. The field itself is the
 // audit record of who requested the restart and when; the reconciler processes
-// it once and mirrors the value into status.lastRestartedAt.
+// it once and mirrors the value into status.lastRestartedAt. Second-granularity
+// timestamps collapse repeated restarts within one second into a single one.
 func (a *Adapter) RestartMCPServerAsCaller(ctx context.Context, name string) (*api.CallToolResult, bool, error) {
 	existing, errResult, handled := a.lifecycleTarget(ctx, name)
 	if !handled {
@@ -172,17 +255,18 @@ func (a *Adapter) RestartMCPServerAsCaller(ctx context.Context, name string) (*a
 		return result, true, err
 	}
 
-	writer, gateResult := a.mutationWriter(ctx)
-	if gateResult != nil {
-		return gateResult, true, nil
+	// Restarting cannot authenticate a session: keep the imperative path's
+	// guidance for servers waiting on OAuth.
+	if state, exists := registryState(name); exists && state == api.StateAuthRequired {
+		result, err := simpleError(OAuthLoginGuidance(name))
+		return result, true, err
 	}
 
 	now := metav1.Now()
-	existing.Spec.RestartRequestedAt = &now
-	if err := writer.UpdateMCPServer(ctx, existing); err != nil {
-		result, retErr := a.lifecycleWriteError(err, "restart", name)
-		return result, true, retErr
-	}
-	result, err := simpleOK(fmt.Sprintf("Restart of service '%s' requested; the reconciler will restart it", name))
+	result, err := a.commitLifecycleWrite(ctx, existing, "restart",
+		requestedMessage(existing, fmt.Sprintf("Restart of service '%s' requested; the reconciler will restart it", name)),
+		func(server *musterv1alpha1.MCPServer) {
+			server.Spec.RestartRequestedAt = &now
+		})
 	return result, true, err
 }

--- a/internal/mcpserver/lifecycle.go
+++ b/internal/mcpserver/lifecycle.go
@@ -1,0 +1,188 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+// Lifecycle actions as CR writes (issue #1057). With writes-as-caller enabled,
+// core_service_start/_stop/_restart no longer mutate orchestrator runtime
+// state directly: they write the MCPServer spec lifecycle fields (issue #1055)
+// with the caller's own bearer, so the apiserver authenticates the real user,
+// k8s RBAC authorizes the action, and the audit log attributes it to the dex
+// subject — exactly like create/update/delete. The reconciler performs the
+// actual start/stop/restart from the spec fields.
+//
+// Each method returns handled=false when the action must fall back to the
+// orchestrator's imperative path: the writesAsCaller flag is off, or the name
+// is not an MCPServer definition (e.g. muster's own aggregator service).
+
+// lifecycleTarget resolves the MCPServer definition a lifecycle action targets.
+// handled=false means the caller must fall back to the imperative path. A
+// non-nil result is a ready-to-return tool error from the definition lookup.
+func (a *Adapter) lifecycleTarget(ctx context.Context, name string) (*musterv1alpha1.MCPServer, *api.CallToolResult, bool) {
+	if !a.writesAsCaller {
+		return nil, nil, false
+	}
+	// The read stays on the SA client — only the spec mutation itself switches
+	// to the caller's identity, same as create/update/delete.
+	existing, err := a.client.GetMCPServer(ctx, name, a.namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil, false
+		}
+		result, _ := simpleError(fmt.Sprintf("Failed to look up MCP server '%s': %v", name, err))
+		return nil, result, true
+	}
+	return existing, nil, true
+}
+
+// lifecycleWriteError maps a failed caller-identity lifecycle write to a tool
+// error: 403 and 401 map exactly like create/update/delete, everything else
+// is reported verbatim.
+func (a *Adapter) lifecycleWriteError(err error, action, name string) (*api.CallToolResult, error) {
+	if msg := a.describeWriteAuthError(err, action, name); msg != "" {
+		return simpleError(msg)
+	}
+	return simpleError(fmt.Sprintf("Failed to request %s of service '%s': %v", action, name, err))
+}
+
+// registryState returns the runtime state of the named service, or ok=false
+// when no service is registered for it (autoStart=false and never started).
+func registryState(name string) (api.ServiceState, bool) {
+	registry := api.GetServiceRegistry()
+	if registry == nil {
+		return "", false
+	}
+	service, exists := registry.Get(name)
+	if !exists {
+		return "", false
+	}
+	return service.GetState(), true
+}
+
+// StartMCPServerAsCaller handles core_service_start as a CR write: it clears
+// spec.suspended on a suspended server, and writes spec.restartRequestedAt for
+// a server that is down without being suspended (autoStart=false servers,
+// failed servers) — for a down service that request is a plain start.
+func (a *Adapter) StartMCPServerAsCaller(ctx context.Context, name string) (*api.CallToolResult, bool, error) {
+	existing, errResult, handled := a.lifecycleTarget(ctx, name)
+	if !handled {
+		return nil, false, nil
+	}
+	if errResult != nil {
+		return errResult, true, nil
+	}
+
+	// No mutation is intended for a server that is already up or on its way up,
+	// so no write identity is required either.
+	if state, exists := registryState(name); exists && !api.IsDownState(state) && !existing.Spec.Suspended {
+		if state == api.StateAuthRequired {
+			result, err := simpleError(fmt.Sprintf(
+				"Service '%s' requires OAuth authentication.\n\n"+
+					"To connect to this server, use the core_auth_login tool:\n"+
+					"  core_auth_login(server=\"%s\")\n\n"+
+					"The service start/restart command cannot be used for OAuth-protected servers "+
+					"because authentication is session-scoped.",
+				name, name))
+			return result, true, err
+		}
+		if api.IsActiveState(state) {
+			result, err := simpleOK(fmt.Sprintf("Service '%s' is already running", name))
+			return result, true, err
+		}
+		result, err := simpleOK(fmt.Sprintf("Service '%s' is already starting", name))
+		return result, true, err
+	}
+
+	writer, gateResult := a.mutationWriter(ctx)
+	if gateResult != nil {
+		return gateResult, true, nil
+	}
+
+	if existing.Spec.Suspended {
+		existing.Spec.Suspended = false
+	} else {
+		now := metav1.Now()
+		existing.Spec.RestartRequestedAt = &now
+	}
+	if err := writer.UpdateMCPServer(ctx, existing); err != nil {
+		result, retErr := a.lifecycleWriteError(err, "start", name)
+		return result, true, retErr
+	}
+	result, err := simpleOK(fmt.Sprintf("Start of service '%s' requested; the reconciler will start it", name))
+	return result, true, err
+}
+
+// StopMCPServerAsCaller handles core_service_stop as a CR write: it sets
+// spec.suspended=true with the caller's identity. The reconciler stops the
+// service and keeps it stopped until it is resumed.
+func (a *Adapter) StopMCPServerAsCaller(ctx context.Context, name string) (*api.CallToolResult, bool, error) {
+	existing, errResult, handled := a.lifecycleTarget(ctx, name)
+	if !handled {
+		return nil, false, nil
+	}
+	if errResult != nil {
+		return errResult, true, nil
+	}
+
+	if existing.Spec.Suspended {
+		result, err := simpleOK(fmt.Sprintf("Service '%s' is already suspended", name))
+		return result, true, err
+	}
+
+	writer, gateResult := a.mutationWriter(ctx)
+	if gateResult != nil {
+		return gateResult, true, nil
+	}
+
+	existing.Spec.Suspended = true
+	if err := writer.UpdateMCPServer(ctx, existing); err != nil {
+		result, retErr := a.lifecycleWriteError(err, "stop", name)
+		return result, true, retErr
+	}
+	result, err := simpleOK(fmt.Sprintf("Stop of service '%s' requested (spec.suspended=true); the reconciler will stop it and keep it stopped", name))
+	return result, true, err
+}
+
+// RestartMCPServerAsCaller handles core_service_restart as a CR write: it sets
+// spec.restartRequestedAt with the caller's identity. The field itself is the
+// audit record of who requested the restart and when; the reconciler processes
+// it once and mirrors the value into status.lastRestartedAt.
+func (a *Adapter) RestartMCPServerAsCaller(ctx context.Context, name string) (*api.CallToolResult, bool, error) {
+	existing, errResult, handled := a.lifecycleTarget(ctx, name)
+	if !handled {
+		return nil, false, nil
+	}
+	if errResult != nil {
+		return errResult, true, nil
+	}
+
+	// The reconciler consumes restart requests on suspended servers without
+	// action (suspension wins), so refuse up front instead of pretending.
+	if existing.Spec.Suspended {
+		result, err := simpleError(fmt.Sprintf("Service '%s' is suspended; use core_service_start to resume it", name))
+		return result, true, err
+	}
+
+	writer, gateResult := a.mutationWriter(ctx)
+	if gateResult != nil {
+		return gateResult, true, nil
+	}
+
+	now := metav1.Now()
+	existing.Spec.RestartRequestedAt = &now
+	if err := writer.UpdateMCPServer(ctx, existing); err != nil {
+		result, retErr := a.lifecycleWriteError(err, "restart", name)
+		return result, true, retErr
+	}
+	result, err := simpleOK(fmt.Sprintf("Restart of service '%s' requested; the reconciler will restart it", name))
+	return result, true, err
+}

--- a/internal/mcpserver/lifecycle_test.go
+++ b/internal/mcpserver/lifecycle_test.go
@@ -48,19 +48,43 @@ func TestLifecycleAsCaller_NotHandledWhenFlagOff(t *testing.T) {
 	}
 }
 
-// TestLifecycleAsCaller_NotHandledForNonMCPServer pins that names without an
-// MCPServer definition (e.g. muster's own aggregator service) fall back to
-// the imperative path instead of erroring.
-func TestLifecycleAsCaller_NotHandledForNonMCPServer(t *testing.T) {
+// TestLifecycleAsCaller_NotHandledForInternalService pins that muster's own
+// internal services (e.g. the aggregator) fall back to the imperative path —
+// resolved from the registry, without any Kubernetes read.
+func TestLifecycleAsCaller_NotHandledForInternalService(t *testing.T) {
+	withServiceRegistry(t, &fakeServiceRegistry{services: map[string]api.ServiceInfo{
+		"aggregator": &fakeServiceInfo{name: "aggregator", typ: api.ServiceType("Aggregator")},
+	}})
 	h := newCallerHarness(t, nil, nil)
 	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
 	for _, action := range []string{"start", "stop", "restart"} {
 		if _, handled, _ := lifecycleCall(t, h.adapter, ctx, action, "aggregator"); handled {
-			t.Errorf("%s: must not be handled for a name without an MCPServer definition", action)
+			t.Errorf("%s: must not be handled for muster's own internal services", action)
 		}
 	}
 	if len(h.tokensSeen) != 0 || len(h.updated) != 0 {
 		t.Fatal("fallback must not touch the caller client")
+	}
+}
+
+// TestLifecycleAsCaller_UnknownNameFailsClosed pins that names without an
+// MCPServer definition and without an internal service do NOT fall back to the
+// privileged imperative path: they get a not-found error. A deleted CR with a
+// lingering registry entry would otherwise reopen the side door.
+func TestLifecycleAsCaller_UnknownNameFailsClosed(t *testing.T) {
+	h := newCallerHarness(t, nil, nil)
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	for _, action := range []string{"start", "stop", "restart"} {
+		result, handled, err := lifecycleCall(t, h.adapter, ctx, action, "ghost")
+		if err != nil || !handled {
+			t.Fatalf("%s: handled=%v err=%v", action, handled, err)
+		}
+		if !result.IsError || !strings.Contains(resultText(t, result), "not found") {
+			t.Errorf("%s: expected a not-found error, got: %s", action, resultText(t, result))
+		}
+	}
+	if len(h.updated) != 0 {
+		t.Fatal("unknown names must not write")
 	}
 }
 
@@ -90,24 +114,49 @@ func TestLifecycleAsCaller_StopWritesSuspended(t *testing.T) {
 }
 
 // TestLifecycleAsCaller_StartClearsSuspended: start on a suspended server is
-// the resume transition — spec.suspended back to false, no restart request.
+// the resume transition — spec.suspended back to false. When the service is
+// down, the write also carries spec.restartRequestedAt so the resume survives
+// a reconciler whose in-memory suspension marker was lost to a muster restart;
+// when the service is still up (stop not yet processed), only the flag is
+// cleared.
 func TestLifecycleAsCaller_StartClearsSuspended(t *testing.T) {
-	h := newCallerHarness(t, suspendedServer(), nil)
-	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	t.Run("service down", func(t *testing.T) {
+		h := newCallerHarness(t, suspendedServer(), nil)
+		ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
 
-	result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
-	if err != nil || !handled || result.IsError {
-		t.Fatalf("handled=%v err=%v result=%s", handled, err, resultText(t, result))
-	}
-	if len(h.updatedObjs) != 1 {
-		t.Fatalf("expected one caller-client update, got %d", len(h.updatedObjs))
-	}
-	if h.updatedObjs[0].Spec.Suspended {
-		t.Fatal("start did not clear spec.suspended")
-	}
-	if h.updatedObjs[0].Spec.RestartRequestedAt != nil {
-		t.Fatal("resume must not also request a restart")
-	}
+		result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
+		if err != nil || !handled || result.IsError {
+			t.Fatalf("handled=%v err=%v result=%s", handled, err, resultText(t, result))
+		}
+		if len(h.updatedObjs) != 1 {
+			t.Fatalf("expected one caller-client update, got %d", len(h.updatedObjs))
+		}
+		if h.updatedObjs[0].Spec.Suspended {
+			t.Fatal("start did not clear spec.suspended")
+		}
+		if h.updatedObjs[0].Spec.RestartRequestedAt == nil {
+			t.Fatal("resume of a down service must also write spec.restartRequestedAt")
+		}
+	})
+
+	t.Run("service still running", func(t *testing.T) {
+		withServiceRegistry(t, &fakeServiceRegistry{services: map[string]api.ServiceInfo{
+			"test-server": &fakeServiceInfo{name: "test-server", state: api.StateRunning},
+		}})
+		h := newCallerHarness(t, suspendedServer(), nil)
+		ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+		result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
+		if err != nil || !handled || result.IsError {
+			t.Fatalf("handled=%v err=%v result=%s", handled, err, resultText(t, result))
+		}
+		if len(h.updatedObjs) != 1 || h.updatedObjs[0].Spec.Suspended {
+			t.Fatalf("expected one update clearing spec.suspended, got %+v", h.updatedObjs)
+		}
+		if h.updatedObjs[0].Spec.RestartRequestedAt != nil {
+			t.Fatal("canceling a not-yet-processed stop must not request a restart")
+		}
+	})
 }
 
 // TestLifecycleAsCaller_StartRequestsStartWhenDown: start on a server that is
@@ -152,7 +201,8 @@ func TestLifecycleAsCaller_StartNoOpStates(t *testing.T) {
 	}{
 		{api.StateRunning, false, "already running"},
 		{api.StateConnected, false, "already running"},
-		{api.StateStarting, false, "already starting"},
+		{api.StateStarting, false, `state "starting"`},
+		{api.StateStopping, false, `state "stopping"`},
 		{api.StateAuthRequired, true, "core_auth_login"},
 	}
 	for _, tc := range cases {
@@ -209,6 +259,28 @@ func TestLifecycleAsCaller_RestartSuspendedRefused(t *testing.T) {
 	}
 	if len(h.updated) != 0 {
 		t.Fatal("refused restart must not write")
+	}
+}
+
+// TestLifecycleAsCaller_RestartAuthRequiredRefused: restarting cannot
+// authenticate a session, so a server waiting on OAuth gets the same
+// core_auth_login guidance the imperative path gave, and no write happens.
+func TestLifecycleAsCaller_RestartAuthRequiredRefused(t *testing.T) {
+	withServiceRegistry(t, &fakeServiceRegistry{services: map[string]api.ServiceInfo{
+		"test-server": &fakeServiceInfo{name: "test-server", state: api.StateAuthRequired},
+	}})
+	h := newCallerHarness(t, existingServer(), nil)
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+	result, handled, err := h.adapter.RestartMCPServerAsCaller(ctx, "test-server")
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+	if !result.IsError || !strings.Contains(resultText(t, result), "core_auth_login") {
+		t.Fatalf("expected OAuth guidance, got: %s", resultText(t, result))
+	}
+	if len(h.updated) != 0 {
+		t.Fatal("auth-required restart must not write")
 	}
 }
 

--- a/internal/mcpserver/lifecycle_test.go
+++ b/internal/mcpserver/lifecycle_test.go
@@ -1,0 +1,300 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/server"
+)
+
+// lifecycleCall invokes one of the three lifecycle-as-caller methods by name.
+func lifecycleCall(t *testing.T, adapter *Adapter, ctx context.Context, action, name string) (*api.CallToolResult, bool, error) {
+	t.Helper()
+	switch action {
+	case "start":
+		return adapter.StartMCPServerAsCaller(ctx, name)
+	case "stop":
+		return adapter.StopMCPServerAsCaller(ctx, name)
+	case "restart":
+		return adapter.RestartMCPServerAsCaller(ctx, name)
+	default:
+		t.Fatalf("unknown action %q", action)
+		return nil, false, nil
+	}
+}
+
+func suspendedServer() *musterv1alpha1.MCPServer {
+	obj := existingServer()
+	obj.Spec.Suspended = true
+	return obj
+}
+
+// TestLifecycleAsCaller_NotHandledWhenFlagOff pins the fallback contract: with
+// writesAsCaller off the orchestrator's imperative path stays in charge.
+func TestLifecycleAsCaller_NotHandledWhenFlagOff(t *testing.T) {
+	adapter := NewAdapterWithClient(&stubMusterClient{existing: existingServer()}, "test-ns")
+	for _, action := range []string{"start", "stop", "restart"} {
+		if _, handled, _ := lifecycleCall(t, adapter, context.Background(), action, "test-server"); handled {
+			t.Errorf("%s: must not be handled with the flag off", action)
+		}
+	}
+}
+
+// TestLifecycleAsCaller_NotHandledForNonMCPServer pins that names without an
+// MCPServer definition (e.g. muster's own aggregator service) fall back to
+// the imperative path instead of erroring.
+func TestLifecycleAsCaller_NotHandledForNonMCPServer(t *testing.T) {
+	h := newCallerHarness(t, nil, nil)
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	for _, action := range []string{"start", "stop", "restart"} {
+		if _, handled, _ := lifecycleCall(t, h.adapter, ctx, action, "aggregator"); handled {
+			t.Errorf("%s: must not be handled for a name without an MCPServer definition", action)
+		}
+	}
+	if len(h.tokensSeen) != 0 || len(h.updated) != 0 {
+		t.Fatal("fallback must not touch the caller client")
+	}
+}
+
+// TestLifecycleAsCaller_StopWritesSuspended: core_service_stop becomes a
+// spec.suspended=true write carried by the caller's own bearer.
+func TestLifecycleAsCaller_StopWritesSuspended(t *testing.T) {
+	token := testJWT(t, DefaultKubernetesAudience)
+	h := newCallerHarness(t, existingServer(), nil)
+	ctx := server.ContextWithIDToken(context.Background(), token)
+
+	result, handled, err := h.adapter.StopMCPServerAsCaller(ctx, "test-server")
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %s", resultText(t, result))
+	}
+	if len(h.tokensSeen) != 1 || h.tokensSeen[0] != token {
+		t.Fatalf("caller bearer did not reach the write: %v", h.tokensSeen)
+	}
+	if len(h.updatedObjs) != 1 || !h.updatedObjs[0].Spec.Suspended {
+		t.Fatalf("expected one update writing spec.suspended=true, got %+v", h.updatedObjs)
+	}
+	if len(h.sa.updated) != 0 {
+		t.Fatal("SA client performed the write on the caller path")
+	}
+}
+
+// TestLifecycleAsCaller_StartClearsSuspended: start on a suspended server is
+// the resume transition — spec.suspended back to false, no restart request.
+func TestLifecycleAsCaller_StartClearsSuspended(t *testing.T) {
+	h := newCallerHarness(t, suspendedServer(), nil)
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+	result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
+	if err != nil || !handled || result.IsError {
+		t.Fatalf("handled=%v err=%v result=%s", handled, err, resultText(t, result))
+	}
+	if len(h.updatedObjs) != 1 {
+		t.Fatalf("expected one caller-client update, got %d", len(h.updatedObjs))
+	}
+	if h.updatedObjs[0].Spec.Suspended {
+		t.Fatal("start did not clear spec.suspended")
+	}
+	if h.updatedObjs[0].Spec.RestartRequestedAt != nil {
+		t.Fatal("resume must not also request a restart")
+	}
+}
+
+// TestLifecycleAsCaller_StartRequestsStartWhenDown: start on a server that is
+// down without being suspended (autoStart=false, failed) writes
+// spec.restartRequestedAt — the one-shot "make it run now" request.
+func TestLifecycleAsCaller_StartRequestsStartWhenDown(t *testing.T) {
+	for name, registry := range map[string]api.ServiceRegistryHandler{
+		"no service registered": &fakeServiceRegistry{services: map[string]api.ServiceInfo{}},
+		"service stopped": &fakeServiceRegistry{services: map[string]api.ServiceInfo{
+			"test-server": &fakeServiceInfo{name: "test-server", state: api.StateStopped},
+		}},
+		"service failed": &fakeServiceRegistry{services: map[string]api.ServiceInfo{
+			"test-server": &fakeServiceInfo{name: "test-server", state: api.StateFailed},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			withServiceRegistry(t, registry)
+			h := newCallerHarness(t, existingServer(), nil)
+			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+			result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
+			if err != nil || !handled || result.IsError {
+				t.Fatalf("handled=%v err=%v result=%s", handled, err, resultText(t, result))
+			}
+			if len(h.updatedObjs) != 1 || h.updatedObjs[0].Spec.RestartRequestedAt == nil {
+				t.Fatalf("expected one update writing spec.restartRequestedAt, got %+v", h.updatedObjs)
+			}
+			if h.updatedObjs[0].Spec.Suspended {
+				t.Fatal("start must not suspend the server")
+			}
+		})
+	}
+}
+
+// TestLifecycleAsCaller_StartNoOpStates: no mutation is intended for a server
+// that is up or on its way up, so nothing is written and no identity needed.
+func TestLifecycleAsCaller_StartNoOpStates(t *testing.T) {
+	cases := []struct {
+		state   api.ServiceState
+		isError bool
+		want    string
+	}{
+		{api.StateRunning, false, "already running"},
+		{api.StateConnected, false, "already running"},
+		{api.StateStarting, false, "already starting"},
+		{api.StateAuthRequired, true, "core_auth_login"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.state), func(t *testing.T) {
+			withServiceRegistry(t, &fakeServiceRegistry{services: map[string]api.ServiceInfo{
+				"test-server": &fakeServiceInfo{name: "test-server", state: tc.state},
+			}})
+			// No token on the context: the no-op paths must not require one.
+			h := newCallerHarness(t, existingServer(), nil)
+
+			result, handled, err := h.adapter.StartMCPServerAsCaller(context.Background(), "test-server")
+			if err != nil || !handled {
+				t.Fatalf("handled=%v err=%v", handled, err)
+			}
+			if result.IsError != tc.isError || !strings.Contains(resultText(t, result), tc.want) {
+				t.Fatalf("state %s: got isError=%v %q, want isError=%v containing %q",
+					tc.state, result.IsError, resultText(t, result), tc.isError, tc.want)
+			}
+			if len(h.updated) != 0 || len(h.tokensSeen) != 0 {
+				t.Fatal("no-op state must not write")
+			}
+		})
+	}
+}
+
+// TestLifecycleAsCaller_RestartWritesTimestamp: core_service_restart becomes a
+// spec.restartRequestedAt write; the field is the audit record of the request.
+func TestLifecycleAsCaller_RestartWritesTimestamp(t *testing.T) {
+	h := newCallerHarness(t, existingServer(), nil)
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+	result, handled, err := h.adapter.RestartMCPServerAsCaller(ctx, "test-server")
+	if err != nil || !handled || result.IsError {
+		t.Fatalf("handled=%v err=%v result=%s", handled, err, resultText(t, result))
+	}
+	if len(h.updatedObjs) != 1 || h.updatedObjs[0].Spec.RestartRequestedAt == nil {
+		t.Fatalf("expected one update writing spec.restartRequestedAt, got %+v", h.updatedObjs)
+	}
+}
+
+// TestLifecycleAsCaller_RestartSuspendedRefused: the reconciler consumes
+// restart requests on suspended servers without action, so the tool refuses
+// up front and points at core_service_start.
+func TestLifecycleAsCaller_RestartSuspendedRefused(t *testing.T) {
+	h := newCallerHarness(t, suspendedServer(), nil)
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+	result, handled, err := h.adapter.RestartMCPServerAsCaller(ctx, "test-server")
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+	if !result.IsError || !strings.Contains(resultText(t, result), "core_service_start") {
+		t.Fatalf("expected refusal pointing at core_service_start, got: %s", resultText(t, result))
+	}
+	if len(h.updated) != 0 {
+		t.Fatal("refused restart must not write")
+	}
+}
+
+// TestLifecycleAsCaller_StopAlreadySuspended: stop is idempotent — an already
+// suspended server needs no write and therefore no write identity.
+func TestLifecycleAsCaller_StopAlreadySuspended(t *testing.T) {
+	h := newCallerHarness(t, suspendedServer(), nil)
+
+	result, handled, err := h.adapter.StopMCPServerAsCaller(context.Background(), "test-server")
+	if err != nil || !handled || result.IsError {
+		t.Fatalf("handled=%v err=%v result=%s", handled, err, resultText(t, result))
+	}
+	if !strings.Contains(resultText(t, result), "already suspended") {
+		t.Fatalf("unexpected message: %s", resultText(t, result))
+	}
+	if len(h.updated) != 0 || len(h.tokensSeen) != 0 {
+		t.Fatal("idempotent stop must not write")
+	}
+}
+
+// TestLifecycleAsCaller_DeniedBeforeWrite: sessions without a usable bearer
+// get the same re-login errors as create/update/delete, before any write.
+func TestLifecycleAsCaller_DeniedBeforeWrite(t *testing.T) {
+	for _, action := range []string{"start", "stop", "restart"} {
+		t.Run(action+" no token", func(t *testing.T) {
+			h := newCallerHarness(t, existingServer(), nil)
+			result, handled, err := lifecycleCall(t, h.adapter, context.Background(), action, "test-server")
+			if err != nil || !handled {
+				t.Fatalf("handled=%v err=%v", handled, err)
+			}
+			if !result.IsError || !strings.Contains(resultText(t, result), "re-login") {
+				t.Fatalf("expected re-login error, got: %s", resultText(t, result))
+			}
+			if len(h.tokensSeen) != 0 || len(h.updated) != 0 {
+				t.Fatal("denied call must not write")
+			}
+		})
+		t.Run(action+" missing audience", func(t *testing.T) {
+			h := newCallerHarness(t, existingServer(), nil)
+			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, "muster-client"))
+			result, handled, err := lifecycleCall(t, h.adapter, ctx, action, "test-server")
+			if err != nil || !handled {
+				t.Fatalf("handled=%v err=%v", handled, err)
+			}
+			text := resultText(t, result)
+			if !result.IsError || !strings.Contains(text, DefaultKubernetesAudience) || !strings.Contains(text, "re-login") {
+				t.Fatalf("expected audience re-login error, got: %s", text)
+			}
+			if len(h.tokensSeen) != 0 {
+				t.Fatal("factory must not be called for a token without the audience")
+			}
+		})
+	}
+}
+
+// TestLifecycleAsCaller_ForbiddenMapsToPermissionError: a 403 on the lifecycle
+// write maps to the same actionable permission error as create/update/delete,
+// naming the action, resource, namespace, and role.
+func TestLifecycleAsCaller_ForbiddenMapsToPermissionError(t *testing.T) {
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "muster.giantswarm.io", Resource: "mcpservers"},
+		"test-server", fmt.Errorf(`User "alice" cannot update resource "mcpservers"`))
+
+	for _, action := range []string{"start", "stop", "restart"} {
+		t.Run(action, func(t *testing.T) {
+			existing := existingServer()
+			if action == "start" {
+				// Route start through the resume transition so a write happens.
+				existing.Spec.Suspended = true
+			}
+			h := newCallerHarness(t, existing, forbidden)
+			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+
+			result, handled, err := lifecycleCall(t, h.adapter, ctx, action, "test-server")
+			if err != nil || !handled {
+				t.Fatalf("handled=%v err=%v", handled, err)
+			}
+			if !result.IsError {
+				t.Fatal("expected a tool error on 403")
+			}
+			text := resultText(t, result)
+			for _, want := range []string{"Permission denied", action, "mcpservers.muster.giantswarm.io", `"test-ns"`, "mcpserver-editor"} {
+				if !strings.Contains(text, want) {
+					t.Errorf("403 mapping %q does not mention %q", text, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/mcpserver/writes_as_caller_envtest_test.go
+++ b/internal/mcpserver/writes_as_caller_envtest_test.go
@@ -15,6 +15,7 @@ import (
 
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
 
+	"github.com/giantswarm/muster/internal/api"
 	kubernetesclient "github.com/giantswarm/muster/internal/client/kubernetes"
 	"github.com/giantswarm/muster/internal/server"
 )
@@ -161,6 +162,90 @@ func TestWritesAsCallerEnvtest(t *testing.T) {
 		}
 		if _, err := saClient.GetMCPServer(ctx, "denied-server", "default"); !apierrors.IsNotFound(err) {
 			t.Fatalf("denied create still wrote the CR: %v", err)
+		}
+	})
+
+	t.Run("lifecycle allowed user suspend-resume-restart", func(t *testing.T) {
+		result, err := adapter.ExecuteTool(allowedCtx, "mcpserver_create", createArgs("lifecycle-server"))
+		if err != nil || result.IsError {
+			t.Fatalf("setup create: err=%v result=%s", err, resultText(t, result))
+		}
+
+		// Stop → spec.suspended=true, written as the caller.
+		result, handled, err := adapter.StopMCPServerAsCaller(allowedCtx, "lifecycle-server")
+		if err != nil || !handled || result.IsError {
+			t.Fatalf("stop: handled=%v err=%v result=%s", handled, err, resultText(t, result))
+		}
+		after, err := saClient.GetMCPServer(ctx, "lifecycle-server", "default")
+		if err != nil {
+			t.Fatalf("get after stop: %v", err)
+		}
+		if !after.Spec.Suspended {
+			t.Fatal("stop did not set spec.suspended")
+		}
+
+		// Start on the suspended server → resume: spec.suspended back to false.
+		result, handled, err = adapter.StartMCPServerAsCaller(allowedCtx, "lifecycle-server")
+		if err != nil || !handled || result.IsError {
+			t.Fatalf("start: handled=%v err=%v result=%s", handled, err, resultText(t, result))
+		}
+		after, err = saClient.GetMCPServer(ctx, "lifecycle-server", "default")
+		if err != nil {
+			t.Fatalf("get after start: %v", err)
+		}
+		if after.Spec.Suspended {
+			t.Fatal("start did not clear spec.suspended")
+		}
+		if after.Spec.RestartRequestedAt != nil {
+			t.Fatal("resume must not also request a restart")
+		}
+
+		// Restart → spec.restartRequestedAt, written as the caller.
+		result, handled, err = adapter.RestartMCPServerAsCaller(allowedCtx, "lifecycle-server")
+		if err != nil || !handled || result.IsError {
+			t.Fatalf("restart: handled=%v err=%v result=%s", handled, err, resultText(t, result))
+		}
+		after, err = saClient.GetMCPServer(ctx, "lifecycle-server", "default")
+		if err != nil {
+			t.Fatalf("get after restart: %v", err)
+		}
+		if after.Spec.RestartRequestedAt == nil {
+			t.Fatal("restart did not write spec.restartRequestedAt")
+		}
+	})
+
+	t.Run("lifecycle denied user suspend-resume-restart", func(t *testing.T) {
+		lifecycle := func(action string) (*api.CallToolResult, bool, error) {
+			switch action {
+			case "start":
+				return adapter.StartMCPServerAsCaller(deniedCtx, "lifecycle-server")
+			case "stop":
+				return adapter.StopMCPServerAsCaller(deniedCtx, "lifecycle-server")
+			default:
+				return adapter.RestartMCPServerAsCaller(deniedCtx, "lifecycle-server")
+			}
+		}
+		before, err := saClient.GetMCPServer(ctx, "lifecycle-server", "default")
+		if err != nil {
+			t.Fatalf("get before: %v", err)
+		}
+		for _, action := range []string{"stop", "restart", "start"} {
+			result, handled, err := lifecycle(action)
+			if err != nil {
+				t.Fatalf("%s: %v", action, err)
+			}
+			if !handled || !result.IsError || !strings.Contains(resultText(t, result), "Permission denied") {
+				t.Fatalf("%s: expected permission error, got handled=%v: %s", action, handled, resultText(t, result))
+			}
+		}
+		after, err := saClient.GetMCPServer(ctx, "lifecycle-server", "default")
+		if err != nil {
+			t.Fatalf("get after: %v", err)
+		}
+		if after.Spec.Suspended != before.Spec.Suspended ||
+			!after.Spec.RestartRequestedAt.Equal(before.Spec.RestartRequestedAt) ||
+			after.ResourceVersion != before.ResourceVersion {
+			t.Fatal("denied lifecycle action still changed the CR")
 		}
 	})
 

--- a/internal/mcpserver/writes_as_caller_envtest_test.go
+++ b/internal/mcpserver/writes_as_caller_envtest_test.go
@@ -185,6 +185,9 @@ func TestWritesAsCallerEnvtest(t *testing.T) {
 		}
 
 		// Start on the suspended server → resume: spec.suspended back to false.
+		// With no service registered (down), the start also writes
+		// spec.restartRequestedAt so the resume survives a lost in-memory
+		// suspension marker.
 		result, handled, err = adapter.StartMCPServerAsCaller(allowedCtx, "lifecycle-server")
 		if err != nil || !handled || result.IsError {
 			t.Fatalf("start: handled=%v err=%v result=%s", handled, err, resultText(t, result))
@@ -196,8 +199,8 @@ func TestWritesAsCallerEnvtest(t *testing.T) {
 		if after.Spec.Suspended {
 			t.Fatal("start did not clear spec.suspended")
 		}
-		if after.Spec.RestartRequestedAt != nil {
-			t.Fatal("resume must not also request a restart")
+		if after.Spec.RestartRequestedAt == nil {
+			t.Fatal("start on a down server must also write spec.restartRequestedAt")
 		}
 
 		// Restart → spec.restartRequestedAt, written as the caller.

--- a/internal/mcpserver/writes_as_caller_test.go
+++ b/internal/mcpserver/writes_as_caller_test.go
@@ -78,12 +78,13 @@ func testJWT(t *testing.T, aud interface{}) string {
 // records the bearer it was handed, and the returned client records writes
 // through interceptors (optionally failing them with injectErr).
 type callerHarness struct {
-	adapter    *Adapter
-	sa         *stubMusterClient
-	tokensSeen []string
-	created    []string
-	updated    []string
-	deleted    []string
+	adapter     *Adapter
+	sa          *stubMusterClient
+	tokensSeen  []string
+	created     []string
+	updated     []string
+	updatedObjs []*musterv1alpha1.MCPServer
+	deleted     []string
 }
 
 func newCallerHarness(t *testing.T, existing *musterv1alpha1.MCPServer, injectErr error) *callerHarness {
@@ -101,11 +102,14 @@ func newCallerHarness(t *testing.T, existing *musterv1alpha1.MCPServer, injectEr
 			h.created = append(h.created, "create")
 			return nil
 		},
-		Update: func(context.Context, ctrlclient.WithWatch, ctrlclient.Object, ...ctrlclient.UpdateOption) error {
+		Update: func(_ context.Context, _ ctrlclient.WithWatch, obj ctrlclient.Object, _ ...ctrlclient.UpdateOption) error {
 			if injectErr != nil {
 				return injectErr
 			}
 			h.updated = append(h.updated, "update")
+			if server, ok := obj.(*musterv1alpha1.MCPServer); ok {
+				h.updatedObjs = append(h.updatedObjs, server.DeepCopy())
+			}
 			return nil
 		},
 		Delete: func(context.Context, ctrlclient.WithWatch, ctrlclient.Object, ...ctrlclient.DeleteOption) error {

--- a/internal/orchestrator/api_adapter.go
+++ b/internal/orchestrator/api_adapter.go
@@ -34,6 +34,20 @@ func formatOAuthAuthenticationError(name string, err error) *api.CallToolResult 
 	return nil
 }
 
+// mcpServerLifecycleAsCaller is the optional capability the registered
+// MCPServer manager gains when writes-as-caller is enabled (issue #1057):
+// lifecycle actions on MCPServer-backed services become CR spec writes
+// performed with the caller's own identity — authorized by k8s RBAC and
+// audited by the apiserver — instead of direct orchestrator mutations with
+// muster's privilege. handled=false falls back to the imperative path (flag
+// off, or the name is not an MCPServer definition, e.g. muster's own
+// aggregator service).
+type mcpServerLifecycleAsCaller interface {
+	StartMCPServerAsCaller(ctx context.Context, name string) (result *api.CallToolResult, handled bool, err error)
+	StopMCPServerAsCaller(ctx context.Context, name string) (result *api.CallToolResult, handled bool, err error)
+	RestartMCPServerAsCaller(ctx context.Context, name string) (result *api.CallToolResult, handled bool, err error)
+}
+
 // Adapter adapts the orchestrator to implement api.ServiceManagerHandler.
 type Adapter struct {
 	orchestrator *Orchestrator
@@ -190,11 +204,11 @@ func (a *Adapter) ExecuteTool(ctx context.Context, toolName string, args map[str
 	case "service_list":
 		return a.handleServiceList()
 	case "service_start":
-		return a.handleServiceStart(args)
+		return a.handleServiceStart(ctx, args)
 	case "service_stop":
-		return a.handleServiceStop(args)
+		return a.handleServiceStop(ctx, args)
 	case "service_restart":
-		return a.handleServiceRestart(args)
+		return a.handleServiceRestart(ctx, args)
 	case "service_status":
 		return a.handleServiceStatus(args)
 	default:
@@ -216,13 +230,19 @@ func (a *Adapter) handleServiceList() (*api.CallToolResult, error) {
 	}, nil
 }
 
-func (a *Adapter) handleServiceStart(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleServiceStart(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	name, ok := args["name"].(string)
 	if !ok {
 		return &api.CallToolResult{
 			Content: []interface{}{"name is required"},
 			IsError: true,
 		}, nil
+	}
+
+	if lc, ok := api.GetMCPServerManager().(mcpServerLifecycleAsCaller); ok {
+		if result, handled, err := lc.StartMCPServerAsCaller(ctx, name); handled {
+			return result, err
+		}
 	}
 
 	// A missing status is not fatal: StartService lazily registers MCPServer
@@ -251,13 +271,19 @@ func (a *Adapter) handleServiceStart(args map[string]interface{}) (*api.CallTool
 	}, nil
 }
 
-func (a *Adapter) handleServiceStop(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleServiceStop(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	name, ok := args["name"].(string)
 	if !ok {
 		return &api.CallToolResult{
 			Content: []interface{}{"name is required"},
 			IsError: true,
 		}, nil
+	}
+
+	if lc, ok := api.GetMCPServerManager().(mcpServerLifecycleAsCaller); ok {
+		if result, handled, err := lc.StopMCPServerAsCaller(ctx, name); handled {
+			return result, err
+		}
 	}
 
 	status, err := a.GetServiceStatus(name)
@@ -288,13 +314,19 @@ func (a *Adapter) handleServiceStop(args map[string]interface{}) (*api.CallToolR
 	}, nil
 }
 
-func (a *Adapter) handleServiceRestart(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleServiceRestart(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	name, ok := args["name"].(string)
 	if !ok {
 		return &api.CallToolResult{
 			Content: []interface{}{"name is required"},
 			IsError: true,
 		}, nil
+	}
+
+	if lc, ok := api.GetMCPServerManager().(mcpServerLifecycleAsCaller); ok {
+		if result, handled, err := lc.RestartMCPServerAsCaller(ctx, name); handled {
+			return result, err
+		}
 	}
 
 	if err := a.RestartService(name); err != nil {

--- a/internal/orchestrator/api_adapter.go
+++ b/internal/orchestrator/api_adapter.go
@@ -16,36 +16,17 @@ import (
 // because authentication is session-scoped and must be done via the authenticate tool.
 //
 // Uses structured AuthRequiredError detection (ADR-008) instead of string matching.
+// The message text is shared with the CR-driven lifecycle path (issue #1057) so
+// both paths answer the same tool call with the same words.
 func formatOAuthAuthenticationError(name string, err error) *api.CallToolResult {
 	var authErr *mcpserver.AuthRequiredError
 	if errors.As(err, &authErr) {
 		return &api.CallToolResult{
-			Content: []interface{}{fmt.Sprintf(
-				"Service '%s' requires OAuth authentication.\n\n"+
-					"To connect to this server, use the core_auth_login tool:\n"+
-					"  core_auth_login(server=\"%s\")\n\n"+
-					"The service start/restart command cannot be used for OAuth-protected servers "+
-					"because authentication is session-scoped.",
-				name, name,
-			)},
+			Content: []interface{}{mcpserver.OAuthLoginGuidance(name)},
 			IsError: true,
 		}
 	}
 	return nil
-}
-
-// mcpServerLifecycleAsCaller is the optional capability the registered
-// MCPServer manager gains when writes-as-caller is enabled (issue #1057):
-// lifecycle actions on MCPServer-backed services become CR spec writes
-// performed with the caller's own identity — authorized by k8s RBAC and
-// audited by the apiserver — instead of direct orchestrator mutations with
-// muster's privilege. handled=false falls back to the imperative path (flag
-// off, or the name is not an MCPServer definition, e.g. muster's own
-// aggregator service).
-type mcpServerLifecycleAsCaller interface {
-	StartMCPServerAsCaller(ctx context.Context, name string) (result *api.CallToolResult, handled bool, err error)
-	StopMCPServerAsCaller(ctx context.Context, name string) (result *api.CallToolResult, handled bool, err error)
-	RestartMCPServerAsCaller(ctx context.Context, name string) (result *api.CallToolResult, handled bool, err error)
 }
 
 // Adapter adapts the orchestrator to implement api.ServiceManagerHandler.
@@ -239,7 +220,7 @@ func (a *Adapter) handleServiceStart(ctx context.Context, args map[string]interf
 		}, nil
 	}
 
-	if lc, ok := api.GetMCPServerManager().(mcpServerLifecycleAsCaller); ok {
+	if lc, ok := api.GetMCPServerManager().(api.MCPServerLifecycleAsCaller); ok {
 		if result, handled, err := lc.StartMCPServerAsCaller(ctx, name); handled {
 			return result, err
 		}
@@ -280,7 +261,7 @@ func (a *Adapter) handleServiceStop(ctx context.Context, args map[string]interfa
 		}, nil
 	}
 
-	if lc, ok := api.GetMCPServerManager().(mcpServerLifecycleAsCaller); ok {
+	if lc, ok := api.GetMCPServerManager().(api.MCPServerLifecycleAsCaller); ok {
 		if result, handled, err := lc.StopMCPServerAsCaller(ctx, name); handled {
 			return result, err
 		}
@@ -323,7 +304,7 @@ func (a *Adapter) handleServiceRestart(ctx context.Context, args map[string]inte
 		}, nil
 	}
 
-	if lc, ok := api.GetMCPServerManager().(mcpServerLifecycleAsCaller); ok {
+	if lc, ok := api.GetMCPServerManager().(api.MCPServerLifecycleAsCaller); ok {
 		if result, handled, err := lc.RestartMCPServerAsCaller(ctx, name); handled {
 			return result, err
 		}

--- a/internal/orchestrator/lifecycle_routing_test.go
+++ b/internal/orchestrator/lifecycle_routing_test.go
@@ -1,0 +1,63 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+// fakeLifecycleManager implements the optional mcpServerLifecycleAsCaller
+// capability on top of a nil MCPServerManagerHandler: only the lifecycle
+// methods may be called.
+type fakeLifecycleManager struct {
+	api.MCPServerManagerHandler
+	calls []string
+}
+
+func (f *fakeLifecycleManager) StartMCPServerAsCaller(_ context.Context, name string) (*api.CallToolResult, bool, error) {
+	f.calls = append(f.calls, "start:"+name)
+	return &api.CallToolResult{Content: []interface{}{"routed start"}}, true, nil
+}
+
+func (f *fakeLifecycleManager) StopMCPServerAsCaller(_ context.Context, name string) (*api.CallToolResult, bool, error) {
+	f.calls = append(f.calls, "stop:"+name)
+	return &api.CallToolResult{Content: []interface{}{"routed stop"}}, true, nil
+}
+
+func (f *fakeLifecycleManager) RestartMCPServerAsCaller(_ context.Context, name string) (*api.CallToolResult, bool, error) {
+	f.calls = append(f.calls, "restart:"+name)
+	return &api.CallToolResult{Content: []interface{}{"routed restart"}}, true, nil
+}
+
+// TestServiceLifecycleRoutesToCallerWrites pins the issue #1057 routing: when
+// the registered MCPServer manager offers caller-identity lifecycle writes and
+// reports the action handled, the service tools return its result without
+// touching the orchestrator.
+func TestServiceLifecycleRoutesToCallerWrites(t *testing.T) {
+	fake := &fakeLifecycleManager{}
+	previous := api.GetMCPServerManager()
+	api.RegisterMCPServerManager(fake)
+	t.Cleanup(func() { api.RegisterMCPServerManager(previous) })
+
+	// The nil orchestrator proves the routed path never reaches it.
+	adapter := &Adapter{}
+
+	for tool, want := range map[string]string{
+		"service_start":   "start:probe",
+		"service_stop":    "stop:probe",
+		"service_restart": "restart:probe",
+	} {
+		fake.calls = nil
+		result, err := adapter.ExecuteTool(context.Background(), tool, map[string]interface{}{"name": "probe"})
+		if err != nil {
+			t.Fatalf("%s: %v", tool, err)
+		}
+		if result.IsError {
+			t.Fatalf("%s: unexpected tool error: %v", tool, result.Content)
+		}
+		if len(fake.calls) != 1 || fake.calls[0] != want {
+			t.Fatalf("%s: expected routed call %q, got %v", tool, want, fake.calls)
+		}
+	}
+}

--- a/internal/reconciler/mcpserver_reconciler.go
+++ b/internal/reconciler/mcpserver_reconciler.go
@@ -147,22 +147,30 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ReconcileReques
 			processedRestart = pending
 		}
 	} else {
-		result = r.reconcileResume(req, exists, existingService)
+		// startedThisPass tracks whether resume/create/update already
+		// (re)started the service in this pass, so a pending restart request
+		// is consumed instead of bouncing the service a second time.
+		var startedThisPass bool
+		result, startedThisPass = r.reconcileResume(req, exists, existingService)
 
-		if result.Error == nil {
+		if result.Error == nil && result.RequeueAfter == 0 {
+			var started bool
 			if !exists {
 				// Service doesn't exist, create it
-				result = r.reconcileCreate(ctx, req, mcpServerInfo)
+				result, started = r.reconcileCreate(ctx, req, mcpServerInfo)
 			} else {
 				// Service exists, check if update is needed
-				result = r.reconcileUpdate(ctx, req, mcpServerInfo, existingService)
+				result, started = r.reconcileUpdate(ctx, req, mcpServerInfo, existingService)
 			}
+			startedThisPass = startedThisPass || started
 		}
 
-		if result.Error == nil {
+		if result.Error == nil && result.RequeueAfter == 0 {
 			if pending := pendingRestart(mcpServerInfo); pending != nil {
-				restartResult := r.reconcileRestart(req, *pending)
-				if restartResult.Error != nil {
+				if startedThisPass {
+					logging.Info("MCPServerReconciler", "Consuming restart request for MCPServer %s: service was (re)started in this pass", req.Name)
+					processedRestart = pending
+				} else if restartResult := r.reconcileRestart(req, *pending); restartResult.Error != nil {
 					result = restartResult
 				} else {
 					processedRestart = pending
@@ -176,8 +184,10 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ReconcileReques
 
 	// If reconciliation succeeded, schedule periodic requeue for status sync.
 	// This implements the idiomatic Kubernetes controller pattern where status
-	// is periodically refreshed to ensure eventual consistency.
-	if result.Error == nil && !result.Requeue {
+	// is periodically refreshed to ensure eventual consistency. A shorter
+	// requeue already requested by a step (e.g. resume waiting out a stop in
+	// flight) is kept.
+	if result.Error == nil && !result.Requeue && result.RequeueAfter == 0 {
 		result.RequeueAfter = DefaultStatusSyncInterval
 	}
 
@@ -427,32 +437,41 @@ func (r *MCPServerReconciler) reconcileSuspend(req ReconcileRequest, exists bool
 // reconcileResume starts a service again after its spec.suspended flag went
 // back to false. No-op for servers this reconciler never saw suspended, so
 // servers stopped through the imperative core_service_stop path (still used
-// when writesAsCaller is off) stay stopped.
-func (r *MCPServerReconciler) reconcileResume(req ReconcileRequest, exists bool, existingService api.ServiceInfo) ReconcileResult {
+// when writesAsCaller is off) stay stopped. The bool reports whether a start
+// was performed in this pass.
+func (r *MCPServerReconciler) reconcileResume(req ReconcileRequest, exists bool, existingService api.ServiceInfo) (ReconcileResult, bool) {
 	if !r.isSuspended(req.Name) {
-		return ReconcileResult{}
+		return ReconcileResult{}, false
 	}
 
 	if exists && !api.IsDownState(existingService.GetState()) {
+		if existingService.GetState() == api.StateStopping {
+			// The suspend's stop is still completing; clearing the marker now
+			// would turn this resume into a silent no-op once the stop lands.
+			// Keep the marker and retry shortly.
+			logging.Debug("MCPServerReconciler", "Resume of MCPServer %s waiting for in-flight stop to settle", req.Name)
+			return ReconcileResult{RequeueAfter: 2 * time.Second}, false
+		}
 		// Already running or on its way up.
 		r.clearSuspended(req.Name)
-		return ReconcileResult{}
+		return ReconcileResult{}, false
 	}
 
 	logging.Info("MCPServerReconciler", "Resuming MCPServer service %s (spec.suspended=false)", req.Name)
 	if err := r.orchestratorAPI.StartService(req.Name); err != nil {
 		if api.IsAuthRequiredError(err) {
 			// Auth Required is a stable state, not a failure (see reconcileCreate).
+			// The start was attempted — a pending restart would hit the same wall.
 			r.clearSuspended(req.Name)
-			return ReconcileResult{}
+			return ReconcileResult{}, true
 		}
 		return ReconcileResult{
 			Error:   fmt.Errorf("failed to resume service: %w", err),
 			Requeue: true,
-		}
+		}, false
 	}
 	r.clearSuspended(req.Name)
-	return ReconcileResult{}
+	return ReconcileResult{}, true
 }
 
 // reconcileRestart performs the one-shot restart requested via
@@ -494,14 +513,15 @@ func (r *MCPServerReconciler) reconcileRestart(req ReconcileRequest, requestedAt
 	return ReconcileResult{}
 }
 
-// reconcileCreate handles creating a new MCPServer service.
-func (r *MCPServerReconciler) reconcileCreate(ctx context.Context, req ReconcileRequest, info *api.MCPServerInfo) ReconcileResult {
+// reconcileCreate handles creating a new MCPServer service. The bool reports
+// whether a start was performed (or attempted up to Auth Required) in this pass.
+func (r *MCPServerReconciler) reconcileCreate(ctx context.Context, req ReconcileRequest, info *api.MCPServerInfo) (ReconcileResult, bool) {
 	logging.Info("MCPServerReconciler", "Creating MCPServer service: %s", req.Name)
 
 	// Only create if AutoStart is enabled
 	if !info.AutoStart {
 		logging.Debug("MCPServerReconciler", "Skipping MCPServer %s: AutoStart=false", req.Name)
-		return ReconcileResult{}
+		return ReconcileResult{}, false
 	}
 
 	// Start the service via orchestrator
@@ -510,21 +530,23 @@ func (r *MCPServerReconciler) reconcileCreate(ctx context.Context, req Reconcile
 		// and will be activated via SSO when a user authenticates.
 		if api.IsAuthRequiredError(err) {
 			logging.Info("MCPServerReconciler", "MCPServer %s requires authentication (Auth Required)", req.Name)
-			return ReconcileResult{}
+			return ReconcileResult{}, true
 		}
 		logging.Debug("MCPServerReconciler", "Failed to start service %s: %v", req.Name, err)
 		return ReconcileResult{
 			Error:   fmt.Errorf("failed to start service: %w", err),
 			Requeue: true,
-		}
+		}, false
 	}
 
 	logging.Info("MCPServerReconciler", "Successfully created MCPServer service: %s", req.Name)
-	return ReconcileResult{}
+	return ReconcileResult{}, true
 }
 
-// reconcileUpdate handles updating an existing MCPServer service.
-func (r *MCPServerReconciler) reconcileUpdate(ctx context.Context, req ReconcileRequest, info *api.MCPServerInfo, existingService api.ServiceInfo) ReconcileResult {
+// reconcileUpdate handles updating an existing MCPServer service. The bool
+// reports whether a restart was performed (or attempted up to Auth Required)
+// in this pass.
+func (r *MCPServerReconciler) reconcileUpdate(ctx context.Context, req ReconcileRequest, info *api.MCPServerInfo, existingService api.ServiceInfo) (ReconcileResult, bool) {
 	logging.Debug("MCPServerReconciler", "Checking MCPServer service for updates: %s", req.Name)
 
 	newConfig := infoToMCPServer(info)
@@ -532,12 +554,12 @@ func (r *MCPServerReconciler) reconcileUpdate(ctx context.Context, req Reconcile
 	configurableService, ok := existingService.(api.ConfigurableService)
 	if !ok {
 		logging.Debug("MCPServerReconciler", "Service %s does not implement ConfigurableService, skipping update", req.Name)
-		return ReconcileResult{}
+		return ReconcileResult{}, false
 	}
 
 	if !configurableService.ConfigurationChanged(newConfig) {
 		logging.Debug("MCPServerReconciler", "MCPServer %s is up to date", req.Name)
-		return ReconcileResult{}
+		return ReconcileResult{}, false
 	}
 
 	logging.Info("MCPServerReconciler", "MCPServer %s configuration changed, updating and restarting", req.Name)
@@ -546,23 +568,23 @@ func (r *MCPServerReconciler) reconcileUpdate(ctx context.Context, req Reconcile
 		return ReconcileResult{
 			Error:   fmt.Errorf("failed to update service configuration: %w", err),
 			Requeue: true,
-		}
+		}, false
 	}
 	logging.Debug("MCPServerReconciler", "Updated configuration for MCPServer %s", req.Name)
 
 	if err := r.orchestratorAPI.RestartService(req.Name); err != nil {
 		if api.IsAuthRequiredError(err) {
 			logging.Info("MCPServerReconciler", "MCPServer %s requires authentication after config update", req.Name)
-			return ReconcileResult{}
+			return ReconcileResult{}, true
 		}
 		return ReconcileResult{
 			Error:   fmt.Errorf("failed to restart service: %w", err),
 			Requeue: true,
-		}
+		}, false
 	}
 
 	logging.Info("MCPServerReconciler", "Successfully updated MCPServer service: %s", req.Name)
-	return ReconcileResult{}
+	return ReconcileResult{}, true
 }
 
 // infoToMCPServer converts an MCPServerInfo (API/reconciler view) to an MCPServer

--- a/internal/reconciler/mcpserver_reconciler.go
+++ b/internal/reconciler/mcpserver_reconciler.go
@@ -54,8 +54,8 @@ type MCPServerReconciler struct {
 	// the service is started again — including autoStart=false servers that
 	// were running when they were suspended. Level-triggered "!suspended →
 	// start" is not an option: it would also start servers stopped through the
-	// imperative core_service_stop tool, which must keep working unchanged
-	// until issue #1057 switches it over.
+	// imperative core_service_stop path, which still exists for installations
+	// without writesAsCaller (issue #1057 switched the tools over only there).
 	// ponytail: in-memory only — a suspend+resume that both happen while
 	// muster is down degrades to autoStart semantics, same as any stopped
 	// service across a restart.
@@ -378,17 +378,6 @@ func pendingRestart(info *api.MCPServerInfo) *time.Time {
 	return info.RestartRequestedAt
 }
 
-// isDownState reports whether a service state means "not running and not on
-// its way up" — the states from which resume must actively start the service.
-func isDownState(state api.ServiceState) bool {
-	switch state {
-	case api.StateStopped, api.StateDisconnected, api.StateFailed, api.StateError, api.StateUnreachable, api.StateUnknown:
-		return true
-	default:
-		return false
-	}
-}
-
 func (r *MCPServerReconciler) markSuspended(name string) {
 	r.suspendedMu.Lock()
 	defer r.suspendedMu.Unlock()
@@ -437,14 +426,14 @@ func (r *MCPServerReconciler) reconcileSuspend(req ReconcileRequest, exists bool
 
 // reconcileResume starts a service again after its spec.suspended flag went
 // back to false. No-op for servers this reconciler never saw suspended, so
-// servers stopped through the imperative core_service_stop tool stay stopped
-// (unchanged behavior until issue #1057 switches the tools over).
+// servers stopped through the imperative core_service_stop path (still used
+// when writesAsCaller is off) stay stopped.
 func (r *MCPServerReconciler) reconcileResume(req ReconcileRequest, exists bool, existingService api.ServiceInfo) ReconcileResult {
 	if !r.isSuspended(req.Name) {
 		return ReconcileResult{}
 	}
 
-	if exists && !isDownState(existingService.GetState()) {
+	if exists && !api.IsDownState(existingService.GetState()) {
 		// Already running or on its way up.
 		r.clearSuspended(req.Name)
 		return ReconcileResult{}
@@ -472,9 +461,22 @@ func (r *MCPServerReconciler) reconcileResume(req ReconcileRequest, exists bool,
 // restarts are retried and successful ones are never repeated.
 func (r *MCPServerReconciler) reconcileRestart(req ReconcileRequest, requestedAt time.Time) ReconcileResult {
 	if _, exists := r.serviceRegistry.Get(req.Name); !exists {
-		// Nothing to restart. Consume the request anyway so it doesn't fire a
-		// surprise restart when the service appears later.
-		logging.Info("MCPServerReconciler", "Ignoring restart request for MCPServer %s: no service registered", req.Name)
+		// No service registered (autoStart=false and never started). A restart
+		// request is an explicit "make it run now" — the CR-driven
+		// core_service_start writes it for exactly this case (issue #1057) —
+		// so start the service; StartService registers definitions lazily
+		// (issue #680).
+		logging.Info("MCPServerReconciler", "Starting unregistered MCPServer service %s (restartRequestedAt=%s)", req.Name, requestedAt.Format(time.RFC3339))
+		if err := r.orchestratorAPI.StartService(req.Name); err != nil {
+			if api.IsAuthRequiredError(err) {
+				logging.Info("MCPServerReconciler", "MCPServer %s requires authentication after requested start", req.Name)
+				return ReconcileResult{}
+			}
+			return ReconcileResult{
+				Error:   fmt.Errorf("failed to start service for restart request: %w", err),
+				Requeue: true,
+			}
+		}
 		return ReconcileResult{}
 	}
 

--- a/internal/reconciler/mcpserver_reconciler_test.go
+++ b/internal/reconciler/mcpserver_reconciler_test.go
@@ -1172,6 +1172,46 @@ func TestMCPServerReconciler_RestartRequestProcessedOnce(t *testing.T) {
 	}
 }
 
+// TestMCPServerReconciler_RestartRequestStartsUnregisteredService: a restart
+// request on a server with no registered service (autoStart=false, never
+// started) is an explicit "make it run now" — the CR-driven core_service_start
+// writes it for exactly this case (issue #1057) — so the reconciler starts the
+// service and consumes the request.
+func TestMCPServerReconciler_RestartRequestStartsUnregisteredService(t *testing.T) {
+	mgr := NewMockMCPServerManager()
+	orchAPI := NewMockOrchestratorAPI()
+	registry := NewMockServiceRegistry()
+	statusUpdater := NewMockStatusUpdater()
+	reconciler := NewMCPServerReconciler(orchAPI, mgr, registry).
+		WithStatusUpdater(statusUpdater, "default")
+
+	requestedAt := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	mgr.AddMCPServer(&api.MCPServerInfo{
+		Name:               "test-server",
+		Type:               "stdio",
+		Command:            "test-command",
+		AutoStart:          false,
+		RestartRequestedAt: &requestedAt,
+	})
+
+	result := reconciler.Reconcile(context.Background(), lifecycleReconcileRequest())
+
+	if result.Error != nil {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+	if !orchAPI.StartedServices["test-server"] {
+		t.Error("expected the restart request to start the unregistered service")
+	}
+	if orchAPI.RestartedServices["test-server"] {
+		t.Error("an unregistered service is started, not restarted")
+	}
+	if statusUpdater.LastUpdatedMCPServer == nil ||
+		statusUpdater.LastUpdatedMCPServer.Status.LastRestartedAt == nil ||
+		!statusUpdater.LastUpdatedMCPServer.Status.LastRestartedAt.Time.Equal(requestedAt) {
+		t.Error("expected the processed request to be mirrored into status.lastRestartedAt")
+	}
+}
+
 func TestMCPServerReconciler_RestartRequestConsumedWhileSuspended(t *testing.T) {
 	mgr := NewMockMCPServerManager()
 	orchAPI := NewMockOrchestratorAPI()

--- a/internal/reconciler/mcpserver_reconciler_test.go
+++ b/internal/reconciler/mcpserver_reconciler_test.go
@@ -1212,6 +1212,103 @@ func TestMCPServerReconciler_RestartRequestStartsUnregisteredService(t *testing.
 	}
 }
 
+// TestMCPServerReconciler_RestartRequestConsumedWhenStartedThisPass: when the
+// same reconcile pass already started the service (create for a fresh
+// autoStart=true server), a pending restart request is consumed instead of
+// bouncing the service that was started microseconds earlier.
+func TestMCPServerReconciler_RestartRequestConsumedWhenStartedThisPass(t *testing.T) {
+	mgr := NewMockMCPServerManager()
+	orchAPI := NewMockOrchestratorAPI()
+	registry := NewMockServiceRegistry()
+	statusUpdater := NewMockStatusUpdater()
+	reconciler := NewMCPServerReconciler(orchAPI, mgr, registry).
+		WithStatusUpdater(statusUpdater, "default")
+
+	requestedAt := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	mgr.AddMCPServer(&api.MCPServerInfo{
+		Name:               "test-server",
+		Type:               "stdio",
+		Command:            "test-command",
+		AutoStart:          true,
+		RestartRequestedAt: &requestedAt,
+	})
+
+	result := reconciler.Reconcile(context.Background(), lifecycleReconcileRequest())
+
+	if result.Error != nil {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+	if !orchAPI.StartedServices["test-server"] {
+		t.Error("expected create to start the service")
+	}
+	if orchAPI.RestartedServices["test-server"] {
+		t.Error("a service started in this pass must not be restarted on top")
+	}
+	if statusUpdater.LastUpdatedMCPServer == nil ||
+		statusUpdater.LastUpdatedMCPServer.Status.LastRestartedAt == nil ||
+		!statusUpdater.LastUpdatedMCPServer.Status.LastRestartedAt.Time.Equal(requestedAt) {
+		t.Error("the consumed request must still be mirrored into status.lastRestartedAt")
+	}
+}
+
+// TestMCPServerReconciler_ResumeWaitsForInFlightStop: a resume observed while
+// the suspend's stop is still completing (state stopping) must not clear the
+// suspension marker — that would leave the service down forever. It requeues
+// and starts the service once the stop has settled.
+func TestMCPServerReconciler_ResumeWaitsForInFlightStop(t *testing.T) {
+	mgr := NewMockMCPServerManager()
+	orchAPI := NewMockOrchestratorAPI()
+	registry := NewMockServiceRegistry()
+	reconciler := NewMCPServerReconciler(orchAPI, mgr, registry)
+
+	server := &api.MCPServerInfo{
+		Name:      "test-server",
+		Type:      "stdio",
+		Command:   "test-command",
+		AutoStart: false,
+		Suspended: true,
+	}
+	mgr.AddMCPServer(server)
+	svc := &MockServiceInfo{
+		Name:        "test-server",
+		ServiceType: api.TypeMCPServer,
+		State:       api.StateRunning,
+		Health:      api.HealthHealthy,
+	}
+	registry.AddService("test-server", svc)
+
+	ctx := context.Background()
+
+	// Suspend: the reconciler issues the stop; the service is still stopping.
+	if result := reconciler.Reconcile(ctx, lifecycleReconcileRequest()); result.Error != nil {
+		t.Fatalf("unexpected error on suspend: %v", result.Error)
+	}
+	svc.State = api.StateStopping
+
+	// Resume while the stop is in flight: no start yet, but a quick requeue —
+	// and the suspension marker must survive.
+	server.Suspended = false
+	result := reconciler.Reconcile(ctx, lifecycleReconcileRequest())
+	if result.Error != nil {
+		t.Fatalf("unexpected error on resume: %v", result.Error)
+	}
+	if orchAPI.StartedServices["test-server"] {
+		t.Fatal("must not start while the service is still stopping")
+	}
+	if result.RequeueAfter == 0 || result.RequeueAfter > 5*time.Second {
+		t.Fatalf("expected a short requeue while the stop settles, got %v", result.RequeueAfter)
+	}
+
+	// The stop has settled; the requeued reconcile must now start the service.
+	svc.State = api.StateStopped
+	if result := reconciler.Reconcile(ctx, lifecycleReconcileRequest()); result.Error != nil {
+		t.Fatalf("unexpected error on settled resume: %v", result.Error)
+	}
+	if !orchAPI.StartedServices["test-server"] {
+		t.Fatal("expected the settled resume to start the service")
+	}
+}
+
 func TestMCPServerReconciler_RestartRequestConsumedWhileSuspended(t *testing.T) {
 	mgr := NewMockMCPServerManager()
 	orchAPI := NewMockOrchestratorAPI()

--- a/internal/testing/scenarios/service-lifecycle-writes-as-caller.yaml
+++ b/internal/testing/scenarios/service-lifecycle-writes-as-caller.yaml
@@ -1,0 +1,149 @@
+name: "service-lifecycle-writes-as-caller"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  CR-driven service lifecycle (issue #1057). With writesAsCaller enabled,
+  core_service_start/_stop/_restart on MCPServer-backed services are CR spec
+  writes performed with the caller's own identity (spec.suspended /
+  spec.restartRequestedAt, issue #1055) instead of direct orchestrator
+  mutations with muster's privilege. A session whose token does not carry the
+  kubernetes audience gets the same actionable re-login error as
+  create/update/delete — before anything is written — and the service keeps
+  running. Start on an already-running service stays a no-op that needs no
+  write identity. The allowed/denied RBAC matrix (suspend/resume/restart as
+  an allowed vs. denied user) runs against a real apiserver in
+  TestWritesAsCallerEnvtest; the imperative path with the flag off is pinned
+  by the mcpserver-lifecycle scenarios.
+tags: ["mcpserver", "lifecycle", "oauth", "writes-as-caller", "rbac", "negative"]
+timeout: "3m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "muster-idp"
+      scopes: ["openid", "profile", "email", "groups"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "muster-client"
+      client_secret: "muster-secret"
+      use_as_muster_oauth_server: true
+
+    - name: "workload-idp"
+
+  muster_broker:
+    trusted_issuers:
+      - oauth_server_ref: "workload-idp"
+        accepted_typ_headers: [""]
+
+  main_config:
+    config:
+      writesAsCaller:
+        enabled: true
+
+  mcp_servers:
+    - name: "lifecycle-wac-server"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "lifecycle_probe_tool"
+            input_schema:
+              type: "object"
+              properties:
+                message: { type: "string" }
+            responses:
+              - response:
+                  message: "alive: {{ .message }}"
+
+steps:
+  - id: "verify-initial-running"
+    tool: "core_service_status"
+    args:
+      name: "lifecycle-wac-server"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        name: "lifecycle-wac-server"
+        state: "connected"
+
+  - id: "mint-session-token"
+    description: |
+      Mint a session token WITHOUT the dex-k8s-authenticator audience — the
+      shape of a session predating the audience configuration. Muster accepts
+      it as a bearer, but the kube-apiserver would not.
+    tool: "test_mint_token"
+    args:
+      server: "workload-idp"
+      name: "no-k8s-audience-token"
+      sub: "alice@giantswarm.io"
+      email: "alice@giantswarm.io"
+      email_verified: true
+    expected:
+      success: true
+
+  - id: "connect-session"
+    description: "Authenticate the MCP session with that token"
+    tool: "test_reconnect_with_token"
+    args:
+      token_ref: "no-k8s-audience-token"
+    expected:
+      success: true
+    retry:
+      count: 5
+      delay: "1s"
+
+  - id: "stop-denied-re-login"
+    description: |
+      core_service_stop is now a spec.suspended write as the caller: a session
+      that cannot authenticate at the apiserver gets the same re-login error
+      as create/update/delete, before anything is written.
+    tool: "core_service_stop"
+    args:
+      name: "lifecycle-wac-server"
+    expected:
+      success: false
+      error_contains:
+        - "dex-k8s-authenticator"
+        - "re-login"
+
+  - id: "verify-still-running-after-denied-stop"
+    description: "The refused stop wrote nothing — the service keeps running"
+    tool: "core_service_status"
+    args:
+      name: "lifecycle-wac-server"
+    expected:
+      success: true
+      json_path:
+        name: "lifecycle-wac-server"
+        state: "connected"
+
+  - id: "restart-denied-re-login"
+    description: "core_service_restart (spec.restartRequestedAt write) is gated identically"
+    tool: "core_service_restart"
+    args:
+      name: "lifecycle-wac-server"
+    expected:
+      success: false
+      error_contains:
+        - "dex-k8s-authenticator"
+        - "re-login"
+
+  - id: "start-already-running-no-op"
+    description: |
+      Start on a running, unsuspended service intends no mutation, so it needs
+      no write identity: still a friendly no-op for every session.
+    tool: "core_service_start"
+    args:
+      name: "lifecycle-wac-server"
+    expected:
+      success: true
+      contains: ["already running"]
+
+  - id: "verify-tool-still-works"
+    description: "Reads and tool calls are untouched by the write gate"
+    tool: "x_lifecycle-wac-server_lifecycle_probe_tool"
+    args:
+      message: "post-denial"
+    expected:
+      success: true
+      contains: ["alive", "post-denial"]


### PR DESCRIPTION
Closes #1057. Part of the writes-as-caller plan (bumblebee-plans#33); depends on #1059 (CR lifecycle fields + reconciler) and #1060 (per-call bearer clients), both merged.

## What

With `writesAsCaller` enabled, `core_service_start` / `_stop` / `_restart` on MCPServer-backed services stop being a side door: instead of mutating orchestrator runtime state directly with muster's own privilege, they write the MCPServer CR lifecycle fields with the caller's own dex id_token — authorized by k8s RBAC, attributed to the real subject in the apiserver audit log, exactly like `core_mcpserver_create/_update/_delete`.

- `core_service_stop` → `spec.suspended: true`
- `core_service_start` → clears `spec.suspended`; for a server that is down without being suspended (autoStart=false, failed) it writes `spec.restartRequestedAt` — the one-shot "make it run now" request
- `core_service_restart` → `spec.restartRequestedAt: now()` (refused up front for suspended servers, where the reconciler would consume the request without action)

The reconciler performs the actual start/stop/restart from the spec fields. One reconciler gap closed: a restart request on a service that was never registered (autoStart=false) now starts it (StartService registers definitions lazily, #680) — previously it was consumed without action, which would have broken `start` on never-started servers.

Denial shape matches create/update/delete: 403 → permission error naming the action, resource, and namespace plus the `mcpserver-editor` role hint; missing/audience-less session token → actionable re-login error before anything is written.

## What stays imperative

- Installations without `writesAsCaller` (transition flag off, filesystem mode) — unchanged.
- Names without an MCPServer definition (muster's own aggregator service) — per the plan, internal services are not user-mutable surface.
- No-op paths need no write identity: start on a running server ("already running"), stop on an already-suspended server, start on an auth-required server (still points at `core_auth_login`).

## Testing

- Unit: `lifecycle_test.go` — field semantics (suspend/resume/restart-request), fallback contract, no-op states, re-login gates, 403 mapping; orchestrator routing test.
- envtest (`make test-envtest`): allowed user's stop/start/restart land as spec writes on a real RBAC-enabled apiserver; denied user gets the permission error on all three with the CR's `resourceVersion` unchanged.
- Behavioral scenario `service-lifecycle-writes-as-caller`: lifecycle mutations from a session whose token lacks the kubernetes audience fail with the re-login error before anything is written (service keeps running); start-on-running stays a no-op; reads keep working. Ran locally with a fresh build, together with `mcpserver-suspend-resume-restart`, `mcpserver-writes-as-caller`, `mcpserver-lifecycle`, and `service-restart-non-existent` — all green.
- Live audit-log verification (allowed caller attributed to their dex subject) happens with the rollout in #1058, which enables the flag on a real installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review hardening (second commit)

An eight-angle adversarial review of the diff surfaced and fixed:

- **Fail-open guard**: the lifecycle capability is a contract in `internal/api` with a compile-time pin in the adapter — signature drift breaks the build instead of silently reverting to the SA side door.
- **Fail closed on lookup**: MCPServer-typed and unknown names never fall back to the imperative path (deleted-CR window); internal services (aggregator) route imperatively from the registry with no Kubernetes read.
- **Resume reliability**: start on a suspended, down server also writes `spec.restartRequestedAt`, so the resume survives a reconciler restart that lost the in-memory suspension marker; a resume observed mid-stop requeues instead of stranding the service stopped.
- **No same-pass bounce**: a pending restart request is consumed when the same reconcile pass already started the service.
- **Tri-state `suspended` on `core_mcpserver_update`**: omitted keeps the current value — unrelated updates no longer silently resume a stopped server.
- **OAuth guardrail on restart** (parity with the imperative path), shared single-source `core_auth_login` guidance, CRD events for lifecycle writes, conflict retry on the read-modify-write, honest transitional-state messages.

Known accepted tradeoffs (from #1055's spec-is-desired design): `restartRequestedAt` has second granularity (two restarts within one second collapse into one — the service restarted anyway), and a spec-only re-apply to a cluster with empty status treats a historical `restartRequestedAt` as pending.
