### PR TITLE
feat(helm): document the editor RoleBinding trade-off and fail on empty subjects

### DIFF
--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -194,3 +194,35 @@ stdio keeps working when muster runs as a local CLI (`muster serve` against a
 config directory), which is what it exists for. To use an existing stdio MCP
 server from a deployed muster, run it as a Deployment behind a Service and
 register it with `type: streamable-http`.
+
+## Who should hold mcpserver-editor and workflow-editor
+
+Session-initiated writes to `MCPServer` and `Workflow` resources go through the
+Kubernetes API **as the calling user** (writes-as-caller), so Kubernetes RBAC is
+the authorization gate. The chart ships that gate as two namespaced Role +
+RoleBinding pairs in muster's install namespace:
+
+* `mcpserver-editor` — create/update/patch/delete on `mcpservers`
+  (`rbac.mcpServerEditor`)
+* `workflow-editor` — create/update/patch/delete on `workflows`
+  (`rbac.workflowEditor`)
+
+These grants are wider than they read, because the aggregator is **shared**:
+a registered MCP server is visible to every user of the instance, and other
+users' sessions are routed through it. A workflow authored by one user is
+listed for and runnable by others.
+
+Pick the binding's subjects to match how the instance is used:
+
+* **Shared / multi-team installs** should narrow `subjects` to an admin group,
+  so only platform administrators curate what everyone else is exposed to.
+* **Single-team installs**, where every authenticated SSO user is trusted to
+  register servers and author workflows, may keep the default
+  `system:authenticated` binding.
+
+The default binds `system:authenticated` — a deliberate choice that keeps
+single-team installs and upgrades working out of the box. Setting `subjects`
+to an empty list **fails the render**: a RoleBinding bound to nobody looks
+enforced while granting nothing. To manage the grants entirely out of band,
+set `rbac.mcpServerEditor.create: false` / `rbac.workflowEditor.create: false`
+and bind the verbs yourself.

--- a/helm/muster/README.md.gotmpl
+++ b/helm/muster/README.md.gotmpl
@@ -37,3 +37,35 @@ stdio keeps working when muster runs as a local CLI (`muster serve` against a
 config directory), which is what it exists for. To use an existing stdio MCP
 server from a deployed muster, run it as a Deployment behind a Service and
 register it with `type: streamable-http`.
+
+## Who should hold mcpserver-editor and workflow-editor
+
+Session-initiated writes to `MCPServer` and `Workflow` resources go through the
+Kubernetes API **as the calling user** (writes-as-caller), so Kubernetes RBAC is
+the authorization gate. The chart ships that gate as two namespaced Role +
+RoleBinding pairs in muster's install namespace:
+
+* `mcpserver-editor` — create/update/patch/delete on `mcpservers`
+  (`rbac.mcpServerEditor`)
+* `workflow-editor` — create/update/patch/delete on `workflows`
+  (`rbac.workflowEditor`)
+
+These grants are wider than they read, because the aggregator is **shared**:
+a registered MCP server is visible to every user of the instance, and other
+users' sessions are routed through it. A workflow authored by one user is
+listed for and runnable by others.
+
+Pick the binding's subjects to match how the instance is used:
+
+* **Shared / multi-team installs** should narrow `subjects` to an admin group,
+  so only platform administrators curate what everyone else is exposed to.
+* **Single-team installs**, where every authenticated SSO user is trusted to
+  register servers and author workflows, may keep the default
+  `system:authenticated` binding.
+
+The default binds `system:authenticated` — a deliberate choice that keeps
+single-team installs and upgrades working out of the box. Setting `subjects`
+to an empty list **fails the render**: a RoleBinding bound to nobody looks
+enforced while granting nothing. To manage the grants entirely out of band,
+set `rbac.mcpServerEditor.create: false` / `rbac.workflowEditor.create: false`
+and bind the verbs yourself.

