### PR TITLE
feat(reconciler): export MCPServer connection state as metrics and alert on sustained failure

### DIFF
--- a/.circleci/custom.yml
+++ b/.circleci/custom.yml
@@ -15,6 +15,10 @@
 #     real kube-apiserver from setup-envtest -- the generated go-build job
 #     only runs `make test`, so TestWritesAsCallerEnvtest self-skips there
 #     without KUBEBUILDER_ASSETS
+#   - the chart test job (chart-test), which runs the helm-unittest suites and
+#     the promtool alert-rule tests. Neither is reachable from `make test`:
+#     both need helm plugins and promtool, which the architect go image does
+#     not carry.
 version: 2.1
 
 jobs:
@@ -37,9 +41,50 @@ jobs:
         command: make test-envtest
     - architect/go-cache-save
 
+  # Chart checks: helm lint, the helm-unittest suites in helm/muster/tests/, and
+  # the promtool unit tests for the PrometheusRule. Runs in a plain container
+  # rather than the architect executor because the dependencies are helm plugins
+  # and a promtool binary, not Go tooling -- nothing here needs the Go cache or
+  # module auth. Pinned versions so a plugin release cannot turn CI red on an
+  # unrelated PR.
+  chart-test:
+    docker:
+      - image: cimg/base:current
+    resource_class: small
+    environment:
+      HELM_VERSION: v3.16.0
+      PROMETHEUS_VERSION: 3.6.0
+      YQ_VERSION: v4.44.6
+    steps:
+      - checkout
+      - run:
+          name: Install helm, promtool and yq
+          command: |
+            set -euxo pipefail
+            curl -sSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar -xz -C /tmp
+            sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
+            curl -sSL "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz" | tar -xz -C /tmp
+            sudo install -m 0755 "/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool" /usr/local/bin/promtool
+            # mikefarah/yq -- cimg/base ships no yq, and the python jq wrapper
+            # of the same name does not understand `yq eval`.
+            sudo curl -sSLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+            sudo chmod 0755 /usr/local/bin/yq
+            helm version --short && promtool --version && yq --version
+      - run:
+          name: Run chart tests
+          command: make helm-test
+
 workflows:
   build:
     jobs:
+    # ---- Chart checks. Independent of go-build: a chart-only PR gets the
+    #      signal without waiting on the Go matrix, and a Go-only PR still
+    #      proves the chart renders. Same tag filter as the other test jobs.
+    - chart-test:
+        filters:
+          tags:
+            only: /^v.*/
+
     # ---- envtest-backed RBAC integration test. Same filters as go-build
     #      (runs on every branch and on release tags) since it's a test job
     #      like go-build's own embedded `make test`, not a branch-only publish

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -8,6 +8,45 @@ helm-lint: ## Run Helm linter
 	@echo "Running Helm linter..."
 	@helm lint helm/muster/
 
+HELM_UNITTEST_VERSION := 1.0.3
+YQ_VERSION := v4.44.6
+
+# What CI runs (the chart-test job in .circleci/custom.yml). Deliberately not
+# the full helm-unittest suite: tests/pdb_test.yaml and tests/gateway_api_test.yaml
+# fail on main because values.schema.json rejects values those suites set
+# (free-form label/annotation maps, a percentage-string minAvailable, and an
+# undeclared maxUnavailable). Widen this to helm-test once those are fixed.
+.PHONY: helm-test
+helm-test: helm-lint helm-alerting-test ## Run the chart checks that pass today (what CI runs).
+
+.PHONY: helm-alerting-test
+helm-alerting-test: ## Run the PrometheusRule checks: its helm-unittest suite plus the promtool alert-rule tests.
+	@echo "Running PrometheusRule chart tests..."
+	@$(MAKE) --no-print-directory helm-plugin-unittest
+	@helm unittest helm/muster/ -f 'tests/prometheusrule_test.yaml'
+	@$(MAKE) --no-print-directory helm-promtool-test
+
+.PHONY: helm-test-all
+helm-test-all: helm-lint helm-unittest helm-promtool-test ## Run every chart check, including the suites that fail on main.
+
+.PHONY: helm-unittest
+helm-unittest: helm-plugin-unittest ## Run all helm-unittest suites in helm/muster/tests/.
+	@echo "Running helm unittest..."
+	@helm unittest helm/muster/
+
+.PHONY: helm-plugin-unittest
+helm-plugin-unittest:
+	@helm plugin list | grep -q '^unittest' || helm plugin install https://github.com/helm-unittest/helm-unittest --version $(HELM_UNITTEST_VERSION)
+
+# Separate from helm-unittest: the alert expressions need a PromQL engine to
+# say anything, and only promtool has one. helm-unittest can assert that the
+# rule renders; only this can assert that it fires when a backend breaks and
+# stays quiet when one is merely waiting for auth.
+.PHONY: helm-promtool-test
+helm-promtool-test: ## Run the promtool unit tests for the PrometheusRule (requires promtool and mikefarah/yq).
+	@echo "Running promtool alert rule tests..."
+	@bash helm/muster/tests/promtool/run.sh
+
 ##@ Testing
 
 # The architect go-build job runs `make test` (test_target: test). Extend that

--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -149,6 +149,8 @@ A Helm chart for muster - Universal Control Plane for AI Agents built on MCP
 | muster.observability.metrics.prometheus.serviceMonitor.enabled | bool | `false` |  |
 | muster.observability.metrics.prometheus.serviceMonitor.interval | string | `""` |  |
 | muster.observability.metrics.prometheus.serviceMonitor.labels | object | `{}` |  |
+| muster.observability.metrics.prometheus.prometheusRule.enabled | bool | `false` |  |
+| muster.observability.metrics.prometheus.prometheusRule.labels | object | `{}` |  |
 | crds.install | bool | `false` |  |
 | crds.annotations."helm.sh/resource-policy" | string | `"keep"` |  |
 | networkPolicy.enabled | bool | `false` |  |

--- a/helm/muster/templates/prometheusrule.yaml
+++ b/helm/muster/templates/prometheusrule.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.muster.observability.metrics.prometheus.prometheusRule.enabled }}
+# Alerts on muster's own view of its MCP backends.
+#
+# muster records every backend's connection state in MCPServer.status.state and
+# now exports it as muster_mcpserver_state; these rules are what turns that from
+# a field somebody has to run kubectl to see into something that pages. Before
+# them a backend could sit Failed indefinitely with the error text right there
+# in status.lastError and nothing would say so.
+#
+# Only "Failed" is alerted on. "Auth Required" is a normal steady state for
+# on-behalf-of servers with no active user session, and every server passes
+# through it briefly after a muster restart, so alerting on it would be pure
+# noise. The transitional states (Connecting, Starting) are covered by the
+# `for:` windows below rather than by being excluded.
+#
+# Gated on its own value rather than on the prometheus exporter: metrics may
+# reach the Prometheus that loads this rule via OTLP instead of a scrape, in
+# which case muster.observability.metrics.exporter never mentions prometheus.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "muster.fullname" . }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    {{- with .Values.muster.observability.metrics.prometheus.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: muster
+      rules:
+        # The window has to ride out a muster rollout: every MCPServer is
+        # re-reconciled from scratch after a restart, and a backend that is
+        # slow to answer its first handshake reads as Failed until it does.
+        # 20m is comfortably longer than a rollout plus initial connect
+        # backoff, and still two orders of magnitude below the ~2 days this
+        # went unnoticed for.
+        - alert: MusterMCPServerFailed
+          annotations:
+            description: '{{`MCPServer {{ $labels.mcpserver_namespace }}/{{ $labels.mcpserver_name }} has been in state Failed for 20m; the MCP backend is unreachable and its tools are unavailable to agents. The reason muster recorded is in the CR status.lastError field.`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-mcpserver-failed/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+          expr: |-
+            muster_mcpserver_state{state="Failed"} == 1
+          for: 20m
+          labels:
+            area: platform
+            cancel_if_monitoring_agent_down: "true"
+            cancel_if_outside_working_hours: "false"
+            severity: notify
+            team: bumblebee
+            topic: muster
+        # Steady-state Failed is not the only way a backend is broken: one that
+        # reconnects and drops every few minutes never satisfies the 20m window
+        # above, but is just as unusable. muster_mcpserver_state_transitions_total
+        # counts entries into each state, so the churn is visible even when no
+        # single scrape catches the server down.
+        #
+        # A muster restart contributes exactly one Failed transition per broken
+        # server, well under the threshold, so rollouts do not trip this.
+        - alert: MusterMCPServerFlapping
+          annotations:
+            description: '{{`MCPServer {{ $labels.mcpserver_namespace }}/{{ $labels.mcpserver_name }} entered state Failed {{ $value | printf "%.0f" }} times in the last hour; the MCP backend is connecting and dropping repeatedly.`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-mcpserver-failed/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+          expr: |-
+            increase(muster_mcpserver_state_transitions_total{state="Failed"}[1h]) > 5
+          for: 10m
+          labels:
+            area: platform
+            cancel_if_monitoring_agent_down: "true"
+            cancel_if_outside_working_hours: "false"
+            severity: notify
+            team: bumblebee
+            topic: muster
+{{- end }}

