### PR TITLE
feat(helm): ship mcpserver-editor default RBAC and writesAsCaller transition flag

### DIFF
--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -35,6 +35,10 @@ A Helm chart for muster - Universal Control Plane for AI Agents built on MCP
 | serviceAccount.name | string | `""` |  |
 | rbac.create | bool | `true` |  |
 | rbac.additionalSecretNamespaces | list | `[]` |  |
+| rbac.mcpServerEditor.create | bool | `true` |  |
+| rbac.mcpServerEditor.subjects[0].apiGroup | string | `"rbac.authorization.k8s.io"` |  |
+| rbac.mcpServerEditor.subjects[0].kind | string | `"Group"` |  |
+| rbac.mcpServerEditor.subjects[0].name | string | `"system:authenticated"` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
@@ -89,6 +93,8 @@ A Helm chart for muster - Universal Control Plane for AI Agents built on MCP
 | muster.aggregator.transport | string | `"streamable-http"` |  |
 | muster.namespace | string | `""` |  |
 | muster.debug | bool | `false` |  |
+| muster.writesAsCaller.enabled | bool | `false` |  |
+| muster.writesAsCaller.kubernetesAudience | string | `""` |  |
 | muster.extraCaFile.path | string | `"/etc/muster/ca/extra-ca.pem"` |  |
 | muster.extraCaFile.secret.name | string | `""` |  |
 | muster.extraCaFile.secret.key | string | `"ca.pem"` |  |

--- a/helm/muster/templates/configmap.yaml
+++ b/helm/muster/templates/configmap.yaml
@@ -109,5 +109,12 @@ data:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
+    {{- if .Values.muster.writesAsCaller.enabled }}
+    writesAsCaller:
+      enabled: true
+      {{- with .Values.muster.writesAsCaller.kubernetesAudience }}
+      kubernetesAudience: {{ . | quote }}
+      {{- end }}
+    {{- end }}
     namespace: {{ include "muster.namespace" . | quote }}
     kubernetes: true