--- a/helm/muster/templates/mcpserver-editor-rbac.yaml
+++ b/helm/muster/templates/mcpserver-editor-rbac.yaml
@@ -7,9 +7,14 @@ the caller's own identity, so k8s RBAC authorizes each write. The default
 binding grants the Role to all authenticated users, preserving the
 pre-enforcement "any user can register" behavior. Installations wanting
 admin-only registration narrow rbac.mcpServerEditor.subjects to an admin
-group.
+group. An empty subjects list fails the render: a RoleBinding bound to
+nobody looks enforced while granting nothing, so the chart forces the
+choice to be explicit.
 */}}
 {{- if and .Values.rbac.create .Values.rbac.mcpServerEditor.create -}}
+{{- if not .Values.rbac.mcpServerEditor.subjects }}
+{{- fail "rbac.mcpServerEditor.subjects must not be empty while the mcpserver-editor RoleBinding is created. Bind an admin group for admin-only registration, bind group system:authenticated to deliberately let every authenticated user register MCP servers, or set rbac.mcpServerEditor.create=false to manage access out of band." }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/muster/templates/workflow-editor-rbac.yaml
+++ b/helm/muster/templates/workflow-editor-rbac.yaml
@@ -6,9 +6,14 @@ against the Kubernetes API with the caller's own identity, so k8s RBAC
 authorizes each write. The default binding grants the Role to all
 authenticated users, preserving the pre-enforcement "any user can create"
 behavior. Installations wanting admin-only workflow authoring narrow
-rbac.workflowEditor.subjects to an admin group.
+rbac.workflowEditor.subjects to an admin group. An empty subjects list
+fails the render: a RoleBinding bound to nobody looks enforced while
+granting nothing, so the chart forces the choice to be explicit.
 */}}
 {{- if and .Values.rbac.create .Values.rbac.workflowEditor.create -}}