--- a/helm/muster/tests/prometheusrule_test.yaml
+++ b/helm/muster/tests/prometheusrule_test.yaml
@@ -1,0 +1,159 @@
+suite: PrometheusRule template tests
+templates:
+  - templates/prometheusrule.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # The rule is gated on its own value, not on the prometheus exporter: the
+  # metrics can reach the Prometheus that loads the rule over OTLP instead of a
+  # scrape. Enabling the ServiceMonitor alone must not pull the rule in either.
+  - it: renders nothing when only the ServiceMonitor is enabled
+    set:
+      muster.observability.metrics.exporter: "prometheus"
+      muster.observability.metrics.prometheus.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders without the prometheus exporter, for the OTLP remote-write path
+    set:
+      muster.observability.metrics.exporter: "otlp"
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: PrometheusRule
+      - equal:
+          path: apiVersion
+          value: monitoring.coreos.com/v1
+
+  - it: defines both MCPServer state alerts in one group
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.groups
+          count: 1
+      - equal:
+          path: spec.groups[0].name
+          value: muster
+      - lengthEqual:
+          path: spec.groups[0].rules
+          count: 2
+      - equal:
+          path: spec.groups[0].rules[0].alert
+          value: MusterMCPServerFailed
+      - equal:
+          path: spec.groups[0].rules[1].alert
+          value: MusterMCPServerFlapping
+
+  # The expression is the contract between the chart and internal/reconciler:
+  # the metric name and the label the reconciler emits the state under. If the
+  # Go side renames either, this test is what catches it.
+  - it: alerts on sustained Failed state with a rollout-proof window
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].expr
+          value: |-
+            muster_mcpserver_state{state="Failed"} == 1
+      - equal:
+          path: spec.groups[0].rules[0].for
+          value: 20m
+
+  - it: alerts on repeated transitions into Failed
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[1].expr
+          value: |-
+            increase(muster_mcpserver_state_transitions_total{state="Failed"}[1h]) > 5
+      - equal:
+          path: spec.groups[0].rules[1].for
+          value: 10m
+
+  # Auth Required is a normal steady state for on-behalf-of servers with no
+  # active user session, and every server shows it briefly after a restart.
+  # Alerting on it would be pure noise, so no expression may select it.
+  - it: never alerts on Auth Required or any other non-Failed state
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.groups[0].rules[0].expr
+          pattern: "Auth Required|Connecting|Disconnected|Stopped|Starting"
+      - notMatchRegex:
+          path: spec.groups[0].rules[1].expr
+          pattern: "Auth Required|Connecting|Disconnected|Stopped|Starting"
+
+  - it: carries the Giant Swarm routing labels on every alert
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].labels
+          value:
+            area: platform
+            cancel_if_monitoring_agent_down: "true"
+            cancel_if_outside_working_hours: "false"
+            severity: notify
+            team: bumblebee
+            topic: muster
+      - equal:
+          path: spec.groups[0].rules[1].labels
+          value:
+            area: platform
+            cancel_if_monitoring_agent_down: "true"
+            cancel_if_outside_working_hours: "false"
+            severity: notify
+            team: bumblebee
+            topic: muster
+
+  # An alert with a dead runbook link is half an alert. Both point at a runbook
+  # that exists in giantswarm/giantswarm, with the interactive-variable query
+  # string the intranet uses to prefill installation and cluster.
+  - it: points both alerts at the runbook
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].annotations.runbook_url
+          value: 'https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-mcpserver-failed/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}'
+      - equal:
+          path: spec.groups[0].rules[1].annotations.runbook_url
+          value: 'https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-mcpserver-failed/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}'
+
+  # The description has to name the offending MCPServer, and it has to use the
+  # prefixed labels the reconciler emits — a bare {{ $labels.namespace }} would
+  # silently render muster's own namespace after the Prometheus Operator
+  # overwrites target-metadata labels on scrape.
+  - it: names the MCPServer in both descriptions using the prefixed labels
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[0].annotations.description
+          pattern: '\{\{ \$labels\.mcpserver_namespace \}\}/\{\{ \$labels\.mcpserver_name \}\}'
+      - matchRegex:
+          path: spec.groups[0].rules[1].annotations.description
+          pattern: '\{\{ \$labels\.mcpserver_namespace \}\}/\{\{ \$labels\.mcpserver_name \}\}'
+
+  - it: applies extra labels for Prometheus ruleSelector matching
+    set:
+      muster.observability.metrics.prometheus.prometheusRule.enabled: true
+      muster.observability.metrics.prometheus.prometheusRule.labels:
+        prometheus: platform
+    asserts:
+      - equal:
+          path: metadata.labels.prometheus
+          value: platform
+      - equal:
+          path: metadata.labels["application.giantswarm.io/team"]
+          value: bumblebee

--- a/helm/muster/tests/promtool/prometheusrule.test.yaml
+++ b/helm/muster/tests/promtool/prometheusrule.test.yaml
@@ -1,0 +1,137 @@
+---
+# promtool unit tests for templates/prometheusrule.yaml.
+#
+# These assert the alerts' behaviour over time, which the helm-unittest suite in
+# ../prometheusrule_test.yaml cannot: that MusterMCPServerFailed holds off long
+# enough to ride out a rollout, that a recovered server does not fire, and above
+# all that "Auth Required" — the normal steady state for on-behalf-of servers
+# with no user session — is silent.
+#
+# `rule_files` points at the rendered+extracted rule groups that run.sh produces
+# (helm template | yq '.spec'). Run via:
+#   helm/muster/tests/promtool/run.sh
+rule_files:
+  - 'rendered.rules.yaml'
+
+tests:
+  # A backend stuck Failed: silent through a rollout-length window, fires after 20m.
+  - interval: 1m
+    input_series:
+      - series: 'muster_mcpserver_state{cluster_id="test", installation="test", mcpserver_name="mcp-kubernetes-test", mcpserver_namespace="agent-platform", state="Failed"}'
+        values: "1+0x40"
+    alert_rule_test:
+      - alertname: MusterMCPServerFailed
+        eval_time: 15m
+        exp_alerts: []
+      - alertname: MusterMCPServerFailed
+        eval_time: 25m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_outside_working_hours: "false"
+              cluster_id: test
+              installation: test
+              mcpserver_name: mcp-kubernetes-test
+              mcpserver_namespace: agent-platform
+              severity: notify
+              state: Failed
+              team: bumblebee
+              topic: muster
+            exp_annotations:
+              description: 'MCPServer agent-platform/mcp-kubernetes-test has been in state Failed for 20m; the MCP backend is unreachable and its tools are unavailable to agents. The reason muster recorded is in the CR status.lastError field.'
+              runbook_url: 'https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-mcpserver-failed/?INSTALLATION=test&CLUSTER=test'
+
+  # A healthy backend never fires, whatever the window.
+  - interval: 1m
+    input_series:
+      - series: 'muster_mcpserver_state{cluster_id="test", installation="test", mcpserver_name="dex-test", mcpserver_namespace="agent-platform", state="Connected"}'
+        values: "1+0x40"
+    alert_rule_test:
+      - alertname: MusterMCPServerFailed
+        eval_time: 35m
+        exp_alerts: []
+
+  # The noise case that makes or breaks this alert. An on-behalf-of server with
+  # no active user session sits in Auth Required indefinitely; alerting on it
+  # would page for normal operation, so it must stay silent forever.
+  - interval: 1m
+    input_series:
+      - series: 'muster_mcpserver_state{cluster_id="test", installation="test", mcpserver_name="obo-server", mcpserver_namespace="agent-platform", state="Auth Required"}'
+        values: "1+0x120"
+    alert_rule_test:
+      - alertname: MusterMCPServerFailed
+        eval_time: 115m
+        exp_alerts: []
+      - alertname: MusterMCPServerFlapping
+        eval_time: 115m
+        exp_alerts: []
+
+  # Transitional states after a restart are equally silent: Connecting for a
+  # while, then Connected. The asynchronous gauge stops exporting the old state,
+  # so the Failed series simply ends rather than going to 0.
+  - interval: 1m
+    input_series:
+      - series: 'muster_mcpserver_state{cluster_id="test", installation="test", mcpserver_name="restarting-server", mcpserver_namespace="agent-platform", state="Connecting"}'
+        values: "1+0x5 _x35"
+      - series: 'muster_mcpserver_state{cluster_id="test", installation="test", mcpserver_name="restarting-server", mcpserver_namespace="agent-platform", state="Connected"}'
+        values: "_x6 1+0x34"
+    alert_rule_test:
+      - alertname: MusterMCPServerFailed
+        eval_time: 35m
+        exp_alerts: []
+
+  # A backend that fails then recovers inside the window: never fires. This is
+  # what the 20m `for:` buys — a slow first handshake after a rollout is not an
+  # incident.
+  - interval: 1m
+    input_series:
+      - series: 'muster_mcpserver_state{cluster_id="test", installation="test", mcpserver_name="slow-starter", mcpserver_namespace="agent-platform", state="Failed"}'
+        values: "1+0x10 _x30"
+      - series: 'muster_mcpserver_state{cluster_id="test", installation="test", mcpserver_name="slow-starter", mcpserver_namespace="agent-platform", state="Connected"}'
+        values: "_x11 1+0x29"
+    alert_rule_test:
+      - alertname: MusterMCPServerFailed
+        eval_time: 35m
+        exp_alerts: []
+
+  # Flapping: the gauge alert cannot see this, because no single 20m window has
+  # the server continuously Failed. The transition counter can. One entry into
+  # Failed per minute is far past the threshold of 5 per hour.
+  - interval: 1m
+    input_series:
+      - series: 'muster_mcpserver_state_transitions_total{cluster_id="test", installation="test", mcpserver_name="flapper", mcpserver_namespace="agent-platform", state="Failed"}'
+        values: "0+1x120"
+    alert_rule_test:
+      - alertname: MusterMCPServerFlapping
+        eval_time: 70m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_outside_working_hours: "false"
+              cluster_id: test
+              installation: test
+              mcpserver_name: flapper
+              mcpserver_namespace: agent-platform
+              severity: notify
+              state: Failed
+              team: bumblebee
+              topic: muster
+            exp_annotations:
+              description: 'MCPServer agent-platform/flapper entered state Failed 60 times in the last hour; the MCP backend is connecting and dropping repeatedly.'
+              runbook_url: 'https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-mcpserver-failed/?INSTALLATION=test&CLUSTER=test'
+
+  # A single restart contributes exactly one Failed transition per broken
+  # server. That must not read as flapping, or every rollout would alert.
+  - interval: 1m
+    input_series:
+      - series: 'muster_mcpserver_state_transitions_total{cluster_id="test", installation="test", mcpserver_name="restart-once", mcpserver_namespace="agent-platform", state="Failed"}'
+        values: "0+0x10 1+0x110"
+    alert_rule_test:
+      - alertname: MusterMCPServerFlapping
+        eval_time: 70m
+        exp_alerts: []
+      - alertname: MusterMCPServerFlapping
+        eval_time: 115m
+        exp_alerts: []

