### PR TITLE
feat(workflow)!: write workflow spec mutations with the caller's own identity in Kubernetes mode

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -39,7 +39,7 @@ muster-integration-test: build ## Run the muster integration suite (./muster tes
 test-envtest: ## Run the envtest-backed RBAC integration tests (downloads a kube-apiserver via setup-envtest).
 	@echo "Running envtest RBAC integration tests..."
 	KUBEBUILDER_ASSETS="$$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24 use -p path)" \
-		go test ./internal/mcpserver/ -run TestWritesAsCallerEnvtest -count=1 -v
+		go test ./internal/mcpserver/ ./internal/workflow/ -run TestWritesAsCallerEnvtest -count=1 -v
 
 .PHONY: test-vet
 test-vet: ## Run go test and go vet

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -292,6 +292,13 @@ the caller, with the reconciler performing the actual start/stop/restart.
 Lifecycle of muster's own internal services (e.g. the aggregator) keeps the
 imperative path.
 
+Workflow spec mutations (`core_workflow_create` / `_update` / `_delete`) go
+through the same gate: the write happens with the caller's identity, and the
+chart ships a `workflow-editor` Role/RoleBinding mirroring `mcpserver-editor`
+(bound to `system:authenticated` by default; narrow
+`rbac.workflowEditor.subjects` for admin-only workflow authoring).
+`core_workflow_validate`, reads, and workflow execution are unaffected.
+
 Caller-identity writes are always active in Kubernetes mode
 (`kubernetes: true`); in filesystem mode there is no apiserver and mutations
 write through the local client. The only knob is the audience override:

--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -39,6 +39,10 @@ A Helm chart for muster - Universal Control Plane for AI Agents built on MCP
 | rbac.mcpServerEditor.subjects[0].apiGroup | string | `"rbac.authorization.k8s.io"` |  |
 | rbac.mcpServerEditor.subjects[0].kind | string | `"Group"` |  |
 | rbac.mcpServerEditor.subjects[0].name | string | `"system:authenticated"` |  |
+| rbac.workflowEditor.create | bool | `true` |  |
+| rbac.workflowEditor.subjects[0].apiGroup | string | `"rbac.authorization.k8s.io"` |  |
+| rbac.workflowEditor.subjects[0].kind | string | `"Group"` |  |
+| rbac.workflowEditor.subjects[0].name | string | `"system:authenticated"` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |

--- a/helm/muster/templates/workflow-editor-rbac.yaml
+++ b/helm/muster/templates/workflow-editor-rbac.yaml
@@ -1,0 +1,38 @@
+{{/*
+workflow-editor: who may create and manage Workflow resources.
+
+Session-initiated Workflow mutations — create/update/delete — are written
+against the Kubernetes API with the caller's own identity, so k8s RBAC
+authorizes each write. The default binding grants the Role to all
+authenticated users, preserving the pre-enforcement "any user can create"
+behavior. Installations wanting admin-only workflow authoring narrow
+rbac.workflowEditor.subjects to an admin group.
+*/}}
+{{- if and .Values.rbac.create .Values.rbac.workflowEditor.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflow-editor
+  namespace: {{ include "muster.namespace" . }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["muster.giantswarm.io"]
+    resources: ["workflows"]
+    verbs: ["create", "update", "patch", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workflow-editor
+  namespace: {{ include "muster.namespace" . }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflow-editor
+subjects:
+  {{- toYaml .Values.rbac.workflowEditor.subjects | nindent 2 }}
+{{- end }}

--- a/helm/muster/tests/workflow_editor_rbac_test.yaml
+++ b/helm/muster/tests/workflow_editor_rbac_test.yaml
@@ -1,0 +1,83 @@
+suite: workflow-editor RBAC template tests
+templates:
+  - templates/workflow-editor-rbac.yaml
+
+tests:
+  - it: ships the workflow-editor Role and default RoleBinding
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Role
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: workflow-editor
+        documentIndex: 0
+      - equal:
+          path: rules
+          value:
+            - apiGroups: ["muster.giantswarm.io"]
+              resources: ["workflows"]
+              verbs: ["create", "update", "patch", "delete"]
+        documentIndex: 0
+      - isKind:
+          of: RoleBinding
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: workflow-editor
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: workflow-editor
+        documentIndex: 1
+      - equal:
+          path: subjects
+          value:
+            - apiGroup: rbac.authorization.k8s.io
+              kind: Group
+              name: system:authenticated
+        documentIndex: 1
+
+  - it: places Role and RoleBinding in the discovery namespace
+    set:
+      muster.namespace: mcp-servers
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: mcp-servers
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: mcp-servers
+        documentIndex: 1
+
+  - it: narrows the binding to custom subjects
+    set:
+      rbac.workflowEditor.subjects:
+        - apiGroup: rbac.authorization.k8s.io
+          kind: Group
+          name: platform-admins
+    asserts:
+      - equal:
+          path: subjects
+          value:
+            - apiGroup: rbac.authorization.k8s.io
+              kind: Group
+              name: platform-admins
+        documentIndex: 1
+
+  - it: creates nothing when rbac.workflowEditor.create is false
+    set:
+      rbac.workflowEditor.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates nothing when rbac.create is false
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -659,6 +659,36 @@
                             }
                         }
                     }
+                },
+                "workflowEditor": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "subjects": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "apiGroup": {
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -60,6 +60,20 @@ rbac:
       - apiGroup: rbac.authorization.k8s.io
         kind: Group
         name: system:authenticated
+  # workflowEditor ships the default answer to "who may create and manage
+  # workflows" under writes-as-caller: a namespaced Role granting
+  # create/update/patch/delete on workflows, plus a RoleBinding. The default
+  # subjects bind all authenticated users, preserving the pre-enforcement
+  # "any user can create" behavior. Narrow subjects to an admin group for
+  # admin-only workflow authoring.
+  workflowEditor:
+    create: true
+    # RoleBinding subjects granted the workflow-editor Role. Standard
+    # rbac.authorization.k8s.io/v1 subjects (Group, User, or ServiceAccount).
+    subjects:  # @schema item: object ; itemProperties: {apiGroup: {type: string}, kind: {type: string}, name: {type: string}, namespace: {type: string}}
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:authenticated
 
 podAnnotations: {}  # @schema additionalProperties: true
 podLabels: {}  # @schema additionalProperties: true

--- a/internal/api/workflow.go
+++ b/internal/api/workflow.go
@@ -410,36 +410,13 @@ type WorkflowHandler interface {
 	GetWorkflow(name string) (*Workflow, error)
 
 	// Workflow lifecycle management
-
-	// CreateWorkflowFromStructured creates a new workflow from structured args.
-	// This allows dynamic workflow creation at runtime.
 	//
-	// Args:
-	//   - args: Structured workflow definition args
-	//
-	// Returns:
-	//   - error: Error if the workflow definition is invalid or creation fails
-	CreateWorkflowFromStructured(args map[string]interface{}) error
-
-	// UpdateWorkflowFromStructured updates an existing workflow from structured args.
-	// This allows runtime modification of workflow definitions.
-	//
-	// Args:
-	//   - name: The name of the workflow to update
-	//   - args: Updated workflow definition args
-	//
-	// Returns:
-	//   - error: Error if the workflow doesn't exist or update fails
-	UpdateWorkflowFromStructured(name string, args map[string]interface{}) error
-
-	// DeleteWorkflow removes a workflow definition from the system.
-	//
-	// Args:
-	//   - name: The name of the workflow to delete
-	//
-	// Returns:
-	//   - error: Error if the workflow doesn't exist or deletion fails
-	DeleteWorkflow(name string) error
+	// Workflow spec mutations (create/update/delete) are deliberately NOT part
+	// of this interface: they must carry the calling session's identity so the
+	// write happens with the caller's own credentials in Kubernetes mode
+	// (issue #1069). They are reachable only through the ToolProvider's
+	// ExecuteTool (workflow_create / workflow_update / workflow_delete), which
+	// threads the request context into the caller-identity write gate.
 
 	// ValidateWorkflowFromStructured validates a workflow definition without creating it.
 	// This is useful for validation during workflow development and testing.

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/muster/internal/aggregator"
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/callerwrite"
 	"github.com/giantswarm/muster/internal/client"
 	"github.com/giantswarm/muster/internal/config"
 	"github.com/giantswarm/muster/internal/events"
@@ -166,27 +167,34 @@ func InitializeServices(cfg *Config) (*Services, error) {
 	eventAdapter := events.NewAdapter(musterClient, namespace)
 	eventAdapter.Register()
 
+	// In Kubernetes mode, session-initiated spec mutations — MCPServer and
+	// Workflow create/update/delete plus CR-driven lifecycle — always write
+	// with the caller's own dex id_token so k8s RBAC decides and the audit
+	// log records the real user (issues #1056/#1057/#1069). When no
+	// Kubernetes config is reachable the factory stays nil and mutations
+	// fail with an explicit configuration error rather than falling back to
+	// the SA. Filesystem mode has no apiserver and keeps writing through the
+	// local client.
+	var callerFactory callerwrite.ClientFactory
+	if musterClient.IsKubernetesMode() {
+		if restConfig, err := ctrl.GetConfig(); err == nil {
+			callerFactory = callerwrite.NewKubernetesClientFactory(restConfig)
+		} else {
+			logging.Warn("Services", "kubernetes mode is active but no Kubernetes config is available for caller-identity writes: %v", err)
+		}
+	}
+
 	// Create and register Workflow adapter using the muster client
 	workflowAdapter := workflow.NewAdapterWithClient(musterClient, namespace, toolCaller, toolChecker, cfg.ConfigPath)
+	if musterClient.IsKubernetesMode() {
+		workflowAdapter.EnableWritesAsCaller(callerFactory, cfg.MusterConfig.WritesAsCaller.KubernetesAudience)
+	}
 	workflowAdapter.Register()
 
 	// Initialize and register MCPServer adapter using the muster client
 	mcpServerAdapter := mcpserverPkg.NewAdapterWithClient(musterClient, namespace)
 	if musterClient.IsKubernetesMode() {
-		// In Kubernetes mode, session-initiated MCPServer spec mutations
-		// always write with the caller's own dex id_token so k8s RBAC decides
-		// and the audit log records the real user (issues #1056/#1057). When
-		// no Kubernetes config is reachable the factory stays nil and
-		// mutations fail with an explicit configuration error rather than
-		// falling back to the SA. Filesystem mode has no apiserver and keeps
-		// writing through the local client.
-		var factory mcpserverPkg.CallerClientFactory
-		if restConfig, err := ctrl.GetConfig(); err == nil {
-			factory = mcpserverPkg.NewKubernetesCallerClientFactory(restConfig)
-		} else {
-			logging.Warn("Services", "kubernetes mode is active but no Kubernetes config is available for caller-identity writes: %v", err)
-		}
-		mcpServerAdapter.EnableWritesAsCaller(factory, cfg.MusterConfig.WritesAsCaller.KubernetesAudience)
+		mcpServerAdapter.EnableWritesAsCaller(callerFactory, cfg.MusterConfig.WritesAsCaller.KubernetesAudience)
 	}
 	mcpServerAdapter.Register()
 

--- a/internal/callerwrite/callerwrite.go
+++ b/internal/callerwrite/callerwrite.go
@@ -1,0 +1,189 @@
+// Package callerwrite implements the shared caller-identity write gate for
+// session-initiated CR mutations (issues #1056, #1069). In Kubernetes mode,
+// spec mutations triggered by MCP sessions must not go through muster's
+// ServiceAccount: the session's dex id_token becomes the bearer of a per-call
+// client, so the apiserver authenticates the real user, Kubernetes RBAC
+// authorizes the write, and the audit log records the true subject. Each
+// CR-owning adapter (MCPServer, Workflow) wraps the Gate into its own typed
+// write surface.
+package callerwrite
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	"github.com/giantswarm/muster/internal/server"
+)
+
+// DefaultKubernetesAudience is the audience the local kube-apiserver trusts on
+// dex id_tokens (the dex-k8s-authenticator cross-client audience). Overridable
+// via writesAsCaller.kubernetesAudience in the muster config.
+const DefaultKubernetesAudience = "dex-k8s-authenticator"
+
+// ClientFactory builds a Kubernetes client authenticated with the caller's
+// own bearer token. Each session-initiated spec mutation gets a per-call
+// client so the apiserver authenticates the real user and k8s RBAC decides —
+// never muster's ServiceAccount, never impersonation headers (dex-only
+// ruling).
+type ClientFactory func(bearerToken string) (ctrlclient.Client, error)
+
+// NewKubernetesClientFactory returns a factory deriving per-call clients from
+// the given base REST config: same apiserver host and CA, all ambient
+// credentials stripped, the caller's bearer as the only authentication.
+func NewKubernetesClientFactory(base *rest.Config) ClientFactory {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(musterv1alpha1.AddToScheme(scheme))
+
+	return func(bearerToken string) (ctrlclient.Client, error) {
+		cfg := rest.AnonymousClientConfig(base)
+		cfg.BearerToken = bearerToken
+		return ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
+	}
+}
+
+// TokenFromContext returns the session's dex id_token carried on the request
+// context by the OAuth middleware, or "" for unauthenticated transports.
+func TokenFromContext(ctx context.Context) string {
+	token, _ := server.GetIDTokenFromContext(ctx)
+	return token
+}
+
+// TokenMissingAudience reports whether token is a JWT whose aud claim
+// verifiably lacks want. The payload is decoded without signature
+// verification — the apiserver is the verifier; this precheck only exists to
+// turn a doomed write into an actionable re-login error. Tokens that don't
+// parse as JWTs (e.g. opaque test tokens) are passed through to the apiserver.
+func TokenMissingAudience(token, want string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims struct {
+		Aud json.RawMessage `json:"aud"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Aud == nil {
+		return true
+	}
+	var single string
+	if err := json.Unmarshal(claims.Aud, &single); err == nil {
+		return single != want
+	}
+	var many []string
+	if err := json.Unmarshal(claims.Aud, &many); err == nil {
+		for _, aud := range many {
+			if aud == want {
+				return false
+			}
+		}
+		return true
+	}
+	return true
+}
+
+// ReloginError is the actionable error for sessions whose token cannot
+// authenticate at the apiserver (missing audience, or rejected outright).
+func ReloginError(reason string) string {
+	return fmt.Sprintf("%s A re-login is required: sign in again to get a fresh session token, then retry.", reason)
+}
+
+// Gate resolves the per-call caller-identity client a session-initiated CR
+// mutation must use. The zero value is disabled: adapters keep their
+// SA-backed write path (filesystem mode). The app layer enables it whenever
+// muster runs in Kubernetes mode.
+type Gate struct {
+	enabled  bool
+	audience string
+	factory  ClientFactory
+
+	// subject names what is being written in the no-token error, e.g.
+	// "MCP server changes" or "workflow changes".
+	subject string
+}
+
+// NewGate returns a disabled gate whose error messages name subject as the
+// thing being written.
+func NewGate(subject string) Gate {
+	return Gate{subject: subject}
+}
+
+// Enable switches the gate on. factory may be nil when muster has no
+// Kubernetes API access; mutations then fail with an explicit configuration
+// error instead of silently falling back to the SA path. An empty audience
+// selects DefaultKubernetesAudience.
+func (g *Gate) Enable(factory ClientFactory, audience string) {
+	g.enabled = true
+	if audience == "" {
+		audience = DefaultKubernetesAudience
+	}
+	g.audience = audience
+	g.factory = factory
+}
+
+// Enabled reports whether caller-identity writes are on.
+func (g *Gate) Enabled() bool {
+	return g.enabled
+}
+
+// Resolve returns the caller-identity client for the session carried by ctx,
+// or a ready-to-return user-facing error message when the session cannot
+// produce a usable bearer. Callers must check Enabled() first: resolving a
+// disabled gate is a bug and fails accordingly.
+func (g *Gate) Resolve(ctx context.Context) (ctrlclient.Client, string) {
+	if !g.enabled {
+		return nil, "internal error: caller-identity write gate is disabled"
+	}
+
+	token := TokenFromContext(ctx)
+	if token == "" {
+		return nil, ReloginError(fmt.Sprintf(
+			"This installation writes %s with your own identity, but your session carries no token.", g.subject))
+	}
+	if TokenMissingAudience(token, g.audience) {
+		return nil, ReloginError(fmt.Sprintf(
+			"Your session token does not carry the %q audience required by the Kubernetes API.", g.audience))
+	}
+	if g.factory == nil {
+		return nil, "writes-as-caller is enabled but muster has no Kubernetes API access to perform the write with — check the muster deployment configuration"
+	}
+
+	client, err := g.factory(token)
+	if err != nil {
+		return nil, fmt.Sprintf("Failed to prepare a Kubernetes client with your identity: %v", err)
+	}
+	return client, ""
+}
+
+// DescribeWriteAuthError maps apiserver authn/authz failures on
+// caller-identity writes to actionable messages: 403 names the verb, kind,
+// fully-qualified resource, and namespace, and points at the editor role the
+// chart ships; 401 asks for a re-login. Returns "" for every other error so
+// callers fall through to their existing handling.
+func DescribeWriteAuthError(err error, verb, kind, resource, name, namespace, editorRole string) string {
+	switch {
+	case errors.IsForbidden(err):
+		return fmt.Sprintf(
+			"Permission denied: your user may not %s %s %q (%s) in namespace %q. "+
+				"Ask a platform admin to grant you the %s role. API server response: %v",
+			verb, kind, name, resource, namespace, editorRole, err)
+	case errors.IsUnauthorized(err):
+		return ReloginError("The Kubernetes API rejected your session token.")
+	}
+	return ""
+}

--- a/internal/callerwrite/callerwrite_test.go
+++ b/internal/callerwrite/callerwrite_test.go
@@ -1,0 +1,45 @@
+package callerwrite
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// testJWT builds an unsigned-but-JWT-shaped token with the given aud claim
+// (string or []string). The gate never verifies signatures — the apiserver
+// does — so a fake signature part suffices.
+func testJWT(t *testing.T, aud interface{}) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := map[string]interface{}{"sub": "alice@example.com", "iss": "https://dex.example.com"}
+	if aud != nil {
+		claims["aud"] = aud
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func TestTokenMissingAudience(t *testing.T) {
+	jwtWith := func(aud interface{}) string { return testJWT(t, aud) }
+	cases := []struct {
+		name    string
+		token   string
+		missing bool
+	}{
+		{"string-match", jwtWith(DefaultKubernetesAudience), false},
+		{"list-match", jwtWith([]string{"x", DefaultKubernetesAudience}), false},
+		{"string-mismatch", jwtWith("other"), true},
+		{"list-mismatch", jwtWith([]string{"a", "b"}), true},
+		{"absent", jwtWith(nil), true},
+		{"opaque-token-passes-through", "not-a-jwt", false},
+	}
+	for _, tc := range cases {
+		if got := TokenMissingAudience(tc.token, DefaultKubernetesAudience); got != tc.missing {
+			t.Errorf("%s: TokenMissingAudience=%v, want %v", tc.name, got, tc.missing)
+		}
+	}
+}

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -12,6 +12,7 @@ import (
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
 
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/callerwrite"
 	"github.com/giantswarm/muster/internal/client"
 	"github.com/giantswarm/muster/internal/events"
 	"github.com/giantswarm/muster/pkg/logging"
@@ -74,14 +75,12 @@ type Adapter struct {
 	client    client.MusterClient
 	namespace string
 
-	// writesAsCaller switches session-initiated spec mutations
-	// (create/update/delete) from the shared SA-backed client to a per-call
-	// client bearing the caller's own dex id_token (issue #1056). Always set
-	// in Kubernetes mode; filesystem mode keeps the local client. Reads,
-	// validation, and muster's own controller writes are unaffected.
-	writesAsCaller     bool
-	kubernetesAudience string
-	callerClients      CallerClientFactory
+	// gate switches session-initiated spec mutations (create/update/delete)
+	// from the shared SA-backed client to a per-call client bearing the
+	// caller's own dex id_token (issue #1056). Always enabled in Kubernetes
+	// mode; filesystem mode keeps the local client. Reads, validation, and
+	// muster's own controller writes are unaffected.
+	gate callerwrite.Gate
 }
 
 // mcpServerWriter is the write surface the mutation handlers go through. The
@@ -100,6 +99,7 @@ func NewAdapterWithClient(musterClient client.MusterClient, namespace string) *A
 	return &Adapter{
 		client:    musterClient,
 		namespace: namespace,
+		gate:      callerwrite.NewGate("MCP server changes"),
 	}
 }
 
@@ -109,13 +109,8 @@ func NewAdapterWithClient(musterClient client.MusterClient, namespace string) *A
 // access; mutations then fail with an explicit configuration error instead of
 // silently falling back to the SA path. An empty kubernetesAudience selects
 // the default.
-func (a *Adapter) EnableWritesAsCaller(factory CallerClientFactory, kubernetesAudience string) {
-	a.writesAsCaller = true
-	if kubernetesAudience == "" {
-		kubernetesAudience = DefaultKubernetesAudience
-	}
-	a.kubernetesAudience = kubernetesAudience
-	a.callerClients = factory
+func (a *Adapter) EnableWritesAsCaller(factory callerwrite.ClientFactory, kubernetesAudience string) {
+	a.gate.Enable(factory, kubernetesAudience)
 }
 
 // mutationWriter resolves the write client a mutation must use. In
@@ -125,29 +120,12 @@ func (a *Adapter) EnableWritesAsCaller(factory CallerClientFactory, kubernetesAu
 // returned together with a ready-to-return tool error when the session cannot
 // produce a usable bearer.
 func (a *Adapter) mutationWriter(ctx context.Context) (mcpServerWriter, *api.CallToolResult) {
-	if !a.writesAsCaller {
+	if !a.gate.Enabled() {
 		return a.client, nil
 	}
-
-	token := callerTokenFromContext(ctx)
-	if token == "" {
-		result, _ := simpleError(reloginError(
-			"This installation writes MCP server changes with your own identity, but your session carries no token."))
-		return nil, result
-	}
-	if tokenMissingAudience(token, a.kubernetesAudience) {
-		result, _ := simpleError(reloginError(fmt.Sprintf(
-			"Your session token does not carry the %q audience required by the Kubernetes API.", a.kubernetesAudience)))
-		return nil, result
-	}
-	if a.callerClients == nil {
-		result, _ := simpleError("writes-as-caller is enabled but muster has no Kubernetes API access to perform the write with — check the muster deployment configuration")
-		return nil, result
-	}
-
-	callerClient, err := a.callerClients(token)
-	if err != nil {
-		result, _ := simpleError(fmt.Sprintf("Failed to prepare a Kubernetes client with your identity: %v", err))
+	callerClient, errMsg := a.gate.Resolve(ctx)
+	if errMsg != "" {
+		result, _ := simpleError(errMsg)
 		return nil, result
 	}
 	return &callerWriter{client: callerClient, namespace: a.namespace}, nil
@@ -158,16 +136,8 @@ func (a *Adapter) mutationWriter(ctx context.Context) (mcpServerWriter, *api.Cal
 // resource, and namespace; 401 asks for a re-login. Returns "" for every
 // other error so callers fall through to their existing handling.
 func (a *Adapter) describeWriteAuthError(err error, verb, name string) string {
-	switch {
-	case errors.IsForbidden(err):
-		return fmt.Sprintf(
-			"Permission denied: your user may not %s MCPServer %q (mcpservers.muster.giantswarm.io) in namespace %q. "+
-				"Ask a platform admin to grant you the mcpserver-editor role. API server response: %v",
-			verb, name, a.namespace, err)
-	case errors.IsUnauthorized(err):
-		return reloginError("The Kubernetes API rejected your session token.")
-	}
-	return ""
+	return callerwrite.DescribeWriteAuthError(err, verb,
+		"MCPServer", "mcpservers.muster.giantswarm.io", name, a.namespace, "mcpserver-editor")
 }
 
 // Register registers the adapter with the API

--- a/internal/mcpserver/caller_client.go
+++ b/internal/mcpserver/caller_client.go
@@ -2,92 +2,16 @@ package mcpserver
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
-
-	"github.com/giantswarm/muster/internal/server"
 )
 
-// DefaultKubernetesAudience is the audience the local kube-apiserver trusts on
-// dex id_tokens (the dex-k8s-authenticator cross-client audience). Overridable
-// via writesAsCaller.kubernetesAudience in the muster config.
-const DefaultKubernetesAudience = "dex-k8s-authenticator"
-
-// CallerClientFactory builds a Kubernetes client authenticated with the
-// caller's own bearer token. Each session-initiated MCPServer spec mutation
-// gets a per-call client so the apiserver authenticates the real user and
-// k8s RBAC decides — never muster's ServiceAccount, never impersonation
-// headers (dex-only ruling).
-type CallerClientFactory func(bearerToken string) (ctrlclient.Client, error)
-
-// NewKubernetesCallerClientFactory returns a factory deriving per-call clients
-// from the given base REST config: same apiserver host and CA, all ambient
-// credentials stripped, the caller's bearer as the only authentication.
-func NewKubernetesCallerClientFactory(base *rest.Config) CallerClientFactory {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(musterv1alpha1.AddToScheme(scheme))
-
-	return func(bearerToken string) (ctrlclient.Client, error) {
-		cfg := rest.AnonymousClientConfig(base)
-		cfg.BearerToken = bearerToken
-		return ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
-	}
-}
-
-// callerTokenFromContext returns the session's dex id_token carried on the
-// request context by the OAuth middleware, or "" for unauthenticated
-// transports.
-func callerTokenFromContext(ctx context.Context) string {
-	token, _ := server.GetIDTokenFromContext(ctx)
-	return token
-}
-
-// tokenMissingAudience reports whether token is a JWT whose aud claim
-// verifiably lacks want. The payload is decoded without signature
-// verification — the apiserver is the verifier; this precheck only exists to
-// turn a doomed write into an actionable re-login error. Tokens that don't
-// parse as JWTs (e.g. opaque test tokens) are passed through to the apiserver.
-func tokenMissingAudience(token, want string) bool {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return false
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return false
-	}
-	var claims struct {
-		Aud json.RawMessage `json:"aud"`
-	}
-	if err := json.Unmarshal(payload, &claims); err != nil || claims.Aud == nil {
-		return true
-	}
-	var single string
-	if err := json.Unmarshal(claims.Aud, &single); err == nil {
-		return single != want
-	}
-	var many []string
-	if err := json.Unmarshal(claims.Aud, &many); err == nil {
-		for _, aud := range many {
-			if aud == want {
-				return false
-			}
-		}
-		return true
-	}
-	return true
-}
+// The caller-identity gate itself (token extraction, audience precheck,
+// per-call client construction) is shared across CR-owning adapters and lives
+// in internal/callerwrite. This file adapts its resolved client to the
+// MCPServer write surface.
 
 // callerWriter adapts a per-call controller-runtime client to the write
 // surface the mutation handlers use.
@@ -109,10 +33,4 @@ func (w *callerWriter) DeleteMCPServer(ctx context.Context, name, namespace stri
 	obj.Name = name
 	obj.Namespace = namespace
 	return w.client.Delete(ctx, obj)
-}
-
-// reloginError is the actionable error for sessions whose token cannot
-// authenticate at the apiserver (missing audience, or rejected outright).
-func reloginError(reason string) (msg string) {
-	return fmt.Sprintf("%s A re-login is required: sign in again to get a fresh session token, then retry.", reason)
 }

--- a/internal/mcpserver/lifecycle.go
+++ b/internal/mcpserver/lifecycle.go
@@ -55,7 +55,7 @@ func OAuthLoginGuidance(name string) string {
 // handled=false means the caller must fall back to the imperative path. A
 // non-nil result is a ready-to-return tool error from the definition lookup.
 func (a *Adapter) lifecycleTarget(ctx context.Context, name string) (*musterv1alpha1.MCPServer, *api.CallToolResult, bool) {
-	if !a.writesAsCaller {
+	if !a.gate.Enabled() {
 		return nil, nil, false
 	}
 

--- a/internal/mcpserver/lifecycle_test.go
+++ b/internal/mcpserver/lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
 
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/callerwrite"
 	"github.com/giantswarm/muster/internal/server"
 )
 
@@ -56,7 +57,7 @@ func TestLifecycleAsCaller_NotHandledForInternalService(t *testing.T) {
 		"aggregator": &fakeServiceInfo{name: "aggregator", typ: api.ServiceType("Aggregator")},
 	}})
 	h := newCallerHarness(t, nil, nil)
-	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 	for _, action := range []string{"start", "stop", "restart"} {
 		if _, handled, _ := lifecycleCall(t, h.adapter, ctx, action, "aggregator"); handled {
 			t.Errorf("%s: must not be handled for muster's own internal services", action)
@@ -73,7 +74,7 @@ func TestLifecycleAsCaller_NotHandledForInternalService(t *testing.T) {
 // lingering registry entry would otherwise reopen the side door.
 func TestLifecycleAsCaller_UnknownNameFailsClosed(t *testing.T) {
 	h := newCallerHarness(t, nil, nil)
-	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 	for _, action := range []string{"start", "stop", "restart"} {
 		result, handled, err := lifecycleCall(t, h.adapter, ctx, action, "ghost")
 		if err != nil || !handled {
@@ -91,7 +92,7 @@ func TestLifecycleAsCaller_UnknownNameFailsClosed(t *testing.T) {
 // TestLifecycleAsCaller_StopWritesSuspended: core_service_stop becomes a
 // spec.suspended=true write carried by the caller's own bearer.
 func TestLifecycleAsCaller_StopWritesSuspended(t *testing.T) {
-	token := testJWT(t, DefaultKubernetesAudience)
+	token := testJWT(t, callerwrite.DefaultKubernetesAudience)
 	h := newCallerHarness(t, existingServer(), nil)
 	ctx := server.ContextWithIDToken(context.Background(), token)
 
@@ -122,7 +123,7 @@ func TestLifecycleAsCaller_StopWritesSuspended(t *testing.T) {
 func TestLifecycleAsCaller_StartClearsSuspended(t *testing.T) {
 	t.Run("service down", func(t *testing.T) {
 		h := newCallerHarness(t, suspendedServer(), nil)
-		ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+		ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 		result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
 		if err != nil || !handled || result.IsError {
@@ -144,7 +145,7 @@ func TestLifecycleAsCaller_StartClearsSuspended(t *testing.T) {
 			"test-server": &fakeServiceInfo{name: "test-server", state: api.StateRunning},
 		}})
 		h := newCallerHarness(t, suspendedServer(), nil)
-		ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+		ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 		result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
 		if err != nil || !handled || result.IsError {
@@ -175,7 +176,7 @@ func TestLifecycleAsCaller_StartRequestsStartWhenDown(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			withServiceRegistry(t, registry)
 			h := newCallerHarness(t, existingServer(), nil)
-			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 			result, handled, err := h.adapter.StartMCPServerAsCaller(ctx, "test-server")
 			if err != nil || !handled || result.IsError {
@@ -232,7 +233,7 @@ func TestLifecycleAsCaller_StartNoOpStates(t *testing.T) {
 // spec.restartRequestedAt write; the field is the audit record of the request.
 func TestLifecycleAsCaller_RestartWritesTimestamp(t *testing.T) {
 	h := newCallerHarness(t, existingServer(), nil)
-	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 	result, handled, err := h.adapter.RestartMCPServerAsCaller(ctx, "test-server")
 	if err != nil || !handled || result.IsError {
@@ -248,7 +249,7 @@ func TestLifecycleAsCaller_RestartWritesTimestamp(t *testing.T) {
 // up front and points at core_service_start.
 func TestLifecycleAsCaller_RestartSuspendedRefused(t *testing.T) {
 	h := newCallerHarness(t, suspendedServer(), nil)
-	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 	result, handled, err := h.adapter.RestartMCPServerAsCaller(ctx, "test-server")
 	if err != nil || !handled {
@@ -270,7 +271,7 @@ func TestLifecycleAsCaller_RestartAuthRequiredRefused(t *testing.T) {
 		"test-server": &fakeServiceInfo{name: "test-server", state: api.StateAuthRequired},
 	}})
 	h := newCallerHarness(t, existingServer(), nil)
-	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 	result, handled, err := h.adapter.RestartMCPServerAsCaller(ctx, "test-server")
 	if err != nil || !handled {
@@ -326,7 +327,7 @@ func TestLifecycleAsCaller_DeniedBeforeWrite(t *testing.T) {
 				t.Fatalf("handled=%v err=%v", handled, err)
 			}
 			text := resultText(t, result)
-			if !result.IsError || !strings.Contains(text, DefaultKubernetesAudience) || !strings.Contains(text, "re-login") {
+			if !result.IsError || !strings.Contains(text, callerwrite.DefaultKubernetesAudience) || !strings.Contains(text, "re-login") {
 				t.Fatalf("expected audience re-login error, got: %s", text)
 			}
 			if len(h.tokensSeen) != 0 {
@@ -352,7 +353,7 @@ func TestLifecycleAsCaller_ForbiddenMapsToPermissionError(t *testing.T) {
 				existing.Spec.Suspended = true
 			}
 			h := newCallerHarness(t, existing, forbidden)
-			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, DefaultKubernetesAudience))
+			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 			result, handled, err := lifecycleCall(t, h.adapter, ctx, action, "test-server")
 			if err != nil || !handled {

--- a/internal/mcpserver/writes_as_caller_envtest_test.go
+++ b/internal/mcpserver/writes_as_caller_envtest_test.go
@@ -16,6 +16,7 @@ import (
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
 
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/callerwrite"
 	kubernetesclient "github.com/giantswarm/muster/internal/client/kubernetes"
 	"github.com/giantswarm/muster/internal/server"
 )
@@ -36,8 +37,8 @@ func TestWritesAsCallerEnvtest(t *testing.T) {
 	// Static token authentication: bearer → user. The tokens are JWT-shaped
 	// and carry the kubernetes audience so the adapter's audience precheck —
 	// the same code the dex path runs — passes and the apiserver decides.
-	allowedToken := testJWT(t, DefaultKubernetesAudience)
-	deniedToken := testJWT(t, []string{DefaultKubernetesAudience, "muster"})
+	allowedToken := testJWT(t, callerwrite.DefaultKubernetesAudience)
+	deniedToken := testJWT(t, []string{callerwrite.DefaultKubernetesAudience, "muster"})
 	tokenFile := filepath.Join(t.TempDir(), "tokens.csv")
 	tokens := fmt.Sprintf("%s,allowed-user,1000,\n%s,denied-user,1001,\n", allowedToken, deniedToken)
 	if err := os.WriteFile(tokenFile, []byte(tokens), 0o600); err != nil {
@@ -94,7 +95,7 @@ func TestWritesAsCallerEnvtest(t *testing.T) {
 	}
 
 	adapter := NewAdapterWithClient(saClient, "default")
-	adapter.EnableWritesAsCaller(NewKubernetesCallerClientFactory(adminCfg), "")
+	adapter.EnableWritesAsCaller(callerwrite.NewKubernetesClientFactory(adminCfg), "")
 
 	allowedCtx := server.ContextWithIDToken(ctx, allowedToken)
 	deniedCtx := server.ContextWithIDToken(ctx, deniedToken)

--- a/internal/workflow/api_adapter.go
+++ b/internal/workflow/api_adapter.go
@@ -12,6 +12,7 @@ import (
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
 
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/callerwrite"
 	"github.com/giantswarm/muster/internal/client"
 	"github.com/giantswarm/muster/internal/events"
 	"github.com/giantswarm/muster/pkg/logging"
@@ -19,7 +20,10 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"gopkg.in/yaml.v3"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // fieldOutput is the argument/field name for both the per-step output flag and
@@ -45,12 +49,49 @@ type Adapter struct {
 	executionTracker *ExecutionTracker
 	toolChecker      ToolAvailabilityChecker
 
+	// gate switches session-initiated spec mutations (create/update/delete)
+	// from the shared SA-backed client to a per-call client bearing the
+	// caller's own dex id_token (issue #1069), exactly like MCPServer
+	// mutations. Always enabled in Kubernetes mode; filesystem mode keeps the
+	// local client. Reads, validation, execution, and muster's own controller
+	// writes are unaffected.
+	gate callerwrite.Gate
+
 	// Prevent circular dependency during tool generation
 	generatingTools bool
 	mu              sync.RWMutex
 
 	// stopGC cancels the background retention GC goroutine on Stop.
 	stopGC context.CancelFunc
+}
+
+// workflowWriter is the write surface the mutation handlers go through. The
+// SA-backed MusterClient and the per-call caller-bearer client both satisfy it.
+type workflowWriter interface {
+	CreateWorkflow(ctx context.Context, workflow *musterv1alpha1.Workflow) error
+	UpdateWorkflow(ctx context.Context, workflow *musterv1alpha1.Workflow) error
+	DeleteWorkflow(ctx context.Context, name, namespace string) error
+}
+
+// callerWriter adapts a per-call controller-runtime client to the write
+// surface the mutation handlers use.
+type callerWriter struct {
+	client ctrlclient.Client
+}
+
+func (w *callerWriter) CreateWorkflow(ctx context.Context, obj *musterv1alpha1.Workflow) error {
+	return w.client.Create(ctx, obj)
+}
+
+func (w *callerWriter) UpdateWorkflow(ctx context.Context, obj *musterv1alpha1.Workflow) error {
+	return w.client.Update(ctx, obj)
+}
+
+func (w *callerWriter) DeleteWorkflow(ctx context.Context, name, namespace string) error {
+	obj := &musterv1alpha1.Workflow{}
+	obj.Name = name
+	obj.Namespace = namespace
+	return w.client.Delete(ctx, obj)
 }
 
 // ToolAvailabilityChecker interface for checking tool availability
@@ -75,6 +116,7 @@ func NewAdapterWithClient(musterClient client.MusterClient, namespace string, to
 		namespace:        namespace,
 		executionTracker: NewExecutionTracker(newExecutionStorage(musterClient, namespace, configPath)),
 		toolChecker:      toolChecker,
+		gate:             callerwrite.NewGate("workflow changes"),
 	}
 
 	adapter.executor = NewWorkflowExecutor(toolCaller, adapter)
@@ -86,6 +128,42 @@ func NewAdapterWithClient(musterClient client.MusterClient, namespace string, to
 	go adapter.runRetentionGC(gcCtx)
 
 	return adapter
+}
+
+// EnableWritesAsCaller switches session-initiated mutations to
+// caller-identity writes; the app layer calls it whenever muster runs in
+// Kubernetes mode. factory may be nil when muster has no Kubernetes API
+// access; mutations then fail with an explicit configuration error instead of
+// silently falling back to the SA path. An empty kubernetesAudience selects
+// the default.
+func (a *Adapter) EnableWritesAsCaller(factory callerwrite.ClientFactory, kubernetesAudience string) {
+	a.gate.Enable(factory, kubernetesAudience)
+}
+
+// mutationWriter resolves the write client a mutation must use. In
+// filesystem mode it is the shared local client. In Kubernetes mode the
+// session's dex id_token becomes the bearer of a per-call client, so the
+// apiserver authenticates the real user and k8s RBAC decides. A nil writer is
+// returned together with a ready-to-return tool error when the session cannot
+// produce a usable bearer.
+func (a *Adapter) mutationWriter(ctx context.Context) (workflowWriter, *api.CallToolResult) {
+	if !a.gate.Enabled() {
+		return a.client, nil
+	}
+	callerClient, errMsg := a.gate.Resolve(ctx)
+	if errMsg != "" {
+		return nil, &api.CallToolResult{Content: []interface{}{errMsg}, IsError: true}
+	}
+	return &callerWriter{client: callerClient}, nil
+}
+
+// describeWriteAuthError maps apiserver authn/authz failures on
+// caller-identity writes to actionable tool errors: 403 names the verb,
+// resource, and namespace; 401 asks for a re-login. Returns "" for every
+// other error so callers fall through to their existing handling.
+func (a *Adapter) describeWriteAuthError(err error, verb, name string) string {
+	return callerwrite.DescribeWriteAuthError(err, verb,
+		"Workflow", "workflows.muster.giantswarm.io", name, a.namespace, "workflow-editor")
 }
 
 // runRetentionGC periodically prunes execution records that violate the default
@@ -313,8 +391,12 @@ func (a *Adapter) getWorkflow(ctx context.Context, name string) (*api.Workflow, 
 	return workflow, nil
 }
 
-// CreateWorkflowFromStructured creates a new workflow from structured arguments
-func (a *Adapter) CreateWorkflowFromStructured(args map[string]interface{}) error {
+// createWorkflow validates the structured arguments, converts them to a
+// Workflow CR, and creates it through writer — the caller's own identity for
+// session-initiated mutations in Kubernetes mode, the shared local client in
+// filesystem mode. Write errors are returned unwrapped enough for the caller
+// to map apiserver authn/authz failures (describeWriteAuthError).
+func (a *Adapter) createWorkflow(ctx context.Context, writer workflowWriter, args map[string]interface{}) error {
 	// Validate the workflow before creating it
 	if err := a.ValidateWorkflowFromStructured(args); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
@@ -333,9 +415,8 @@ func (a *Adapter) CreateWorkflowFromStructured(args map[string]interface{}) erro
 		Kind:       "Workflow",
 	}
 
-	// Create the CRD
-	ctx := context.Background()
-	if err := a.client.CreateWorkflow(ctx, workflowCRD); err != nil {
+	// Create the CRD with the resolved write identity
+	if err := writer.CreateWorkflow(ctx, workflowCRD); err != nil {
 		// Generate failure event
 		a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{
 			Error:     err.Error(),
@@ -353,8 +434,15 @@ func (a *Adapter) CreateWorkflowFromStructured(args map[string]interface{}) erro
 	return nil
 }
 
-// UpdateWorkflowFromStructured updates an existing workflow from structured arguments
-func (a *Adapter) UpdateWorkflowFromStructured(name string, args map[string]interface{}) error {
+// updateWorkflow validates the structured arguments and updates the named
+// Workflow CR through writer (see createWorkflow for the identity contract).
+//
+// The update is a get-modify-write: the read of the current CR stays on the
+// SA client — only the spec mutation itself switches to the caller's identity
+// — and carries the resourceVersion the apiserver requires for CR updates (a
+// fresh object without one is rejected). Conflicts with muster's own status
+// reconciler bumping the resourceVersion are retried on a fresh read.
+func (a *Adapter) updateWorkflow(ctx context.Context, writer workflowWriter, name string, args map[string]interface{}) error {
 	// Validate the workflow before updating it
 	if err := a.ValidateWorkflowFromStructured(args); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
@@ -369,12 +457,22 @@ func (a *Adapter) UpdateWorkflowFromStructured(name string, args map[string]inte
 	// Ensure the name matches
 	wf.Name = name
 
-	// Convert to CRD
-	workflowCRD := a.convertWorkflowToCRD(&wf)
+	// Convert to CRD; only its spec is applied onto the live object.
+	desired := a.convertWorkflowToCRD(&wf)
 
-	// Update the CRD
-	ctx := context.Background()
-	if err := a.client.UpdateWorkflow(ctx, workflowCRD); err != nil {
+	apply := func() error {
+		existing, err := a.client.GetWorkflow(ctx, name, a.namespace)
+		if err != nil {
+			return err
+		}
+		existing.Spec = desired.Spec
+		return writer.UpdateWorkflow(ctx, existing)
+	}
+	err = apply()
+	if apierrors.IsConflict(err) {
+		err = retry.RetryOnConflict(retry.DefaultRetry, apply)
+	}
+	if err != nil {
 		// Generate failure event
 		a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{
 			Error:     err.Error(),
@@ -559,10 +657,10 @@ func validateWorkflowSubSteps(label string, subs []api.WorkflowSubStep) error {
 	return nil
 }
 
-// DeleteWorkflow deletes a workflow
-func (a *Adapter) DeleteWorkflow(name string) error {
-	ctx := context.Background()
-	if err := a.client.DeleteWorkflow(ctx, name, a.namespace); err != nil {
+// deleteWorkflow deletes the named Workflow CR through writer (see
+// createWorkflow for the identity contract).
+func (a *Adapter) deleteWorkflow(ctx context.Context, writer workflowWriter, name string) error {
+	if err := writer.DeleteWorkflow(ctx, name, a.namespace); err != nil {
 		// Generate failure event
 		a.generateCRDEvent(name, events.ReasonWorkflowValidationFailed, events.EventData{
 			Error:     err.Error(),
@@ -1436,11 +1534,11 @@ func (a *Adapter) ExecuteTool(ctx context.Context, toolName string, args map[str
 	case toolName == "workflow_get":
 		return a.handleGet(ctx, args)
 	case toolName == "workflow_create":
-		return a.handleCreate(args)
+		return a.handleCreate(ctx, args)
 	case toolName == "workflow_update":
-		return a.handleUpdate(args)
+		return a.handleUpdate(ctx, args)
 	case toolName == "workflow_delete":
-		return a.handleDelete(args)
+		return a.handleDelete(ctx, args)
 	case toolName == "workflow_validate":
 		return a.handleValidate(args)
 	case toolName == "workflow_available":
@@ -1553,7 +1651,7 @@ func (a *Adapter) handleGet(ctx context.Context, args map[string]interface{}) (*
 	}, nil
 }
 
-func (a *Adapter) handleCreate(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleCreate(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	var req api.WorkflowCreateRequest
 	if err := api.ParseRequest(args, &req); err != nil {
 		return &api.CallToolResult{
@@ -1562,14 +1660,22 @@ func (a *Adapter) handleCreate(args map[string]interface{}) (*api.CallToolResult
 		}, nil
 	}
 
+	writer, errResult := a.mutationWriter(ctx)
+	if errResult != nil {
+		return errResult, nil
+	}
+
 	// Convert structured arguments to api.Workflow
 	wf, err := convertToWorkflow(args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 
-	// Create workflow through adapter
-	if err := a.CreateWorkflowFromStructured(args); err != nil {
+	// Create the workflow with the resolved write identity
+	if err := a.createWorkflow(ctx, writer, args); err != nil {
+		if msg := a.describeWriteAuthError(err, "create", req.Name); msg != "" {
+			return &api.CallToolResult{Content: []interface{}{msg}, IsError: true}, nil
+		}
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 
@@ -1594,7 +1700,7 @@ func (a *Adapter) handleCreate(args map[string]interface{}) (*api.CallToolResult
 	}, nil
 }
 
-func (a *Adapter) handleUpdate(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleUpdate(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	var req api.WorkflowUpdateRequest
 	if err := api.ParseRequest(args, &req); err != nil {
 		return &api.CallToolResult{
@@ -1603,7 +1709,15 @@ func (a *Adapter) handleUpdate(args map[string]interface{}) (*api.CallToolResult
 		}, nil
 	}
 
-	if err := a.UpdateWorkflowFromStructured(req.Name, args); err != nil {
+	writer, errResult := a.mutationWriter(ctx)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	if err := a.updateWorkflow(ctx, writer, req.Name, args); err != nil {
+		if msg := a.describeWriteAuthError(err, "update", req.Name); msg != "" {
+			return &api.CallToolResult{Content: []interface{}{msg}, IsError: true}, nil
+		}
 		return api.HandleErrorWithPrefix(err, "Failed to update workflow"), nil
 	}
 
@@ -1613,7 +1727,7 @@ func (a *Adapter) handleUpdate(args map[string]interface{}) (*api.CallToolResult
 	}, nil
 }
 
-func (a *Adapter) handleDelete(args map[string]interface{}) (*api.CallToolResult, error) {
+func (a *Adapter) handleDelete(ctx context.Context, args map[string]interface{}) (*api.CallToolResult, error) {
 	name, ok := args["name"].(string)
 	if !ok {
 		return &api.CallToolResult{
@@ -1622,7 +1736,15 @@ func (a *Adapter) handleDelete(args map[string]interface{}) (*api.CallToolResult
 		}, nil
 	}
 
-	if err := a.DeleteWorkflow(name); err != nil {
+	writer, errResult := a.mutationWriter(ctx)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	if err := a.deleteWorkflow(ctx, writer, name); err != nil {
+		if msg := a.describeWriteAuthError(err, "delete", name); msg != "" {
+			return &api.CallToolResult{Content: []interface{}{msg}, IsError: true}, nil
+		}
 		return api.HandleErrorWithPrefix(err, "Failed to delete workflow"), nil
 	}
 

--- a/internal/workflow/doc.go
+++ b/internal/workflow/doc.go
@@ -116,45 +116,24 @@
 //
 // ## Creating Workflows
 //
-//	workflow := api.Workflow{
-//	    Name:        "deploy-app",
-//	    Description: "Deploy application to environment",
-//	    Args: map[string]api.ArgDefinition{
-//	        "environment": {
-//	            Type:        "string",
-//	            Description: "Target environment",
-//	            Default:     "development",
-//	            Required:    false,
-//	        },
-//	        "version": {
-//	            Type:        "string",
-//	            Description: "Application version",
-//	            Required:    true,
-//	        },
-//	    },
-//	    Steps: []api.WorkflowStep{
-//	        {
-//	            ID:   "validate",
-//	            Tool: "validate_environment",
-//	            Args: map[string]interface{}{
-//	                "environment": "{{.environment}}",
-//	            },
-//	        },
-//	        {
-//	            ID:   "deploy",
-//	            Tool: "deploy_application",
-//	            Args: map[string]interface{}{
-//	                "environment": "{{.environment}}",
-//	                "version":     "{{.version}}",
-//	            },
-//	        },
-//	    },
-//	}
+// Workflow spec mutations must carry the calling session's identity so
+// Kubernetes-mode installations write them with the caller's own credentials
+// (issue #1069). They are therefore only reachable through the tool dispatch,
+// never as direct handler methods:
 //
 //	workflowHandler := api.GetWorkflow()
-//	if err := workflowHandler.CreateWorkflowFromStructured(workflowData); err != nil {
-//	    log.Fatal(err)
-//	}
+//	provider := workflowHandler.(api.ToolProvider)
+//	result, err := provider.ExecuteTool(ctx, "workflow_create", map[string]interface{}{
+//	    "name":        "deploy-app",
+//	    "description": "Deploy application to environment",
+//	    "steps": []interface{}{
+//	        map[string]interface{}{
+//	            "id":   "deploy",
+//	            "tool": "deploy_application",
+//	            "args": map[string]interface{}{"environment": "{{.environment}}"},
+//	        },
+//	    },
+//	})
 //
 // ## Executing Workflows
 //

--- a/internal/workflow/writes_as_caller_envtest_test.go
+++ b/internal/workflow/writes_as_caller_envtest_test.go
@@ -1,0 +1,208 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/giantswarm/muster/internal/callerwrite"
+	kubernetesclient "github.com/giantswarm/muster/internal/client/kubernetes"
+	"github.com/giantswarm/muster/internal/server"
+)
+
+// TestWritesAsCallerEnvtest runs the Workflow writes-as-caller path against a
+// real kube-apiserver with RBAC: an allowed user (bound to a workflow-editor
+// style Role) creates, updates, and deletes through the adapter; a denied
+// user gets the mapped permission error and no write occurs; muster's own
+// SA-equivalent client still reconciles status on a CR it did not create.
+//
+// Requires envtest binaries: run via `make test-envtest`, which resolves
+// KUBEBUILDER_ASSETS with setup-envtest. Skipped otherwise.
+func TestWritesAsCallerEnvtest(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; run via `make test-envtest`")
+	}
+
+	// Static token authentication: bearer → user. The tokens are JWT-shaped
+	// and carry the kubernetes audience so the adapter's audience precheck —
+	// the same code the dex path runs — passes and the apiserver decides.
+	allowedToken := testJWT(t, callerwrite.DefaultKubernetesAudience)
+	deniedToken := testJWT(t, []string{callerwrite.DefaultKubernetesAudience, "muster"})
+	tokenFile := filepath.Join(t.TempDir(), "tokens.csv")
+	tokens := fmt.Sprintf("%s,allowed-user,1000,\n%s,denied-user,1001,\n", allowedToken, deniedToken)
+	if err := os.WriteFile(tokenFile, []byte(tokens), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "helm", "muster", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+	// envtest's apiserver already runs --authorization-mode=RBAC by default.
+	testEnv.ControlPlane.GetAPIServer().Configure().Set("token-auth-file", tokenFile)
+
+	adminCfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Errorf("stop envtest: %v", err)
+		}
+	})
+
+	// The admin config plays muster's ServiceAccount: it backs the shared
+	// MusterClient (reads, status reconciliation) exactly like production.
+	saClient, err := kubernetesclient.New(adminCfg)
+	if err != nil {
+		t.Fatalf("create kubernetes muster client: %v", err)
+	}
+	t.Cleanup(func() { _ = saClient.Close() })
+
+	ctx := context.Background()
+
+	// workflow-editor equivalent, bound to allowed-user only (the chart ships
+	// the default binding; the Role shape is the same).
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "workflow-editor", Namespace: "default"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"muster.giantswarm.io"},
+			Resources: []string{"workflows"},
+			Verbs:     []string{"create", "update", "patch", "delete"},
+		}},
+	}
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "workflow-editor", Namespace: "default"},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "allowed-user"}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "workflow-editor"},
+	}
+	if err := saClient.Create(ctx, role); err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	if err := saClient.Create(ctx, binding); err != nil {
+		t.Fatalf("create rolebinding: %v", err)
+	}
+
+	adapter := NewAdapterWithClient(saClient, "default", nil, nil, "")
+	t.Cleanup(adapter.stopGC)
+	adapter.EnableWritesAsCaller(callerwrite.NewKubernetesClientFactory(adminCfg), "")
+
+	allowedCtx := server.ContextWithIDToken(ctx, allowedToken)
+	deniedCtx := server.ContextWithIDToken(ctx, deniedToken)
+
+	// createArgs builds a minimal valid definition whose step tool identifies
+	// the writing revision, so update effects are observable in the CR.
+	createArgs := func(name, stepTool string) map[string]interface{} {
+		return map[string]interface{}{
+			"name": name,
+			"steps": []interface{}{
+				map[string]interface{}{"id": "s1", "tool": stepTool},
+			},
+		}
+	}
+
+	t.Run("allowed user create-update-delete", func(t *testing.T) {
+		result, err := adapter.ExecuteTool(allowedCtx, "workflow_create", createArgs("allowed-workflow", "core_service_list"))
+		if err != nil || result.IsError {
+			t.Fatalf("create: err=%v result=%s", err, resultText(t, result))
+		}
+		created, err := saClient.GetWorkflow(ctx, "allowed-workflow", "default")
+		if err != nil {
+			t.Fatalf("created CR not found: %v", err)
+		}
+		if len(created.Spec.Steps) != 1 || created.Spec.Steps[0].Tool != "core_service_list" {
+			t.Fatalf("unexpected spec: %+v", created.Spec)
+		}
+
+		result, err = adapter.ExecuteTool(allowedCtx, "workflow_update", createArgs("allowed-workflow", "core_workflow_list"))
+		if err != nil || result.IsError {
+			t.Fatalf("update: err=%v result=%s", err, resultText(t, result))
+		}
+		updated, err := saClient.GetWorkflow(ctx, "allowed-workflow", "default")
+		if err != nil {
+			t.Fatalf("get after update: %v", err)
+		}
+		if len(updated.Spec.Steps) != 1 || updated.Spec.Steps[0].Tool != "core_workflow_list" {
+			t.Fatalf("update did not land: %+v", updated.Spec)
+		}
+
+		// Muster's SA still reconciles status on the user-created CR: the
+		// controllers keep their identity, only spec mutations switched.
+		updated.Status.Valid = true
+		updated.Status.StepCount = len(updated.Spec.Steps)
+		if err := saClient.UpdateWorkflowStatus(ctx, updated); err != nil {
+			t.Fatalf("SA status update on caller-created CR: %v", err)
+		}
+
+		result, err = adapter.ExecuteTool(allowedCtx, "workflow_delete",
+			map[string]interface{}{"name": "allowed-workflow"})
+		if err != nil || result.IsError {
+			t.Fatalf("delete: err=%v result=%s", err, resultText(t, result))
+		}
+		if _, err := saClient.GetWorkflow(ctx, "allowed-workflow", "default"); !apierrors.IsNotFound(err) {
+			t.Fatalf("CR still present after delete: %v", err)
+		}
+	})
+
+	t.Run("denied user create", func(t *testing.T) {
+		result, err := adapter.ExecuteTool(deniedCtx, "workflow_create", createArgs("denied-workflow", "core_service_list"))
+		if err != nil {
+			t.Fatalf("ExecuteTool: %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("expected permission error")
+		}
+		text := resultText(t, result)
+		for _, want := range []string{"Permission denied", "create", "workflows.muster.giantswarm.io", `"default"`, "workflow-editor"} {
+			if !strings.Contains(text, want) {
+				t.Errorf("error %q does not mention %q", text, want)
+			}
+		}
+		if _, err := saClient.GetWorkflow(ctx, "denied-workflow", "default"); !apierrors.IsNotFound(err) {
+			t.Fatalf("denied create still wrote the CR: %v", err)
+		}
+	})
+
+	t.Run("denied user update and delete", func(t *testing.T) {
+		// A CR the denied user did not create and may not touch.
+		result, err := adapter.ExecuteTool(allowedCtx, "workflow_create", createArgs("victim-workflow", "core_service_list"))
+		if err != nil || result.IsError {
+			t.Fatalf("setup create: err=%v result=%s", err, resultText(t, result))
+		}
+
+		result, err = adapter.ExecuteTool(deniedCtx, "workflow_update", createArgs("victim-workflow", "x_evil_tool"))
+		if err != nil {
+			t.Fatalf("ExecuteTool: %v", err)
+		}
+		if !result.IsError || !strings.Contains(resultText(t, result), "Permission denied") {
+			t.Fatalf("expected permission error on update, got: %s", resultText(t, result))
+		}
+		after, err := saClient.GetWorkflow(ctx, "victim-workflow", "default")
+		if err != nil {
+			t.Fatalf("get victim: %v", err)
+		}
+		if len(after.Spec.Steps) != 1 || after.Spec.Steps[0].Tool != "core_service_list" {
+			t.Fatalf("denied update still changed the spec: %+v", after.Spec)
+		}
+
+		result, err = adapter.ExecuteTool(deniedCtx, "workflow_delete",
+			map[string]interface{}{"name": "victim-workflow"})
+		if err != nil {
+			t.Fatalf("ExecuteTool: %v", err)
+		}
+		if !result.IsError || !strings.Contains(resultText(t, result), "Permission denied") {
+			t.Fatalf("expected permission error on delete, got: %s", resultText(t, result))
+		}
+		if _, err := saClient.GetWorkflow(ctx, "victim-workflow", "default"); err != nil {
+			t.Fatalf("denied delete still removed the CR: %v", err)
+		}
+	})
+}

--- a/internal/workflow/writes_as_caller_test.go
+++ b/internal/workflow/writes_as_caller_test.go
@@ -1,4 +1,4 @@
-package mcpserver
+package workflow
 
 import (
 	"context"
@@ -30,38 +30,32 @@ import (
 // must never fall back to the SA client for writes.
 type stubMusterClient struct {
 	client.MusterClient
-	existing *musterv1alpha1.MCPServer
+	existing *musterv1alpha1.Workflow
 	created  []string
 	updated  []string
 	deleted  []string
-
-	// filesystem flips the reported mode. It defaults to Kubernetes mode
-	// because every test in this file exercises the Kubernetes-mode write
-	// path; the mode now also decides whether a stdio definition is admitted
-	// at all (issue #1067).
-	filesystem bool
 }
 
-func (s *stubMusterClient) IsKubernetesMode() bool { return !s.filesystem }
+func (s *stubMusterClient) IsKubernetesMode() bool { return true }
 
-func (s *stubMusterClient) GetMCPServer(_ context.Context, name, namespace string) (*musterv1alpha1.MCPServer, error) {
+func (s *stubMusterClient) GetWorkflow(_ context.Context, name, namespace string) (*musterv1alpha1.Workflow, error) {
 	if s.existing != nil && s.existing.Name == name {
 		return s.existing.DeepCopy(), nil
 	}
-	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "muster.giantswarm.io", Resource: "mcpservers"}, name)
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "muster.giantswarm.io", Resource: "workflows"}, name)
 }
 
-func (s *stubMusterClient) CreateMCPServer(_ context.Context, obj *musterv1alpha1.MCPServer) error {
+func (s *stubMusterClient) CreateWorkflow(_ context.Context, obj *musterv1alpha1.Workflow) error {
 	s.created = append(s.created, obj.Name)
 	return nil
 }
 
-func (s *stubMusterClient) UpdateMCPServer(_ context.Context, obj *musterv1alpha1.MCPServer) error {
+func (s *stubMusterClient) UpdateWorkflow(_ context.Context, obj *musterv1alpha1.Workflow) error {
 	s.updated = append(s.updated, obj.Name)
 	return nil
 }
 
-func (s *stubMusterClient) DeleteMCPServer(_ context.Context, name, _ string) error {
+func (s *stubMusterClient) DeleteWorkflow(_ context.Context, name, _ string) error {
 	s.deleted = append(s.deleted, name)
 	return nil
 }
@@ -87,16 +81,15 @@ func testJWT(t *testing.T, aud interface{}) string {
 // records the bearer it was handed, and the returned client records writes
 // through interceptors (optionally failing them with injectErr).
 type callerHarness struct {
-	adapter     *Adapter
-	sa          *stubMusterClient
-	tokensSeen  []string
-	created     []string
-	updated     []string
-	updatedObjs []*musterv1alpha1.MCPServer
-	deleted     []string
+	adapter    *Adapter
+	sa         *stubMusterClient
+	tokensSeen []string
+	created    []string
+	updated    []string
+	deleted    []string
 }
 
-func newCallerHarness(t *testing.T, existing *musterv1alpha1.MCPServer, injectErr error) *callerHarness {
+func newCallerHarness(t *testing.T, existing *musterv1alpha1.Workflow, injectErr error) *callerHarness {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	utilruntime.Must(musterv1alpha1.AddToScheme(scheme))
@@ -111,14 +104,11 @@ func newCallerHarness(t *testing.T, existing *musterv1alpha1.MCPServer, injectEr
 			h.created = append(h.created, "create")
 			return nil
 		},
-		Update: func(_ context.Context, _ ctrlclient.WithWatch, obj ctrlclient.Object, _ ...ctrlclient.UpdateOption) error {
+		Update: func(context.Context, ctrlclient.WithWatch, ctrlclient.Object, ...ctrlclient.UpdateOption) error {
 			if injectErr != nil {
 				return injectErr
 			}
 			h.updated = append(h.updated, "update")
-			if server, ok := obj.(*musterv1alpha1.MCPServer); ok {
-				h.updatedObjs = append(h.updatedObjs, server.DeepCopy())
-			}
 			return nil
 		},
 		Delete: func(context.Context, ctrlclient.WithWatch, ctrlclient.Object, ...ctrlclient.DeleteOption) error {
@@ -130,7 +120,8 @@ func newCallerHarness(t *testing.T, existing *musterv1alpha1.MCPServer, injectEr
 		},
 	}).Build()
 
-	h.adapter = NewAdapterWithClient(h.sa, "test-ns")
+	h.adapter = NewAdapterWithClient(h.sa, "test-ns", nil, nil, "")
+	t.Cleanup(h.adapter.stopGC)
 	h.adapter.EnableWritesAsCaller(func(bearerToken string) (ctrlclient.Client, error) {
 		h.tokensSeen = append(h.tokensSeen, bearerToken)
 		return fakeClient, nil
@@ -146,13 +137,22 @@ func resultText(t *testing.T, result *api.CallToolResult) string {
 	return fmt.Sprintf("%v", result.Content[0])
 }
 
-func existingServer() *musterv1alpha1.MCPServer {
-	obj := &musterv1alpha1.MCPServer{}
-	obj.Name = "test-server"
+func existingWorkflow() *musterv1alpha1.Workflow {
+	obj := &musterv1alpha1.Workflow{}
+	obj.Name = "test-workflow"
 	obj.Namespace = "test-ns"
-	obj.Spec.Type = "streamable-http"
-	obj.Spec.URL = "http://example.com/mcp"
+	obj.Spec.Steps = []musterv1alpha1.WorkflowStep{{ID: "s1", Tool: "core_service_list"}}
 	return obj
+}
+
+// workflowArgs is a minimal valid workflow definition for create/update.
+func workflowArgs(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name": name,
+		"steps": []interface{}{
+			map[string]interface{}{"id": "s1", "tool": "core_service_list"},
+		},
+	}
 }
 
 // TestWritesAsCaller_IdentityReachesWrite is the regression guard against the
@@ -166,14 +166,14 @@ func TestWritesAsCaller_IdentityReachesWrite(t *testing.T) {
 		tool string
 		args map[string]interface{}
 	}{
-		{"mcpserver_create", map[string]interface{}{"name": "test-server", "type": "streamable-http", "url": "http://example.com/mcp"}},
-		{"mcpserver_update", map[string]interface{}{"name": "test-server", "url": "http://example.com/mcp2"}},
-		{"mcpserver_delete", map[string]interface{}{"name": "test-server"}},
+		{"workflow_create", workflowArgs("test-workflow")},
+		{"workflow_update", workflowArgs("test-workflow")},
+		{"workflow_delete", map[string]interface{}{"name": "test-workflow"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.tool, func(t *testing.T) {
-			h := newCallerHarness(t, existingServer(), nil)
+			h := newCallerHarness(t, existingWorkflow(), nil)
 			ctx := server.ContextWithIDToken(context.Background(), token)
 
 			result, err := h.adapter.ExecuteTool(ctx, tc.tool, tc.args)
@@ -203,11 +203,10 @@ func TestWritesAsCaller_MissingAudience(t *testing.T) {
 		"no-aud":           nil,
 	} {
 		t.Run(name, func(t *testing.T) {
-			h := newCallerHarness(t, existingServer(), nil)
+			h := newCallerHarness(t, existingWorkflow(), nil)
 			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, aud))
 
-			result, err := h.adapter.ExecuteTool(ctx, "mcpserver_create",
-				map[string]interface{}{"name": "test-server", "type": "streamable-http", "url": "http://example.com/mcp"})
+			result, err := h.adapter.ExecuteTool(ctx, "workflow_create", workflowArgs("test-workflow"))
 			if err != nil {
 				t.Fatalf("ExecuteTool: %v", err)
 			}
@@ -228,10 +227,10 @@ func TestWritesAsCaller_MissingAudience(t *testing.T) {
 }
 
 func TestWritesAsCaller_NoSessionToken(t *testing.T) {
-	h := newCallerHarness(t, existingServer(), nil)
+	h := newCallerHarness(t, existingWorkflow(), nil)
 
-	result, err := h.adapter.ExecuteTool(context.Background(), "mcpserver_delete",
-		map[string]interface{}{"name": "test-server"})
+	result, err := h.adapter.ExecuteTool(context.Background(), "workflow_delete",
+		map[string]interface{}{"name": "test-workflow"})
 	if err != nil {
 		t.Fatalf("ExecuteTool: %v", err)
 	}
@@ -242,22 +241,22 @@ func TestWritesAsCaller_NoSessionToken(t *testing.T) {
 
 func TestWritesAsCaller_ForbiddenMapsToPermissionError(t *testing.T) {
 	forbidden := apierrors.NewForbidden(
-		schema.GroupResource{Group: "muster.giantswarm.io", Resource: "mcpservers"},
-		"test-server", fmt.Errorf(`User "alice" cannot create resource "mcpservers"`))
+		schema.GroupResource{Group: "muster.giantswarm.io", Resource: "workflows"},
+		"test-workflow", fmt.Errorf(`User "alice" cannot create resource "workflows"`))
 
 	cases := []struct {
 		tool string
 		verb string
 		args map[string]interface{}
 	}{
-		{"mcpserver_create", "create", map[string]interface{}{"name": "test-server", "type": "streamable-http", "url": "http://example.com/mcp"}},
-		{"mcpserver_update", "update", map[string]interface{}{"name": "test-server", "url": "http://example.com/mcp2"}},
-		{"mcpserver_delete", "delete", map[string]interface{}{"name": "test-server"}},
+		{"workflow_create", "create", workflowArgs("test-workflow")},
+		{"workflow_update", "update", workflowArgs("test-workflow")},
+		{"workflow_delete", "delete", map[string]interface{}{"name": "test-workflow"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.tool, func(t *testing.T) {
-			h := newCallerHarness(t, existingServer(), forbidden)
+			h := newCallerHarness(t, existingWorkflow(), forbidden)
 			ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
 			result, err := h.adapter.ExecuteTool(ctx, tc.tool, tc.args)
@@ -268,7 +267,7 @@ func TestWritesAsCaller_ForbiddenMapsToPermissionError(t *testing.T) {
 				t.Fatal("expected a tool error on 403")
 			}
 			text := resultText(t, result)
-			for _, want := range []string{"Permission denied", tc.verb, "mcpservers.muster.giantswarm.io", `"test-ns"`, "mcpserver-editor"} {
+			for _, want := range []string{"Permission denied", tc.verb, "workflows.muster.giantswarm.io", `"test-ns"`, "workflow-editor"} {
 				if !strings.Contains(text, want) {
 					t.Errorf("403 mapping %q does not mention %q", text, want)
 				}
@@ -278,11 +277,10 @@ func TestWritesAsCaller_ForbiddenMapsToPermissionError(t *testing.T) {
 }
 
 func TestWritesAsCaller_UnauthorizedMapsToRelogin(t *testing.T) {
-	h := newCallerHarness(t, existingServer(), apierrors.NewUnauthorized("token expired"))
+	h := newCallerHarness(t, existingWorkflow(), apierrors.NewUnauthorized("token expired"))
 	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
-	result, err := h.adapter.ExecuteTool(ctx, "mcpserver_create",
-		map[string]interface{}{"name": "test-server", "type": "streamable-http", "url": "http://example.com/mcp"})
+	result, err := h.adapter.ExecuteTool(ctx, "workflow_create", workflowArgs("test-workflow"))
 	if err != nil {
 		t.Fatalf("ExecuteTool: %v", err)
 	}
@@ -291,33 +289,32 @@ func TestWritesAsCaller_UnauthorizedMapsToRelogin(t *testing.T) {
 	}
 }
 
-// TestWritesAsCaller_FlagOff pins the legacy behavior: with the flag off the
-// SA client performs the write even when the session carries a token.
+// TestWritesAsCaller_FlagOff pins the filesystem-mode behavior: with the gate
+// off the SA client performs the write even when the session carries a token.
 func TestWritesAsCaller_FlagOff(t *testing.T) {
-	sa := &stubMusterClient{existing: existingServer()}
-	adapter := NewAdapterWithClient(sa, "test-ns")
+	sa := &stubMusterClient{existing: existingWorkflow()}
+	adapter := NewAdapterWithClient(sa, "test-ns", nil, nil, "")
+	t.Cleanup(adapter.stopGC)
 	ctx := server.ContextWithIDToken(context.Background(), testJWT(t, callerwrite.DefaultKubernetesAudience))
 
-	result, err := adapter.ExecuteTool(ctx, "mcpserver_create",
-		map[string]interface{}{"name": "another-server", "type": "streamable-http", "url": "http://example.com/mcp"})
+	result, err := adapter.ExecuteTool(ctx, "workflow_create", workflowArgs("another-workflow"))
 	if err != nil {
 		t.Fatalf("ExecuteTool: %v", err)
 	}
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %s", resultText(t, result))
 	}
-	if len(sa.created) != 1 || sa.created[0] != "another-server" {
-		t.Fatalf("SA client did not perform the write with the flag off: %v", sa.created)
+	if len(sa.created) != 1 || sa.created[0] != "another-workflow" {
+		t.Fatalf("SA client did not perform the write with the gate off: %v", sa.created)
 	}
 }
 
 // TestWritesAsCaller_ValidateUntouched pins that validation stays available to
-// callers who cannot write: no token, flag on, validate still succeeds.
+// callers who cannot write: no token, gate on, validate still succeeds.
 func TestWritesAsCaller_ValidateUntouched(t *testing.T) {
 	h := newCallerHarness(t, nil, nil)
 
-	result, err := h.adapter.ExecuteTool(context.Background(), "mcpserver_validate",
-		map[string]interface{}{"name": "test-server", "type": "streamable-http", "url": "http://example.com/mcp"})
+	result, err := h.adapter.ExecuteTool(context.Background(), "workflow_validate", workflowArgs("test-workflow"))
 	if err != nil {
 		t.Fatalf("ExecuteTool: %v", err)
 	}


### PR DESCRIPTION
Fixes #1069

## What

`workflow_create` / `workflow_update` / `workflow_delete` bypassed the caller-identity gate that MCPServer writes got in #1060/#1061/#1064: the handlers received no `ctx` and wrote through muster's ServiceAccount with no authorization check. They now resolve the same gate — the session's dex id_token becomes the bearer of a per-call client, the apiserver authenticates the real user, k8s RBAC authorizes the write, and the audit log records the true subject.

- Sessions with no token or without the kubernetes audience get the same actionable re-login error as MCPServer writes; `workflow_validate` stays ungated, matching `mcpserver_validate`.
- 403s name the verb, resource, and namespace and point at the **`workflow-editor`** Role/RoleBinding the chart now ships, mirroring `mcpserver-editor` (bound to `system:authenticated` by default — same default-subjects decision, see #1070).
- The gate (token extraction, audience precheck, per-call client factory, 401/403 mapping) is extracted from `internal/mcpserver` into the shared **`internal/callerwrite`** package; the MCPServer adapter delegates to it, so both resources answer with identical errors.
- The mutation methods leave the `api.WorkflowHandler` interface — they must carry the calling session's identity, so they are reachable only through `ExecuteTool`, mirroring `MCPServerManagerHandler`.

## Bonus bug found by the new envtest

`workflow_update` sent a freshly-built object with no `resourceVersion`, which a real apiserver rejects for CRs (`metadata.resourceVersion: Invalid value: 0: must be specified for an update`) — **`core_workflow_update` was broken in Kubernetes mode all along**. It is now a get-modify-write: the read stays on the SA client (it carries the resourceVersion), only the spec write switches to the caller's identity, and conflicts with the status reconciler are retried on a fresh read.

## Audit of the other core_ tools

Checked every tool provider for CR mutations through the SA:

| Surface | Verdict |
| --- | --- |
| `core_mcpserver_*` create/update/delete | gated (#1060/#1064) |
| `core_service_start/stop/restart` on MCPServer-backed services | gated (#1061) |
| `core_workflow_*` create/update/delete | **this PR** |
| WorkflowExecution CRs | muster's own execution records/GC — correctly SA |
| status subresources | muster's own controllers — correctly SA |
| `core_config_*` | writes the local config file, no CR writes (read-only ConfigMap mount in k8s) |
| `core_events`, metatools, auth tools | no CR writes |

Workflow was the last session-triggered CR mutation surface writing as the SA.

## Testing

- Unit tests mirroring `internal/mcpserver/writes_as_caller_test.go`: identity reaches the write, missing audience / no token refused before any write, 403→permission error naming verb/resource/namespace/role, 401→re-login, gate off = SA path, validate untouched.
- `TestWritesAsCallerEnvtest` in `internal/workflow`: allowed/denied RBAC matrix against a real apiserver (wired into `make test-envtest`, which the existing CircleCI job runs). Verified locally: both packages PASS.
- Helm unittest for the `workflow-editor` template (5 cases). (`gateway_api`/`pdb` suites fail locally on main already — pre-existing, unrelated.)
- Behavioral scenarios: full `--concept workflow` (94/94) and `--concept mcpserver` (77/77) pass with a fresh build — filesystem mode unchanged. Per the #1064 precedent, the caller gate itself is not harness-expressible (the harness runs filesystem mode, no apiserver), so gate coverage lives in the unit tests + envtest.

BREAKING CHANGE: Kubernetes-mode installations now require sessions to carry the kubernetes audience (`dex-k8s-authenticator` by default) and users to hold the `workflow-editor` role (shipped by the chart, bound to `system:authenticated` by default) for workflow create/update/delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)