+{{- if not .Values.rbac.workflowEditor.subjects }}
+{{- fail "rbac.workflowEditor.subjects must not be empty while the workflow-editor RoleBinding is created. Bind an admin group for admin-only workflow authoring, bind group system:authenticated to deliberately let every authenticated user author workflows, or set rbac.workflowEditor.create=false to manage access out of band." }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/muster/tests/mcpserver_editor_rbac_test.yaml
+++ b/helm/muster/tests/mcpserver_editor_rbac_test.yaml
@@ -68,9 +68,24 @@ tests:
               name: platform-admins
         documentIndex: 1
 
+  - it: fails when subjects is empty so the binding cannot silently grant nobody
+    set:
+      rbac.mcpServerEditor.subjects: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "rbac.mcpServerEditor.subjects must not be empty while the mcpserver-editor RoleBinding is created. Bind an admin group for admin-only registration, bind group system:authenticated to deliberately let every authenticated user register MCP servers, or set rbac.mcpServerEditor.create=false to manage access out of band."
+
   - it: creates nothing when rbac.mcpServerEditor.create is false
     set:
       rbac.mcpServerEditor.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: allows empty subjects when the binding is not created
+    set:
+      rbac.mcpServerEditor.create: false
+      rbac.mcpServerEditor.subjects: []
     asserts:
       - hasDocuments:
           count: 0

--- a/helm/muster/tests/workflow_editor_rbac_test.yaml
+++ b/helm/muster/tests/workflow_editor_rbac_test.yaml
@@ -68,9 +68,24 @@ tests:
               name: platform-admins
         documentIndex: 1
 
+  - it: fails when subjects is empty so the binding cannot silently grant nobody
+    set:
+      rbac.workflowEditor.subjects: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "rbac.workflowEditor.subjects must not be empty while the workflow-editor RoleBinding is created. Bind an admin group for admin-only workflow authoring, bind group system:authenticated to deliberately let every authenticated user author workflows, or set rbac.workflowEditor.create=false to manage access out of band."
+
   - it: creates nothing when rbac.workflowEditor.create is false
     set:
       rbac.workflowEditor.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: allows empty subjects when the binding is not created
+    set:
+      rbac.workflowEditor.create: false
+      rbac.workflowEditor.subjects: []
     asserts:
       - hasDocuments:
           count: 0

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -48,28 +48,41 @@ rbac:
   additionalSecretNamespaces: []
   # mcpServerEditor ships the default answer to "who may register and manage
   # MCP servers" under writes-as-caller: a namespaced Role granting
-  # create/update/patch/delete on mcpservers, plus a RoleBinding. The default
-  # subjects bind all authenticated users, preserving the pre-enforcement
-  # "any user can register" behavior. Narrow subjects to an admin group for
-  # admin-only registration.
+  # create/update/patch/delete on mcpservers, plus a RoleBinding.
+  #
+  # Who to bind is a real trade-off. Everyone bound here registers servers
+  # into a SHARED aggregator: other users see those servers and are routed
+  # through them. Shared multi-team installs should narrow subjects to an
+  # admin group. The default binds all authenticated users — a deliberate
+  # fit for single-team installs where every SSO user is trusted to
+  # register, and the compatible default for existing installs. An empty
+  # subjects list fails the render rather than shipping a binding bound to
+  # nobody; set create=false to manage access out of band instead.
   mcpServerEditor:
     create: true
     # RoleBinding subjects granted the mcpserver-editor Role. Standard
     # rbac.authorization.k8s.io/v1 subjects (Group, User, or ServiceAccount).
+    # Must not be empty while create is true.
     subjects:  # @schema item: object ; itemProperties: {apiGroup: {type: string}, kind: {type: string}, name: {type: string}, namespace: {type: string}}
       - apiGroup: rbac.authorization.k8s.io
         kind: Group
         name: system:authenticated
   # workflowEditor ships the default answer to "who may create and manage
   # workflows" under writes-as-caller: a namespaced Role granting
-  # create/update/patch/delete on workflows, plus a RoleBinding. The default
-  # subjects bind all authenticated users, preserving the pre-enforcement
-  # "any user can create" behavior. Narrow subjects to an admin group for
-  # admin-only workflow authoring.
+  # create/update/patch/delete on workflows, plus a RoleBinding.
+  #
+  # Same trade-off as mcpServerEditor: workflows authored here are visible
+  # to and runnable by other users of a shared aggregator. Shared
+  # multi-team installs should narrow subjects to an admin group; the
+  # default binds all authenticated users, the deliberate fit for
+  # single-team installs and the compatible default for existing ones. An
+  # empty subjects list fails the render rather than shipping a binding
+  # bound to nobody; set create=false to manage access out of band.
   workflowEditor:
     create: true
     # RoleBinding subjects granted the workflow-editor Role. Standard
     # rbac.authorization.k8s.io/v1 subjects (Group, User, or ServiceAccount).
+    # Must not be empty while create is true.
     subjects:  # @schema item: object ; itemProperties: {apiGroup: {type: string}, kind: {type: string}, name: {type: string}, namespace: {type: string}}
       - apiGroup: rbac.authorization.k8s.io
         kind: Group


### PR DESCRIPTION
## What

Resolves the open question from #1070 (decision recorded there):

- `rbac.mcpServerEditor.subjects` / `rbac.workflowEditor.subjects` **keep the `system:authenticated` default** — the deliberate fit for single-team installs and the compatible default for existing ones. No behavior change for anyone on defaults (non-breaking).
- The trade-off is now documented at both values keys and in a chart README section (*Who should hold mcpserver-editor and workflow-editor*): on a shared aggregator, everyone bound here registers servers / authors workflows that other users see and get routed through, so shared multi-team installs should narrow `subjects` to an admin group.
- An explicitly **emptied** subjects list now fails the render (same pattern as the oauth-secret and httproute guards) instead of shipping a RoleBinding bound to nobody — which looks enforced while granting nothing. Out-of-band management stays available via `create: false`.
- helm unittests cover: default subjects, overridden subjects, empty-subjects failure, and `create: false` with empty subjects for both editors.

The agent-platform umbrella narrowing (bind GS admin groups explicitly) is the companion change in that repo.

## Why

Found while triaging an externally reported vulnerability (#1070, internal ref giantswarm/giantswarm#37518). The default was inherited from the #1064 migration rather than chosen; this makes it a documented, guarded choice.

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)