--- a/helm/muster/tests/promtool/run.sh
+++ b/helm/muster/tests/promtool/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Renders templates/prometheusrule.yaml, extracts the bare rule groups (promtool
+# wants `groups:`, not the PrometheusRule CRD wrapper), and runs the promtool
+# unit tests against them. Requires: helm, yq, promtool.
+#
+# These tests live outside the helm-unittest suite in ../ on purpose: that
+# directory is globbed as tests/*_test.yaml by `helm unittest`, and the two
+# frameworks share neither a schema nor a runner.
+
+# mikefarah/yq, not the similarly named python jq wrapper -- the `eval` syntax
+# below is specific to it, and the wrapper fails with a confusing argparse error.
+if ! yq --version 2>&1 | grep -q 'mikefarah/yq'; then
+  echo "error: mikefarah/yq is required (see https://github.com/mikefarah/yq)" >&2
+  exit 1
+fi
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+chart="$here/../.."
+rendered="$here/rendered.rules.yaml"
+
+trap 'rm -f "$rendered"' EXIT
+
+helm template muster "$chart" \
+  --set muster.observability.metrics.prometheus.prometheusRule.enabled=true \
+  --show-only templates/prometheusrule.yaml \
+  | yq eval '.spec' - > "$rendered"
+
+promtool check rules "$rendered"
+promtool test rules "$here/prometheusrule.test.yaml"

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -444,6 +444,19 @@
                                         "port": {
                                             "type": "integer"
                                         },
+                                        "prometheusRule": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "enabled": {
+                                                    "type": "boolean"
+                                                },
+                                                "labels": {
+                                                    "type": "object",
+                                                    "additionalProperties": true
+                                                }
+                                            }
+                                        },
                                         "serviceMonitor": {
                                             "type": "object",
                                             "additionalProperties": false,

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -699,6 +699,20 @@ muster:
           # selecting the right Prometheus instance in a multi-tenant
           # cluster.
           labels: {}  # @schema additionalProperties: true
+        # PrometheusRule with the MCPServer connection-state alerts
+        # (MusterMCPServerFailed, MusterMCPServerFlapping). Fires on
+        # muster's own muster_mcpserver_state /
+        # muster_mcpserver_state_transitions_total metrics, so the
+        # Prometheus that loads the rule has to be receiving them —
+        # either by scraping the endpoint above, or via OTLP to a
+        # remote-write target. Gated separately from serviceMonitor so
+        # the OTLP path can have rules without a local scrape.
+        prometheusRule:
+          enabled: false
+          # Extra labels applied to the PrometheusRule — on
+          # Prometheus-Operator clusters this is how a rule is matched
+          # to the right Prometheus instance (ruleSelector).
+          labels: {}  # @schema additionalProperties: true
 
 # CRD ownership. The muster application chart ships the MCPServer and Workflow
 # CustomResourceDefinitions in the Helm 3 `crds/` directory (helm/muster/crds/),

--- a/internal/reconciler/manager.go
+++ b/internal/reconciler/manager.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -495,6 +496,25 @@ func (m *Manager) Stop() error {
 
 	// Wait for workers
 	m.wg.Wait()
+
+	// Release per-reconciler resources. Only reconcilers that hold something
+	// beyond their own memory implement io.Closer (the MCPServer reconciler
+	// holds an OTel metric callback registration).
+	m.mu.RLock()
+	reconcilers := make([]Reconciler, 0, len(m.reconcilers))
+	for _, reconciler := range m.reconcilers {
+		reconcilers = append(reconcilers, reconciler)
+	}
+	m.mu.RUnlock()
+	for _, reconciler := range reconcilers {
+		closer, ok := reconciler.(io.Closer)
+		if !ok {
+			continue
+		}
+		if err := closer.Close(); err != nil {
+			logging.Error("ReconcileManager", err, "Error closing reconciler")
+		}
+	}
 
 	logging.Info("ReconcileManager", "Reconciliation manager stopped")
 	return nil

--- a/internal/reconciler/mcpserver_reconciler.go
+++ b/internal/reconciler/mcpserver_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/pkg/logging"
+	"github.com/giantswarm/muster/pkg/observability"
 )
 
 // MCPServerManager is an interface for accessing MCPServer definitions.
@@ -61,6 +63,10 @@ type MCPServerReconciler struct {
 	// muster is down degrades to autoStart semantics, same as any stopped
 	// service across a restart.
 	suspended map[string]bool
+
+	// stateMetrics publishes status.state as OTel metrics so a server stuck in
+	// Failed is alertable, not just visible to whoever runs kubectl.
+	stateMetrics *mcpServerStateMetrics
 }
 
 // NewMCPServerReconciler creates a new MCPServer reconciler.
@@ -75,7 +81,15 @@ func NewMCPServerReconciler(
 		mcpServerManager: mcpServerManager,
 		serviceRegistry:  serviceRegistry,
 		suspended:        make(map[string]bool),
+		stateMetrics:     newMCPServerStateMetrics(otel.Meter(observability.TracerName)),
 	}
+}
+
+// Close releases the reconciler's metric callback registration. It is called by
+// Manager.Stop via the io.Closer type assertion; a reconciler that is never
+// registered with a Manager does not need it (the process is exiting).
+func (r *MCPServerReconciler) Close() error {
+	return r.stateMetrics.close()
 }
 
 // WithStatusUpdater sets the status updater for syncing status back to CRDs.
@@ -142,6 +156,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ReconcileReques
 	if rejectErr := api.ValidateStdioAllowed(mcpServerInfo.Type, r.isKubernetesMode()); rejectErr != nil {
 		result := r.reconcileReject(req, rejectErr, exists)
 		r.syncStatus(ctx, req.Name, req.Namespace, result.Error, nil)
+		r.recordState(ctx, req, mcpServerInfo.Type, result.Error)
 		return result
 	}
 
@@ -192,6 +207,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ReconcileReques
 
 	// Sync status back to CRD after reconciliation
 	r.syncStatus(ctx, req.Name, req.Namespace, result.Error, processedRestart)
+	r.recordState(ctx, req, mcpServerInfo.Type, result.Error)
 
 	// If reconciliation succeeded, schedule periodic requeue for status sync.
 	// This implements the idiomatic Kubernetes controller pattern where status
@@ -273,16 +289,14 @@ func (r *MCPServerReconciler) applyStatusFromService(server *musterv1alpha1.MCPS
 		server.Status.LastRestartedAt = &t
 	}
 
+	// Set State based on infrastructure state and server type. State
+	// terminology differs based on server type (stdio vs remote).
+	server.Status.State = r.observedState(name, server.Spec.Type, reconcileErr)
+
 	// Get the current service state
 	service, exists := r.serviceRegistry.Get(name)
 
 	if exists {
-		state := service.GetState()
-
-		// Set State based on infrastructure state and server type
-		// State terminology differs based on server type (stdio vs remote)
-		server.Status.State = r.determineState(state, server.Spec.Type)
-
 		if service.GetLastError() != nil {
 			// Sanitize error message to remove sensitive data before CRD exposure
 			// Note: Per-user auth errors are tracked in Session Registry, not here
@@ -292,31 +306,64 @@ func (r *MCPServerReconciler) applyStatusFromService(server *musterv1alpha1.MCPS
 		}
 
 		// Update LastConnected if service is running/connected
-		if api.IsActiveState(state) {
+		if api.IsActiveState(service.GetState()) {
 			now := metav1.NewTime(time.Now())
 			server.Status.LastConnected = &now
 		}
 
-	} else {
-		// Service doesn't exist - use appropriate initial state based on server type
-		isRemote := server.Spec.Type == "streamable-http" || server.Spec.Type == "sse"
-		if isRemote {
-			server.Status.State = musterv1alpha1.MCPServerStateDisconnected
-		} else {
-			server.Status.State = musterv1alpha1.MCPServerStateStopped
-		}
-		if reconcileErr != nil {
-			// Sanitize error message to remove sensitive data before CRD exposure
-			server.Status.LastError = SanitizeErrorMessage(reconcileErr.Error())
-			// A definition muster refuses to run will never start, so it reads
-			// as Failed rather than as a server merely not started yet
-			// (issue #1067). Transient reconcile errors keep the stopped /
-			// disconnected reading and are retried.
-			if errors.Is(reconcileErr, api.ErrStdioNotAllowedInKubernetesMode) {
-				server.Status.State = musterv1alpha1.MCPServerStateFailed
-			}
-		}
+	} else if reconcileErr != nil {
+		// Sanitize error message to remove sensitive data before CRD exposure
+		server.Status.LastError = SanitizeErrorMessage(reconcileErr.Error())
 	}
+}
+
+// observedState derives the state the reconciler currently sees for one
+// MCPServer.
+//
+// This is the single decision site for status.state: applyStatusFromService
+// writes its result to the CRD and recordState reports it as a metric, so the
+// alert can never disagree with what `kubectl get mcpserver` shows. It takes
+// the server type as an argument rather than reading a CRD object, because the
+// metric is also recorded in filesystem mode, where there is no CRD to sync
+// status to.
+func (r *MCPServerReconciler) observedState(name, serverType string, reconcileErr error) musterv1alpha1.MCPServerStateValue {
+	if service, exists := r.serviceRegistry.Get(name); exists {
+		return r.determineState(service.GetState(), serverType)
+	}
+
+	// Service doesn't exist - use appropriate initial state based on server type.
+	// A definition muster refuses to run will never start, so it reads as Failed
+	// rather than as a server merely not started yet (issue #1067). Transient
+	// reconcile errors keep the stopped / disconnected reading and are retried.
+	if reconcileErr != nil && errors.Is(reconcileErr, api.ErrStdioNotAllowedInKubernetesMode) {
+		return musterv1alpha1.MCPServerStateFailed
+	}
+	if serverType == "streamable-http" || serverType == "sse" {
+		return musterv1alpha1.MCPServerStateDisconnected
+	}
+	return musterv1alpha1.MCPServerStateStopped
+}
+
+// recordState publishes the reconciler's view of one MCPServer's state as a
+// metric.
+//
+// Called alongside every syncStatus so the gauge tracks the CRD status field,
+// but unconditionally: syncStatus returns early without a StatusUpdater
+// (filesystem mode), where the metric is the only external view of state there
+// is.
+func (r *MCPServerReconciler) recordState(ctx context.Context, req ReconcileRequest, serverType string, reconcileErr error) {
+	r.stateMetrics.record(ctx, r.metricKey(req), r.observedState(req.Name, serverType, reconcileErr))
+}
+
+// metricKey builds the metric identity for a reconcile request, falling back to
+// the reconciler's configured namespace so the attribute is never empty (the
+// filesystem change detector does not set one).
+func (r *MCPServerReconciler) metricKey(req ReconcileRequest) stateKey {
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = r.Namespace
+	}
+	return stateKey{name: req.Name, namespace: namespace}
 }
 
 // determineState converts service state to MCPServer State using context-appropriate terminology.