--- a/helm/muster/templates/mcpserver-editor-rbac.yaml
+++ b/helm/muster/templates/mcpserver-editor-rbac.yaml
@@ -1,0 +1,43 @@
+{{/*
+mcpserver-editor: who may register and manage MCPServer resources once the
+writes-as-caller transition flag (muster.writesAsCaller) is on.
+
+With the flag on, session-initiated MCPServer mutations — create/update/delete
+and CR-driven lifecycle (start/stop/restart) — are written against the
+Kubernetes API with the caller's own identity, so k8s RBAC authorizes each
+write. The default binding grants the Role to all authenticated users,
+preserving today's effective "any user can register" behavior: enabling
+enforcement is not a silent breaking change. Installations wanting admin-only
+registration narrow rbac.mcpServerEditor.subjects to an admin group.
+
+Inert while the flag is off: muster then writes with its own ServiceAccount
+and this Role is never consulted.
+*/}}
+{{- if and .Values.rbac.create .Values.rbac.mcpServerEditor.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mcpserver-editor
+  namespace: {{ include "muster.namespace" . }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["muster.giantswarm.io"]
+    resources: ["mcpservers"]
+    verbs: ["create", "update", "patch", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcpserver-editor
+  namespace: {{ include "muster.namespace" . }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcpserver-editor
+subjects:
+  {{- toYaml .Values.rbac.mcpServerEditor.subjects | nindent 2 }}
+{{- end }}

--- a/helm/muster/tests/configmap_test.yaml
+++ b/helm/muster/tests/configmap_test.yaml
@@ -135,3 +135,29 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: "muster-broker-clients"
+
+  - it: omits writesAsCaller by default (transition flag off)
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "writesAsCaller:"
+
+  - it: renders writesAsCaller when enabled
+    set:
+      muster.writesAsCaller.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "writesAsCaller:\n  enabled: true"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "kubernetesAudience:"
+
+  - it: renders writesAsCaller kubernetesAudience override
+    set:
+      muster.writesAsCaller.enabled: true
+      muster.writesAsCaller.kubernetesAudience: "custom-audience"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "kubernetesAudience: \"custom-audience\""

--- a/helm/muster/tests/mcpserver_editor_rbac_test.yaml
+++ b/helm/muster/tests/mcpserver_editor_rbac_test.yaml
@@ -1,0 +1,83 @@
+suite: mcpserver-editor RBAC template tests
+templates:
+  - templates/mcpserver-editor-rbac.yaml
+
+tests:
+  - it: ships the mcpserver-editor Role and default RoleBinding
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Role
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: mcpserver-editor
+        documentIndex: 0
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["muster.giantswarm.io"]
+              resources: ["mcpservers"]
+              verbs: ["create", "update", "patch", "delete"]
+        documentIndex: 0
+      - isKind:
+          of: RoleBinding
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: mcpserver-editor
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: mcpserver-editor
+        documentIndex: 1
+      - equal:
+          path: subjects
+          value:
+            - apiGroup: rbac.authorization.k8s.io
+              kind: Group
+              name: system:authenticated
+        documentIndex: 1
+
+  - it: places Role and RoleBinding in the MCPServer discovery namespace
+    set:
+      muster.namespace: mcp-servers
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: mcp-servers
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: mcp-servers
+        documentIndex: 1
+
+  - it: narrows the binding to custom subjects
+    set:
+      rbac.mcpServerEditor.subjects:
+        - apiGroup: rbac.authorization.k8s.io
+          kind: Group
+          name: platform-admins
+    asserts:
+      - equal:
+          path: subjects
+          value:
+            - apiGroup: rbac.authorization.k8s.io
+              kind: Group
+              name: platform-admins
+        documentIndex: 1
+
+  - it: creates nothing when rbac.mcpServerEditor.create is false
+    set:
+      rbac.mcpServerEditor.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates nothing when rbac.create is false
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -483,6 +483,18 @@
                             }
                         }
                     }
+                },
+                "writesAsCaller": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "kubernetesAudience": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },
@@ -620,6 +632,36 @@
                 },
                 "create": {
                     "type": "boolean"
+                },
+                "mcpServerEditor": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "subjects": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "apiGroup": {
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -46,6 +46,22 @@ rbac:
   # broker target credential secrets may reside.
   # A Role/RoleBinding granting `get` on secrets is created in each listed namespace.
   additionalSecretNamespaces: []
+  # mcpServerEditor ships the default answer to "who may register and manage
+  # MCP servers" once the writes-as-caller transition flag
+  # (muster.writesAsCaller) is on: a namespaced Role granting
+  # create/update/patch/delete on mcpservers, plus a RoleBinding. The default
+  # subjects bind all authenticated users, preserving today's effective "any
+  # user can register" behavior — flipping the flag is not a silent breaking
+  # change. Narrow subjects to an admin group for admin-only registration.
+  # Inert while the flag is off.
+  mcpServerEditor:
+    create: true
+    # RoleBinding subjects granted the mcpserver-editor Role. Standard
+    # rbac.authorization.k8s.io/v1 subjects (Group, User, or ServiceAccount).
+    subjects:  # @schema item: object ; itemProperties: {apiGroup: {type: string}, kind: {type: string}, name: {type: string}, namespace: {type: string}}
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:authenticated
 
 podAnnotations: {}  # @schema additionalProperties: true
 podLabels: {}  # @schema additionalProperties: true
@@ -235,6 +251,25 @@ muster:
 
   # Enable debug logging
   debug: false
+
+  # Transition flag for the writes-as-caller rollout. When enabled,
+  # session-initiated MCPServer mutations (create/update/delete and CR-driven
+  # start/stop/restart) are written with the caller's own dex id_token: the
+  # apiserver authenticates the real user, k8s RBAC (see rbac.mcpServerEditor)
+  # authorizes the write, and the audit log records the true subject. Muster's
+  # own controllers (status reconciliation, service registration, startup
+  # sync) keep using the ServiceAccount either way.
+  #
+  # Default off. Flip per installation only after its preconditions are
+  # verified: the dex-k8s-authenticator audience is in the login scope set and
+  # the local apiserver trusts dex OIDC. The flag is transitional and will be
+  # removed once every installation has flipped.
+  writesAsCaller:
+    enabled: false
+    # Audience the session's dex id_token must carry to be accepted by the
+    # local kube-apiserver. Empty uses muster's default
+    # ("dex-k8s-authenticator").
+    kubernetesAudience: ""
 
   # Append a PEM file to muster's system trust pool at startup. Use this when
   # muster talks to backends served by an internal CA (for example, the SPIFFE


### PR DESCRIPTION
## What

Implements #1058 (closes #1058) — the shippable default policy and per-installation flip switch for the writes-as-caller rollout ([bumblebee-plans#33](https://github.com/giantswarm/bumblebee-plans/pull/33), part of [giantswarm#37459](https://github.com/giantswarm/giantswarm/issues/37459)).

- `helm/muster` ships a namespaced `mcpserver-editor` Role (`create`/`update`/`patch`/`delete` on `mcpservers.muster.giantswarm.io`) plus a default RoleBinding granting it to `system:authenticated`, rendered into the MCPServer discovery namespace. Default preserves today's effective "any user can register" behavior, so enabling enforcement is not a silent breaking change. Installations narrow `rbac.mcpServerEditor.subjects` to an admin group for admin-only registration. Since lifecycle (#1057) is CR-driven, the same Role governs start/stop/restart.
- The existing `writesAsCaller` transition flag (#1056/#1057, already in the Go config) is now exposed as chart values (`muster.writesAsCaller.enabled` / `.kubernetesAudience`), **default off**; the block is rendered into `config.yaml` only when enabled, so the default deploy is byte-identical in behavior.
- values.schema.json + chart README regenerated via pre-commit; `subjects` items accept the standard rbac/v1 subject keys (`apiGroup`, `kind`, `name`, `namespace`).

Per the plan, the flag-removal issue is deliberately **not** filed now — it gets filed as a rollout task once the last installation has flipped.

## Testing

- New helm-unittest suite for the template: default Role+Binding shape, discovery-namespace placement, custom (narrowed) subjects, `rbac.create`/`rbac.mcpServerEditor.create` gates.
- ConfigMap tests: flag omitted by default, rendered when enabled, audience override.
- No Go changes: with the flag off the SA path is untouched (existing tests unchanged); the flag-on RBAC path is covered by the #1056/#1057 suites incl. `TestWritesAsCallerEnvtest` wired into CI (#1062).

The end-to-end two-user check on a dev installation is a rollout step (plan §"Rollout order") and happens when that installation flips the flag, with its precondition evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)