### PR TITLE
ci: wire TestWritesAsCallerEnvtest into a real CircleCI job

### DIFF
--- a/.circleci/custom.yml
+++ b/.circleci/custom.yml
@@ -11,11 +11,47 @@
 #   - branch dev-chart push for the muster chart
 #   - the standalone muster-crds chart (build, ATS tests, branch + tag push),
 #     versioned in lockstep with muster off the same git tag
+#   - the envtest-backed RBAC integration job (test-envtest), which needs a
+#     real kube-apiserver from setup-envtest -- the generated go-build job
+#     only runs `make test`, so TestWritesAsCallerEnvtest self-skips there
+#     without KUBEBUILDER_ASSETS
 version: 2.1
+
+jobs:
+  # `make test` (run by the generated go-build job) doesn't set
+  # KUBEBUILDER_ASSETS, so TestWritesAsCallerEnvtest (added in #1060) self-skips
+  # via t.Skip() there. This job runs `make test-envtest`, which downloads a
+  # real kube-apiserver via setup-envtest and points KUBEBUILDER_ASSETS at it,
+  # so the RBAC integration test actually executes. Reuses the same
+  # `architect` image/context as go-build -- no extra module auth needed since
+  # github.com/giantswarm/muster and its Go module deps are public repos.
+  test-envtest:
+    executor: architect/architect
+    resource_class: medium
+    steps:
+    - checkout
+    - architect/tools-info
+    - architect/go-cache-restore
+    - run:
+        name: Run envtest-backed RBAC integration tests
+        command: make test-envtest
+    - architect/go-cache-save
 
 workflows:
   build:
     jobs:
+    # ---- envtest-backed RBAC integration test. Same filters as go-build
+    #      (runs on every branch and on release tags) since it's a test job
+    #      like go-build's own embedded `make test`, not a branch-only publish
+    #      step.
+    - test-envtest:
+        context: architect
+        requires:
+        - go-build
+        filters:
+          tags:
+            only: /^v.*/
+
     # ---- Branch builds: dev image for PR validation. split-china-push is
     #      safe on branches: registries-data marks Aliyun push_dev_image=false.
     - architect/push-to-registries:


### PR DESCRIPTION
## Summary
- #1060 added `TestWritesAsCallerEnvtest`, an envtest-backed RBAC integration test that requires `KUBEBUILDER_ASSETS` and self-skips via `t.Skip()` when it's absent.
- The generated `go-build` job only runs `make test`, which never sets `KUBEBUILDER_ASSETS` — so this test has silently skipped in every CI run since it merged, including the run that made #1060 itself all-green.
- Adds a `test-envtest` job to `.circleci/custom.yml` that runs `make test-envtest` (added in the same PR), which downloads a real kube-apiserver via `setup-envtest` and points `KUBEBUILDER_ASSETS` at it so the test actually executes.
- Reuses the `architect` executor/context and the `architect/go-cache-restore` + `architect/go-cache-save` commands already used by `go-build` — no extra module auth needed since muster and its Go module deps (`mcp-oauth`, `mcp-toolkit`) are all public repos.

This closes the silent-skip gap before #1057 / #1058 land more RBAC-path tests following the same pattern (giantswarm/giantswarm#37459).

## Test plan
- [x] Validated the merged `.circleci/workflows.yml` + `.circleci/custom.yml` locally with `mikefarah/yq eval-all` (the same command `.circleci/config.yml`'s setup job runs) and `circleci config validate` — merge produces a valid config with the new `test-envtest` job wired into the `build` workflow.
- [x] Ran `make test-envtest` locally — subtests execute and pass (not skipped): `allowed_user_create-update-delete`, `denied_user_create`, `denied_user_update_and_delete`.
- [x] Confirmed on this PR's own CircleCI run (job [20509](https://circleci.com/gh/giantswarm/muster/20509)): the log shows the real subtests running and passing, not a bare skip-PASS. (First attempt, job 20505, failed on a transient `ssh: connect to host github.com port 22: Connection refused` during checkout — unrelated to this change; a from-failed rerun passed cleanly.)