@@ -657,6 +704,12 @@ func (r *MCPServerReconciler) reconcileDelete(ctx context.Context, req Reconcile
 	logging.Info("MCPServerReconciler", "Deleting MCPServer service: %s", req.Name)
 
 	r.clearSuspended(req.Name)
+
+	// Stop reporting state for a resource that no longer exists, so a Failed
+	// server that is deleted rather than fixed does not keep an alert firing.
+	// Done before the early returns below: every path out of here means the
+	// definition is gone.
+	r.stateMetrics.forget(r.metricKey(req))
 
 	// Check if service exists
 	_, exists := r.serviceRegistry.Get(req.Name)

--- a/internal/reconciler/mcpserver_state_metrics.go
+++ b/internal/reconciler/mcpserver_state_metrics.go
@@ -1,0 +1,199 @@
+package reconciler
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// Metric attribute keys for the MCPServer state instruments.
+const (
+	// attrMCPServerName and attrMCPServerNamespace identify a single MCPServer.
+	//
+	// Deliberately not the bare "namespace": with a Prometheus Operator
+	// ServiceMonitor, target metadata labels (namespace, pod, service, ...)
+	// win over metric-borne labels of the same name unless honorLabels is set,
+	// and the metric's own value is renamed to "exported_namespace". Prefixing
+	// keeps the label the alert expressions select on stable regardless of how
+	// the endpoint is scraped.
+	attrMCPServerName      = "mcpserver.name"
+	attrMCPServerNamespace = "mcpserver.namespace"
+
+	// attrMCPServerState carries MCPServer.status.state verbatim, spaces
+	// included ("Auth Required"), so a label value can be compared against
+	// `kubectl get mcpserver` output without translation.
+	attrMCPServerState = "state"
+)
+
+// stateKey identifies one MCPServer.
+type stateKey struct {
+	name      string
+	namespace string
+}
+
+// mcpServerStateMetrics publishes the reconciler's view of
+// MCPServer.status.state as OpenTelemetry metrics:
+//
+//   - muster.mcpserver.state (observable gauge) — 1 for the current state of
+//     every MCPServer the reconciler has reconciled, with attributes
+//     mcpserver.name, mcpserver.namespace and state. Exported through the
+//     Prometheus exporter this becomes
+//     muster_mcpserver_state{mcpserver_name, mcpserver_namespace, state}.
+//   - muster.mcpserver.state_transitions (counter) — one increment per state
+//     change, same attributes, where state is the state being entered.
+//     Becomes muster_mcpserver_state_transitions_total.
+//
+// The gauge is asynchronous on purpose. Only the attribute sets observed during
+// a collection cycle are exported (the SDK aggregates observable gauges with
+// PrecomputedLastValue, which clears its values on every collection), so a
+// deleted MCPServer stops reporting as soon as forget() drops it instead of
+// pinning an alert on a series that no longer has a resource behind it. A
+// synchronous gauge or a per-state boolean would keep the last written value
+// forever, which is exactly the stale-alert failure mode to avoid.
+//
+// A single gauge carrying the state as an attribute is used rather than one
+// boolean gauge per state: at any collection each MCPServer contributes exactly
+// one series, so the previous state's series disappears on its own and the
+// alert expression stays a plain equality match on the state label.
+//
+// The two instruments answer different questions. The gauge shows sustained
+// breakage (what is broken right now, and for how long), the counter shows
+// churn — a server that fails and recovers every few minutes never satisfies a
+// `for:` window on the gauge but is obvious in the transition rate.
+type mcpServerStateMetrics struct {
+	// mu guards states. It is taken by both the reconcile path (record,
+	// forget) and the metric collection callback (observe).
+	mu     sync.Mutex
+	states map[stateKey]musterv1alpha1.MCPServerStateValue
+
+	// gauge and transitions are nil when instrument creation failed. Metrics
+	// are best effort: muster must reconcile MCPServers whether or not it can
+	// report on them.
+	gauge        metric.Int64ObservableGauge
+	transitions  metric.Int64Counter
+	registration metric.Registration
+}
+
+// newMCPServerStateMetrics creates the MCPServer state instruments on meter and
+// registers the gauge callback.
+//
+// The meter is a parameter rather than resolved from otel.Meter here so tests
+// can collect from a reader of their own without swapping the global
+// MeterProvider — the global one delegates instruments created before a
+// provider is installed, which would pull every other reconciler in the
+// process into the test's reader.
+//
+// Instrument or callback registration failures are logged and degrade to a
+// no-op recorder rather than failing reconciler construction. When no metric
+// exporter is configured the global provider is a no-op and every call here
+// succeeds cheaply.
+func newMCPServerStateMetrics(meter metric.Meter) *mcpServerStateMetrics {
+	m := &mcpServerStateMetrics{
+		states: make(map[stateKey]musterv1alpha1.MCPServerStateValue),
+	}
+
+	transitions, err := meter.Int64Counter("muster.mcpserver.state_transitions",
+		metric.WithDescription("Number of MCPServer state transitions observed by the reconciler, labelled with the state entered."),
+		metric.WithUnit("{transition}"),
+	)
+	if err != nil {
+		logging.Warn("MCPServerReconciler", "create muster.mcpserver.state_transitions counter: %v", err)
+	} else {
+		m.transitions = transitions
+	}
+
+	gauge, err := meter.Int64ObservableGauge("muster.mcpserver.state",
+		metric.WithDescription("Current state of each MCPServer known to the reconciler: 1 for the state the MCPServer is in, no series for the states it is not in."),
+	)
+	if err != nil {
+		logging.Warn("MCPServerReconciler", "create muster.mcpserver.state gauge: %v", err)
+		return m
+	}
+	m.gauge = gauge
+
+	registration, err := meter.RegisterCallback(m.observe, gauge)
+	if err != nil {
+		logging.Warn("MCPServerReconciler", "register muster.mcpserver.state callback: %v", err)
+		m.gauge = nil
+		return m
+	}
+	m.registration = registration
+
+	return m
+}
+
+// observe reports the current state of every known MCPServer. Called by the
+// SDK on each metric collection.
+func (m *mcpServerStateMetrics) observe(_ context.Context, observer metric.Observer) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for key, state := range m.states {
+		observer.ObserveInt64(m.gauge, 1, metric.WithAttributes(
+			attribute.String(attrMCPServerName, key.name),
+			attribute.String(attrMCPServerNamespace, key.namespace),
+			attribute.String(attrMCPServerState, string(state)),
+		))
+	}
+	return nil
+}
+
+// record stores the state the reconciler observed for one MCPServer and counts
+// a transition when it differs from the previous observation.
+//
+// Safe to call repeatedly with an unchanged state — the periodic status resync
+// does exactly that, and the retry-on-conflict loop in syncStatus can re-derive
+// the same state several times for one reconcile pass. Only changes are counted.
+//
+// The first observation of an MCPServer counts as a transition into its initial
+// state, so a server that comes up broken is visible in the counter and not
+// only in the gauge. One increment per server per muster restart is well below
+// any sensible flapping threshold.
+func (m *mcpServerStateMetrics) record(ctx context.Context, key stateKey, state musterv1alpha1.MCPServerStateValue) {
+	m.mu.Lock()
+	previous, known := m.states[key]
+	m.states[key] = state
+	m.mu.Unlock()
+
+	if known && previous == state {
+		return
+	}
+	if m.transitions == nil {
+		return
+	}
+	m.transitions.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(attrMCPServerName, key.name),
+		attribute.String(attrMCPServerNamespace, key.namespace),
+		attribute.String(attrMCPServerState, string(state)),
+	))
+}
+
+// forget drops an MCPServer from the gauge, so a deleted resource stops
+// reporting from the next collection onwards.
+//
+// The transition counter is intentionally left alone: it is cumulative, and
+// deleting its series would make a recreate look like it had never failed.
+func (m *mcpServerStateMetrics) forget(key stateKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.states, key)
+}
+
+// close unregisters the gauge callback. Idempotent.
+func (m *mcpServerStateMetrics) close() error {
+	m.mu.Lock()
+	registration := m.registration
+	m.registration = nil
+	m.mu.Unlock()
+
+	if registration == nil {
+		return nil
+	}
+	return registration.Unregister()
+}

--- a/internal/reconciler/mcpserver_state_metrics_test.go
+++ b/internal/reconciler/mcpserver_state_metrics_test.go
@@ -1,0 +1,339 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+// metricHarness drives the reconciler against a real SDK MeterProvider with a
+// ManualReader, so assertions run against the datapoints an exporter would see
+// rather than against the reconciler's internal map.
+type metricHarness struct {
+	t          *testing.T
+	reader     *metric.ManualReader
+	reconciler *MCPServerReconciler
+	manager    *MockMCPServerManager
+	registry   *MockServiceRegistry
+}
+
+// newMetricHarness builds a reconciler whose instruments live on a private
+// MeterProvider.
+//
+// The global provider is deliberately left alone. otel's global handle
+// delegates instruments and callbacks created before a provider is installed,
+// so calling otel.SetMeterProvider here would retro-register every reconciler
+// built by every other test in this package onto this reader.
+func newMetricHarness(t *testing.T) *metricHarness {
+	t.Helper()
+
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	manager := NewMockMCPServerManager()
+	registry := NewMockServiceRegistry()
+	reconciler := NewMCPServerReconciler(NewMockOrchestratorAPI(), manager, registry)
+
+	// Swap the constructor's global-meter instruments for ones on the private
+	// provider, releasing the global callback registration first.
+	if err := reconciler.Close(); err != nil {
+		t.Fatalf("release global metric registration: %v", err)
+	}
+	reconciler.stateMetrics = newMCPServerStateMetrics(provider.Meter("test"))
+	t.Cleanup(func() { _ = reconciler.Close() })
+
+	return &metricHarness{
+		t:          t,
+		reader:     reader,
+		reconciler: reconciler,
+		manager:    manager,
+		registry:   registry,
+	}
+}
+
+// addServer registers an MCPServer definition. A nil state means the service
+// was never created, modelling a server that has never connected.
+func (h *metricHarness) addServer(name, serverType string, state *api.ServiceState) {
+	h.t.Helper()
+	h.manager.AddMCPServer(&api.MCPServerInfo{Name: name, Type: serverType})
+	if state != nil {
+		h.registry.AddService(name, &MockServiceInfo{
+			Name:        name,
+			ServiceType: api.TypeMCPServer,
+			State:       *state,
+		})
+	}
+}
+
+func (h *metricHarness) reconcile(name string) {
+	h.t.Helper()
+	h.reconciler.Reconcile(context.Background(), ReconcileRequest{
+		Type:      ResourceTypeMCPServer,
+		Name:      name,
+		Namespace: "muster-test",
+	})
+}
+
+// states collects the muster.mcpserver.state gauge as name -> state label. A
+// server absent from the result is not reporting at all.
+func (h *metricHarness) states() map[string]string {
+	h.t.Helper()
+	return h.collect("muster.mcpserver.state")
+}
+
+// transitionCounts collects muster.mcpserver.state_transitions as
+// "<name>/<state>" -> count.
+func (h *metricHarness) transitionCounts() map[string]int64 {
+	h.t.Helper()
+
+	var collected metricdata.ResourceMetrics
+	if err := h.reader.Collect(context.Background(), &collected); err != nil {
+		h.t.Fatalf("collect metrics: %v", err)
+	}
+
+	counts := make(map[string]int64)
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "muster.mcpserver.state_transitions" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				h.t.Fatalf("muster.mcpserver.state_transitions is %T, want Sum[int64]", m.Data)
+			}
+			for _, point := range sum.DataPoints {
+				name, _ := point.Attributes.Value(attrMCPServerName)
+				state, _ := point.Attributes.Value(attrMCPServerState)
+				counts[name.String()+"/"+state.String()] += point.Value
+			}
+		}
+	}
+	return counts
+}
+
+// collect returns name -> state for the named gauge, failing on a duplicate
+// series for one server: exactly one state must be reported per MCPServer.
+func (h *metricHarness) collect(instrument string) map[string]string {
+	h.t.Helper()
+
+	var collected metricdata.ResourceMetrics
+	if err := h.reader.Collect(context.Background(), &collected); err != nil {
+		h.t.Fatalf("collect metrics: %v", err)
+	}
+
+	states := make(map[string]string)
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != instrument {
+				continue
+			}
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			if !ok {
+				h.t.Fatalf("%s is %T, want Gauge[int64]", instrument, m.Data)
+			}
+			for _, point := range gauge.DataPoints {
+				name, _ := point.Attributes.Value(attrMCPServerName)
+				state, _ := point.Attributes.Value(attrMCPServerState)
+				namespace, _ := point.Attributes.Value(attrMCPServerNamespace)
+
+				if namespace.String() != "muster-test" {
+					h.t.Errorf("%s: %s has namespace %q, want muster-test", instrument, name.String(), namespace.String())
+				}
+				if point.Value != 1 {
+					h.t.Errorf("%s: %s has value %d, want 1", instrument, name.String(), point.Value)
+				}
+				if existing, dup := states[name.String()]; dup {
+					h.t.Errorf("%s: %s reported twice (%q and %q); exactly one state per MCPServer expected",
+						instrument, name.String(), existing, state.String())
+				}
+				states[name.String()] = state.String()
+			}
+		}
+	}
+	return states
+}
+
+func statePtr(state api.ServiceState) *api.ServiceState { return &state }
+
+// TestStateGaugeReportsEveryKnownServer is the core of the detection gap this
+// metric closes: a remote server whose endpoint is unreachable must be visible
+// as Failed, alongside healthy servers and servers that never connected.
+func TestStateGaugeReportsEveryKnownServer(t *testing.T) {
+	h := newMetricHarness(t)
+
+	h.addServer("healthy-remote", "streamable-http", statePtr(api.StateRunning))
+	h.addServer("broken-remote", "streamable-http", statePtr(api.StateFailed))
+	h.addServer("unreachable-remote", "streamable-http", statePtr(api.StateUnreachable))
+	h.addServer("waiting-on-auth", "streamable-http", statePtr(api.StateAuthRequired))
+	// No service entry: a definition the orchestrator has never started.
+	h.addServer("never-connected", "streamable-http", nil)
+
+	for _, name := range []string{"healthy-remote", "broken-remote", "unreachable-remote", "waiting-on-auth", "never-connected"} {
+		h.reconcile(name)
+	}
+
+	want := map[string]string{
+		"healthy-remote":     string(musterv1alpha1.MCPServerStateConnected),
+		"broken-remote":      string(musterv1alpha1.MCPServerStateFailed),
+		"unreachable-remote": string(musterv1alpha1.MCPServerStateFailed),
+		"waiting-on-auth":    string(musterv1alpha1.MCPServerStateAuthRequired),
+		"never-connected":    string(musterv1alpha1.MCPServerStateDisconnected),
+	}
+	got := h.states()
+	if len(got) != len(want) {
+		t.Fatalf("gauge reported %d servers (%v), want %d", len(got), got, len(want))
+	}
+	for name, state := range want {
+		if got[name] != state {
+			t.Errorf("%s reported as %q, want %q", name, got[name], state)
+		}
+	}
+}
+
+// TestStateGaugeMatchesCRDStatus pins the metric to the CRD field it is meant
+// to mirror. If the two ever disagree, an alert can fire for a state nobody can
+// see with kubectl, or stay silent for one they can.
+func TestStateGaugeMatchesCRDStatus(t *testing.T) {
+	h := newMetricHarness(t)
+
+	updater := NewMockStatusUpdater()
+	h.reconciler.WithStatusUpdater(updater, "muster-test")
+
+	h.addServer("broken-remote", "streamable-http", statePtr(api.StateFailed))
+	updater.AddMCPServer(&musterv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "broken-remote", Namespace: "muster-test"},
+		Spec:       musterv1alpha1.MCPServerSpec{Type: "streamable-http"},
+	})
+
+	h.reconcile("broken-remote")
+
+	written := updater.GetLastUpdatedMCPServer()
+	if written == nil {
+		t.Fatal("reconciler did not write MCPServer status")
+	}
+	if got := h.states()["broken-remote"]; got != string(written.Status.State) {
+		t.Errorf("gauge reports %q but status.state is %q", got, written.Status.State)
+	}
+	if written.Status.State != musterv1alpha1.MCPServerStateFailed {
+		t.Errorf("status.state is %q, want Failed", written.Status.State)
+	}
+}
+
+// TestStateGaugeFollowsTransitions checks a server only ever reports its
+// current state — the previous state's series must not linger, or a recovered
+// server would keep a Failed alert firing.
+func TestStateGaugeFollowsTransitions(t *testing.T) {
+	h := newMetricHarness(t)
+
+	h.addServer("flapper", "streamable-http", statePtr(api.StateFailed))
+	h.reconcile("flapper")
+	if got := h.states()["flapper"]; got != string(musterv1alpha1.MCPServerStateFailed) {
+		t.Fatalf("after failure, gauge reports %q, want Failed", got)
+	}
+
+	h.registry.AddService("flapper", &MockServiceInfo{
+		Name:        "flapper",
+		ServiceType: api.TypeMCPServer,
+		State:       api.StateRunning,
+	})
+	h.reconcile("flapper")
+
+	states := h.states()
+	if got := states["flapper"]; got != string(musterv1alpha1.MCPServerStateConnected) {
+		t.Errorf("after recovery, gauge reports %q, want Connected", got)
+	}
+	if len(states) != 1 {
+		t.Errorf("gauge reports %d series (%v), want only the current state", len(states), states)
+	}
+}
+
+// TestStateGaugeStopsReportingDeletedServer is the stale-series guarantee: a
+// deleted MCPServer must drop out of the gauge, so deleting a broken server
+// resolves its alert instead of pinning it forever.
+func TestStateGaugeStopsReportingDeletedServer(t *testing.T) {
+	h := newMetricHarness(t)
+
+	h.addServer("doomed", "streamable-http", statePtr(api.StateFailed))
+	h.addServer("survivor", "streamable-http", statePtr(api.StateRunning))
+	h.reconcile("doomed")
+	h.reconcile("survivor")
+
+	if got := len(h.states()); got != 2 {
+		t.Fatalf("gauge reports %d servers, want 2", got)
+	}
+
+	// Drop the definition, then reconcile: a missing definition is the delete
+	// path, the same way the change detector drives it.
+	h.manager.RemoveMCPServer("doomed")
+	h.reconcile("doomed")
+
+	states := h.states()
+	if _, still := states["doomed"]; still {
+		t.Errorf("deleted MCPServer still reports state %q", states["doomed"])
+	}
+	if got := states["survivor"]; got != string(musterv1alpha1.MCPServerStateConnected) {
+		t.Errorf("survivor reports %q, want Connected", got)
+	}
+}
+
+// TestStateTransitionsCounterCountsChangesOnly keeps the flapping signal
+// meaningful: the periodic status resync reconciles unchanged servers
+// repeatedly, and those passes must not inflate the counter.
+func TestStateTransitionsCounterCountsChangesOnly(t *testing.T) {
+	h := newMetricHarness(t)
+
+	h.addServer("flapper", "streamable-http", statePtr(api.StateFailed))
+
+	// Three reconciles with no state change: one transition into Failed.
+	h.reconcile("flapper")
+	h.reconcile("flapper")
+	h.reconcile("flapper")
+
+	if got := h.transitionCounts()["flapper/Failed"]; got != 1 {
+		t.Errorf("Failed transitions after 3 unchanged reconciles: %d, want 1", got)
+	}
+
+	// Recover, then fail again: one more Failed transition, one Connected.
+	h.registry.AddService("flapper", &MockServiceInfo{
+		Name: "flapper", ServiceType: api.TypeMCPServer, State: api.StateRunning,
+	})
+	h.reconcile("flapper")
+	h.registry.AddService("flapper", &MockServiceInfo{
+		Name: "flapper", ServiceType: api.TypeMCPServer, State: api.StateFailed,
+	})
+	h.reconcile("flapper")
+
+	counts := h.transitionCounts()
+	if got := counts["flapper/Failed"]; got != 2 {
+		t.Errorf("Failed transitions after a flap: %d, want 2", got)
+	}
+	if got := counts["flapper/Connected"]; got != 1 {
+		t.Errorf("Connected transitions after a flap: %d, want 1", got)
+	}
+}
+
+// TestStateMetricsRecordedWithoutStatusUpdater covers filesystem mode, where
+// syncStatus returns early because there is no CRD to write to. The metric is
+// the only external view of state there, so it must still be published.
+func TestStateMetricsRecordedWithoutStatusUpdater(t *testing.T) {
+	h := newMetricHarness(t)
+
+	if h.reconciler.StatusUpdater != nil {
+		t.Fatal("harness reconciler unexpectedly has a StatusUpdater")
+	}
+
+	h.addServer("local-stdio", "stdio", statePtr(api.StateFailed))
+	h.reconcile("local-stdio")
+
+	if got := h.states()["local-stdio"]; got != string(musterv1alpha1.MCPServerStateFailed) {
+		t.Errorf("gauge reports %q, want Failed", got)
+	}
+}

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -242,9 +242,27 @@ func (m *musterInstanceManager) CreateInstance(ctx context.Context, scenarioName
 		return nil, fmt.Errorf("failed to find available port: %w", err)
 	}
 
+	// A second reserved port for the instance's Prometheus /metrics endpoint,
+	// so scenarios can assert on exported metrics (see test_scrape_metrics).
+	// Reserved through the same allocator as the MCP port, so parallel
+	// instances cannot collide on it.
+	metricsPort, err := m.findAvailablePort(instanceID, logger)
+	if err != nil {
+		m.releasePort(port, instanceID, logger)
+		return nil, fmt.Errorf("failed to find available metrics port: %w", err)
+	}
+
+	// releasePorts hands both reservations back. Used by every cleanup path
+	// from here on; the MkdirAll failure below previously leaked the MCP port.
+	releasePorts := func() {
+		m.releasePort(port, instanceID, logger)
+		m.releasePort(metricsPort, instanceID, logger)
+	}
+
 	// Create instance configuration directory
 	configPath := filepath.Join(m.tempDir, instanceID)
 	if err := os.MkdirAll(configPath, 0755); err != nil { //nolint:gosec
+		releasePorts()
 		return nil, fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -255,7 +273,7 @@ func (m *musterInstanceManager) CreateInstance(ctx context.Context, scenarioName
 	// Start mock OAuth servers FIRST (before HTTP servers, as they may depend on OAuth)
 	mockOAuthServerInfo, err := m.startMockOAuthServers(ctx, instanceID, config, logger)
 	if err != nil {
-		m.releasePort(port, instanceID, logger)
+		releasePorts()
 		_ = os.RemoveAll(configPath)
 		return nil, fmt.Errorf("failed to start mock OAuth servers: %w", err)
 	}
@@ -265,7 +283,7 @@ func (m *musterInstanceManager) CreateInstance(ctx context.Context, scenarioName
 	mockHTTPServerInfo, err := m.startMockHTTPServersWithOAuth(ctx, instanceID, configPath, port, config, mockOAuthServerInfo, logger)
 	if err != nil {
 		m.stopMockOAuthServers(ctx, instanceID, logger)
-		m.releasePort(port, instanceID, logger)
+		releasePorts()
 		_ = os.RemoveAll(configPath)
 		return nil, fmt.Errorf("failed to start mock HTTP servers: %w", err)
 	}
@@ -274,17 +292,17 @@ func (m *musterInstanceManager) CreateInstance(ctx context.Context, scenarioName
 	if err := m.generateConfigFilesWithMocks(configPath, config, port, mockHTTPServerInfo, instanceID, logger); err != nil {
 		// Clean up mock HTTP servers on failure
 		m.stopMockHTTPServers(ctx, instanceID, logger)
-		m.releasePort(port, instanceID, logger)
+		releasePorts()
 		_ = os.RemoveAll(configPath)
 		return nil, fmt.Errorf("failed to generate config files: %w", err)
 	}
 
 	// Start muster serve process with log capture
-	managedProc, err := m.startMusterProcess(ctx, configPath, port, logger)
+	managedProc, err := m.startMusterProcess(ctx, configPath, port, metricsPort, logger)
 	if err != nil {
 		// Clean up on failure: stop mock servers, release port and remove config directory
 		m.stopMockHTTPServers(ctx, instanceID, logger)
-		m.releasePort(port, instanceID, logger)
+		releasePorts()
 		_ = os.RemoveAll(configPath)
 		return nil, fmt.Errorf("failed to start muster process: %w", err)
 	}
@@ -311,6 +329,7 @@ func (m *musterInstanceManager) CreateInstance(ctx context.Context, scenarioName
 		ID:                     instanceID,
 		ConfigPath:             configPath,
 		Port:                   port,
+		MetricsPort:            metricsPort,
 		Endpoint:               fmt.Sprintf("http://localhost:%d/mcp", port),
 		Process:                managedProc.cmd.Process,
 		StartTime:              time.Now(),
@@ -375,8 +394,9 @@ func (m *musterInstanceManager) DestroyInstance(ctx context.Context, instance *M
 	// Stop mock OAuth servers for this instance
 	m.stopMockOAuthServers(ctx, instance.ID, logger)
 
-	// Release the reserved port
+	// Release the reserved ports
 	m.releasePort(instance.Port, instance.ID, logger)
+	m.releasePort(instance.MetricsPort, instance.ID, logger)
 
 	// Clean up configuration directory unless keepTempConfig is true
 	if m.keepTempConfig {
@@ -969,7 +989,7 @@ func (m *musterInstanceManager) releasePort(port int, instanceID string, logger 
 // port is the reserved port muster serve will bind. The probe listener held open
 // for it (see findAvailablePort) is closed immediately before exec so the child
 // can take the port over with a near-zero race window.
-func (m *musterInstanceManager) startMusterProcess(ctx context.Context, configPath string, port int, logger TestLogger) (*managedProcess, error) {
+func (m *musterInstanceManager) startMusterProcess(ctx context.Context, configPath string, port, metricsPort int, logger TestLogger) (*managedProcess, error) {
 	// Get the path to the muster binary
 	musterPath, err := m.getMusterBinaryPath()
 	if err != nil {
@@ -1003,9 +1023,19 @@ func (m *musterInstanceManager) startMusterProcess(ctx context.Context, configPa
 	// up to a 30s orchestrator tick before the retry, blowing past scenario
 	// wait_for_state budgets. Fast-retry inside the harness so transient
 	// failures recover in seconds.
+	//
+	// The OTEL_* trio turns on the self-hosted Prometheus exporter on
+	// metricsPort. It is enabled for every instance rather than per scenario:
+	// muster resolves the exporter once at startup from the environment, and an
+	// unscraped exporter costs one idle listener. This is what makes exported
+	// metrics assertable end to end, through the real OTel pipeline, rather
+	// than only in Go unit tests.
 	cmd.Env = append(os.Environ(),
 		"MUSTER_MCPSERVER_INITIAL_BACKOFF=1s",
 		"MUSTER_ORCHESTRATOR_RETRY_INTERVAL=1s",
+		"OTEL_METRICS_EXPORTER=prometheus",
+		"OTEL_EXPORTER_PROMETHEUS_HOST=127.0.0.1",
+		fmt.Sprintf("OTEL_EXPORTER_PROMETHEUS_PORT=%d", metricsPort),
 	)
 
 	// Configure the process attributes (platform-specific)
@@ -1027,6 +1057,7 @@ func (m *musterInstanceManager) startMusterProcess(ctx context.Context, configPa
 	// muster serve binds it immediately, leaving only a process-startup-sized
 	// race window.
 	m.closeReservedListener(port)
+	m.closeReservedListener(metricsPort)
 
 	// Start the process
 	if err := cmd.Start(); err != nil {

--- a/internal/testing/scenarios/mcpserver-state-metrics.yaml
+++ b/internal/testing/scenarios/mcpserver-state-metrics.yaml
@@ -1,0 +1,176 @@
+name: "mcpserver-state-metrics"
+description: "MCPServer connection state is exported as Prometheus metrics the alert rules can fire on"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["mcpserver", "observability", "metrics", "reconciler", "alerting"]
+timeout: "3m"
+
+# Test Story: a broken MCP backend has to be visible to monitoring
+#
+# Given: a healthy MCP server and an unreachable one
+# Then:  muster_mcpserver_state exports 1 for each, labelled with the state,
+#        so the healthy one reads Connected and the broken one Failed
+# When:  the broken server is deleted
+# Then:  it stops being exported, so deleting a server resolves its alert
+#        instead of leaving a series that pins it firing forever
+#
+# This closes the detection gap behind giantswarm/giantswarm#37521: 21
+# MCPServers sat in status.state Failed for two days with the reason recorded
+# in status.lastError, and nothing could alert on it.
+#
+# The assertions deliberately run against the process's real Prometheus
+# endpoint (test_scrape_metrics), not against internal state. That is what
+# pins the exported names and labels the PrometheusRule expressions in
+# helm/muster/templates/prometheusrule.yaml select on — the OTel Prometheus
+# exporter rewrites muster.mcpserver.state to muster_mcpserver_state and
+# mcpserver.name to mcpserver_name, and only a scrape proves it.
+
+pre_configuration:
+  mcp_servers:
+    - name: "metrics-healthy-server"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "healthy_probe_tool"
+            input_schema:
+              type: "object"
+              properties:
+                message: { type: "string" }
+            responses:
+              - response:
+                  message: "alive: {{ .message }}"
+
+steps:
+  - id: "verify-healthy-connected"
+    description: "Baseline: the pre-configured server reaches Connected"
+    tool: "core_service_status"
+    args:
+      name: "metrics-healthy-server"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        name: "metrics-healthy-server"
+        state: "connected"
+
+  # A URL nothing listens on: the connection attempt fails outright, which is
+  # the shape of the incident (TLS handshake failure against a reachable host
+  # produced the same Failed state).
+  - id: "create-unreachable-server"
+    description: "Add a server whose endpoint cannot be reached"
+    tool: "core_mcpserver_create"
+    args:
+      name: "metrics-broken-server"
+      type: "streamable-http"
+      url: "http://127.0.0.1:1/mcp"
+      autoStart: true
+    expected:
+      success: true
+
+  - id: "verify-broken-failed"
+    description: "The reconciler records the unreachable server as Failed"
+    tool: "core_mcpserver_get"
+    args:
+      name: "metrics-broken-server"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      json_path:
+        name: "metrics-broken-server"
+        state: "Failed"
+
+  # The exported name and label set are the contract the PrometheusRule depends
+  # on. wait_for_state polls the scrape: a state the reconciler just wrote
+  # reaches the exporter on the next collection, not synchronously.
+  - id: "verify-failed-state-exported"
+    description: "muster_mcpserver_state exports the Failed server with the labels the alert selects on"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_mcpserver_state"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      contains:
+        - 'muster_mcpserver_state{'
+        - 'mcpserver_name="metrics-broken-server"'
+        - 'state="Failed"'
+
+  - id: "verify-healthy-state-exported"
+    description: "The healthy server is exported too, as Connected — the gauge covers every known server, not only broken ones"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_mcpserver_state"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      contains:
+        - 'mcpserver_name="metrics-healthy-server"'
+        - 'state="Connected"'
+
+  - id: "verify-transitions-counter-exported"
+    description: "The transition counter is exported so flapping is visible, not just steady-state failure"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_mcpserver_state_transitions_total"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      contains:
+        - 'muster_mcpserver_state_transitions_total{'
+        - 'mcpserver_name="metrics-broken-server"'
+        - 'state="Failed"'
+
+  # A metric-borne "namespace" label would be renamed to exported_namespace by
+  # the Prometheus Operator's scrape config, silently breaking the alert
+  # descriptions. The reconciler emits the prefixed form to avoid that; assert
+  # the prefix actually survives to the wire.
+  - id: "verify-namespace-label-is-prefixed"
+    description: "The namespace attribute is exported as mcpserver_namespace, not as a bare namespace label"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_mcpserver_state{"
+    expected:
+      success: true
+      contains:
+        - "mcpserver_namespace="
+
+  - id: "delete-broken-server"
+    description: "Delete the broken server"
+    tool: "core_mcpserver_delete"
+    args:
+      name: "metrics-broken-server"
+    expected:
+      success: true
+
+  # The stale-series guarantee. An asynchronous gauge only exports what its
+  # callback observes, so a forgotten server drops off the endpoint entirely.
+  #
+  # Absence is asserted as "exactly one series remains, and it is the healthy
+  # server" rather than with not_contains: not_contains is validated by the
+  # scenario loader but never evaluated for test_* steps, so an absence
+  # assertion written that way would silently pass. line_count plus the
+  # positive match is an equivalent and actually-enforced proof.
+  - id: "verify-deleted-server-stops-reporting"
+    description: "The deleted server no longer appears, so its alert resolves instead of firing forever"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_mcpserver_state{"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      contains:
+        - 'mcpserver_name="metrics-healthy-server"'
+      json_path:
+        line_count: 1
+
+  - id: "verify-healthy-server-still-works"
+    description: "Reporting on the deleted server stopped without disturbing the healthy one"
+    tool: "x_metrics-healthy-server_healthy_probe_tool"
+    args:
+      message: "post-delete"
+    expected:
+      success: true
+      contains: ["alive", "post-delete"]
+
+# No cleanup block: deleting the broken server is a test step, and the healthy
+# server goes away with the instance.

--- a/internal/testing/test_runner.go
+++ b/internal/testing/test_runner.go
@@ -623,8 +623,11 @@ func (r *testRunner) runTestToolStep(ctx context.Context, step TestStep, config 
 		}
 	}
 
-	// Execute the test tool
-	response, err := testToolsHandler.HandleTestTool(stepCtx, step.Tool, resolvedArgs)
+	// Execute the test tool, re-invoking it until expectations hold when the
+	// step declares wait_for_state. Test tools observe eventually-consistent
+	// state just like the regular tools do -- an exported metric reflects a
+	// reconcile that has already happened, but only from the next collection.
+	response, err := r.callTestToolWithWait(stepCtx, testToolsHandler, step, resolvedArgs, logger)
 
 	// Wrap the response in MCP-compatible format
 	wrappedResult := WrapTestToolResult(response, err)
@@ -656,6 +659,52 @@ func (r *testRunner) runTestToolStep(ctx context.Context, step TestStep, config 
 	}
 
 	return result
+}
+
+// testToolPollInterval is how often a wait_for_state test-tool step re-invokes
+// its tool. Matches the 1s interval the regular tool path polls at.
+const testToolPollInterval = 1 * time.Second
+
+// callTestToolWithWait invokes a test tool once, or repeatedly until its
+// expectations hold when the step sets wait_for_state.
+//
+// Mirrors validateExpectationsWithClient's polling for regular tool steps. The
+// last response is returned either way, so a timeout is reported by the normal
+// validation path with the actual response attached rather than as a bare
+// timeout.
+func (r *testRunner) callTestToolWithWait(ctx context.Context, handler *TestToolsHandler, step TestStep, args map[string]interface{}, logger TestLogger) (interface{}, error) {
+	response, err := handler.HandleTestTool(ctx, step.Tool, args)
+	if step.Expected.WaitForState <= 0 {
+		return response, err
+	}
+	if err == nil && r.validateTestToolExpectations(step.Expected, response, nil, logger) {
+		return response, nil
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, step.Expected.WaitForState)
+	defer cancel()
+
+	ticker := time.NewTicker(testToolPollInterval)
+	defer ticker.Stop()
+
+	if r.debug {
+		logger.Debug("🔄 Polling test tool %s for up to %v\n", step.Tool, step.Expected.WaitForState)
+	}
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			if r.debug {
+				logger.Debug("⏰ Test tool %s did not meet expectations within %v\n", step.Tool, step.Expected.WaitForState)
+			}
+			return response, err
+		case <-ticker.C:
+			response, err = handler.HandleTestTool(waitCtx, step.Tool, args)
+			if err == nil && r.validateTestToolExpectations(step.Expected, response, nil, logger) {
+				return response, nil
+			}
+		}
+	}
 }
 
 // validateTestToolExpectations validates expectations for test tool results:

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -69,6 +69,12 @@ const (
 	// TestToolGetServerInfo returns the protocol version and server capabilities
 	// negotiated during the current session's initialize handshake.
 	TestToolGetServerInfo = "test_get_server_info"
+	// TestToolScrapeMetrics scrapes the instance's Prometheus /metrics endpoint
+	// and returns the matching exposition lines, so a scenario can assert on
+	// what muster actually exports rather than on internal state. Optional
+	// "filter" argument narrows the body to lines containing that substring;
+	// without it the whole scrape is returned.
+	TestToolScrapeMetrics = "test_scrape_metrics"
 )
 
 // TestToolsHandler handles test-specific tools that operate on mock infrastructure.
@@ -189,7 +195,8 @@ func IsTestTool(toolName string) bool {
 		TestToolMintToken,
 		TestToolBrokerTokenExchange,
 		TestToolCallProtectedMCP,
-		TestToolReconnectWithToken:
+		TestToolReconnectWithToken,
+		TestToolScrapeMetrics:
 		return true
 	}
 	return false
@@ -232,6 +239,8 @@ func (h *TestToolsHandler) HandleTestTool(ctx context.Context, toolName string, 
 		return h.handleRemoveMockTool(ctx, args)
 	case TestToolCallMetaTool:
 		return h.handleCallMetaTool(ctx, args)
+	case TestToolScrapeMetrics:
+		return h.handleScrapeMetrics(ctx, args)
 	case TestToolGetServerInfo:
 		return h.handleGetServerInfo(ctx, args)
 	case TestToolMintToken:
@@ -1175,6 +1184,71 @@ func (h *TestToolsHandler) handleGetServerInfo(_ context.Context, _ map[string]i
 	}
 
 	return result, nil
+}
+
+// handleScrapeMetrics fetches the instance's Prometheus /metrics endpoint and
+// returns the exposition text, optionally narrowed to lines containing the
+// "filter" substring.
+//
+// This is the seam that lets a scenario assert on metrics end to end: the
+// scrape goes through the real OTel Prometheus exporter in the real muster
+// serve process, so it catches naming and label translation that a Go test
+// against an in-memory reader cannot (dots becoming underscores, _total
+// suffixes, attribute-to-label mapping).
+//
+// A newly reconciled state can take a moment to reach the exporter, so
+// scenarios pair this with a retry on the step.
+func (h *TestToolsHandler) handleScrapeMetrics(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	if h.currentInstance == nil {
+		return nil, fmt.Errorf("no muster instance available to scrape")
+	}
+	if h.currentInstance.MetricsPort == 0 {
+		return nil, fmt.Errorf("muster instance %s has no metrics port", h.currentInstance.ID)
+	}
+
+	filter, _ := args["filter"].(string)
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d/metrics", h.currentInstance.MetricsPort)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build metrics request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scrape %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read metrics response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("scrape %s returned %d", endpoint, resp.StatusCode)
+	}
+
+	// Comments (# HELP / # TYPE) are dropped: a scenario asserting on a metric
+	// name would otherwise match its own HELP line and pass without the metric
+	// ever being exported.
+	var matched []string
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if filter != "" && !strings.Contains(line, filter) {
+			continue
+		}
+		matched = append(matched, line)
+	}
+
+	return map[string]interface{}{
+		api.FieldSuccess: true,
+		"endpoint":       endpoint,
+		"filter":         filter,
+		"line_count":     len(matched),
+		"metrics":        matched,
+	}, nil
 }
 
 // handleSimulateMusterReauth simulates re-authentication to muster with a new token.

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -216,6 +216,10 @@ type MusterInstance struct {
 	ConfigPath string
 	// Port is the port the instance is listening on
 	Port int
+	// MetricsPort is the port the instance serves its Prometheus /metrics
+	// endpoint on. The harness always enables the prometheus exporter so
+	// scenarios can assert on exported metrics (see test_scrape_metrics).
+	MetricsPort int
 	// Endpoint is the full MCP endpoint URL
 	Endpoint string
 	// Process is the running muster serve process


### PR DESCRIPTION
## Why

muster already knew when an MCP backend was broken. The reconciler wrote the state to `MCPServer.status.state` and the reason to `status.lastError`. Nothing could alert on it, so a backend could sit `Failed` indefinitely with the diagnosis right there in the CR and nobody paged — which is exactly what happened: 21 MCPServers across two management clusters were `Failed` for roughly two days, found by accident while verifying an unrelated rollout.

The underlying cause of that outage is fixed. This closes the detection gap.

Tracking issue: giantswarm/giantswarm#37521 (gap 1).

## The metrics

Two instruments in the reconciler, on the meter `mcp-toolkit` already initialises at `cmd/serve.go:123`:

| Instrument | Exported as | Attributes |
|---|---|---|
| `muster.mcpserver.state` (observable gauge) | `muster_mcpserver_state` | `mcpserver_name`, `mcpserver_namespace`, `state` |
| `muster.mcpserver.state_transitions` (counter) | `muster_mcpserver_state_transitions_total` | same, `state` = state entered |

```
muster_mcpserver_state{mcpserver_name="mcp-kubernetes-example",mcpserver_namespace="agent-platform",state="Failed"} 1
```

### Why an observable gauge with the state as an attribute

Two requirements drove both choices: each MCPServer must contribute exactly one series, and a server that goes away must stop reporting.

Observable gauges are aggregated with `PrecomputedLastValue`, which clears its values on every collection — only what the callback observes gets exported. So a recovered server's previous state disappears on its own, and a deleted one drops off entirely once `reconcileDelete` forgets it. A **synchronous** gauge uses `cumulativeLastValue`, which retains its last write indefinitely (upstream `TODO #3006`), and would pin an alert on a resource that no longer exists. A **per-state boolean gauge** would need explicit zeroing of every other state and makes the alert expression a comparison rather than a label match.

Carrying the state as an attribute keeps the alert a plain equality match and means the old state's series vanishes without bookkeeping.

### Why the counter earns its keep

The gauge shows sustained breakage; it cannot see churn. A backend that reconnects and drops every few minutes never satisfies a `for:` window but is just as unusable. The counter makes that visible. It counts only actual changes — the periodic status resync reconciles unchanged servers constantly and must not inflate it.

### `mcpserver_namespace`, not `namespace`

With a Prometheus Operator ServiceMonitor, target-metadata labels (`namespace`, `pod`, `service`, …) win over metric-borne labels of the same name unless `honorLabels` is set, and the metric's own value gets renamed to `exported_namespace`. Prefixing keeps the label the alert selects on stable however the endpoint is scraped. The BDD scenario asserts the prefix survives to the wire.

### One decision site

`status.state` now goes through a single `observedState` function that both the CRD status write and the metric use, so the alert cannot disagree with `kubectl get mcpserver`. A test pins them together. The metric is recorded next to every `syncStatus` but unconditionally — `syncStatus` returns early without a `StatusUpdater` (filesystem mode), where the metric is the only external view of state.

## The alerts

`helm/muster/templates/prometheusrule.yaml`, modelled on `giantswarm/tunnelport`'s: same `area` / `severity` / `team: bumblebee` / `topic` / `cancel_if_*` conventions, values-gated, default off, configurable extra labels for `ruleSelector` matching.

- **`MusterMCPServerFailed`** — `muster_mcpserver_state{state="Failed"} == 1`, `for: 20m`. Long enough to ride out a rollout plus initial connect backoff, two orders of magnitude below the ~2 days this went unnoticed.
- **`MusterMCPServerFlapping`** — `increase(muster_mcpserver_state_transitions_total{state="Failed"}[1h]) > 5`, `for: 10m`. A restart contributes exactly one Failed transition per broken server, so rollouts don't trip it.

`cancel_if_monitoring_agent_down` rather than tunnelport's `cancel_if_kube_state_metrics_down`: muster exports this itself.

**`Auth Required` is deliberately not alerted on.** It is the normal steady state for on-behalf-of servers with no active user session, and every server shows it briefly after a restart. A promtool test asserts it stays silent indefinitely.

Gated on its own value rather than on the prometheus exporter, so the OTLP remote-write path can have rules without a local scrape.

## Verification

Not just unit tests — that was precisely the failure mode here.

- **Live scrape, real process.** `internal/testing/scenarios/mcpserver-state-metrics.yaml` asserts against the actual `/metrics` endpoint of a real `muster serve`: a broken backend appears as `Failed`, a healthy one as `Connected`, the counter increments, the namespace label is prefixed, and a deleted server drops off entirely. This is what pins the exported names and labels the rule expressions depend on — the exporter rewrites `muster.mcpserver.state` → `muster_mcpserver_state` and `mcpserver.name` → `mcpserver_name`, and only a scrape proves it.
- **Alert behaviour over time.** `helm/muster/tests/promtool/` — the 20m window rides out a rollout, a recovered server never fires, `Auth Required` is silent for two hours, flapping is caught, a single restart is not.
- **Rendering and labels.** `helm/muster/tests/prometheusrule_test.yaml` (11 assertions).
- **Metric mechanics.** `internal/reconciler/mcpserver_state_metrics_test.go` against a real SDK `ManualReader`.
- All 186 BDD scenarios, full `go test ./...`, `make lint`, `make vet` green against a fresh build.
- Runbook remediation claims checked against a running muster, not just read off the code: suspending a `Failed` server does move it to `Disconnected` (one series, alert clears).

## Test-harness additions

Three, all needed for the scenario to be able to assert on metrics at all:

- A second reserved port per instance with the prometheus exporter enabled. This also fixes a pre-existing leak of the MCP port reservation on the config-directory failure path.
- A `test_scrape_metrics` test tool.
- `wait_for_state` support for `test_*` steps, mirroring the regular tool path. Only this scenario combines the two, so no existing scenario changes behaviour. (`retry:` is validated by the scenario loader but never executed by the runner — worth knowing before writing a scenario that relies on it.)

## CI

A `chart-test` job runs the chart checks; the architect Go image carries neither the helm plugins nor promtool, so `make test` cannot reach them. Scoped to `helm-lint` plus the PrometheusRule suites, because `tests/pdb_test.yaml` and `tests/gateway_api_test.yaml` already fail on `main` on `values.schema.json` strictness (free-form label maps, a percentage-string `minAvailable`, an undeclared `maxUnavailable`). `make helm-test-all` runs everything including those. Filed separately.

## Runbook

https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-mcpserver-failed/ — both alerts point at it. Covers reading `status.lastError` first, classifying by error (TLS SAN mismatch, unreachable, 401), blast-radius triage, and remediation via `spec.restartRequestedAt` / `spec.suspended` / delete.

## Compatibility

Additive. No metric or chart value removed or renamed; both alerts default to off. No major version needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)