### PR TITLE
feat(oauth): check CIMD support and fall back to Dynamic Client Registration

### DIFF
--- a/docs/explanation/mcp-2026-07-28/05-authorization-hardening.md
+++ b/docs/explanation/mcp-2026-07-28/05-authorization-hardening.md
@@ -444,12 +444,22 @@ Concrete work items, grouped by SEP and ordered by risk:
   `docs/explanation/decisions/005-muster-auth.md`), SEP-2207 / SEP-2350
   guardrails on what *not* to include need to be applied to whatever
   code path generates those payloads.
-- **CIMD-vs-DCR matrix.** SEP-2352 is favourable to muster precisely
+- **CIMD-vs-DCR matrix.** ~~SEP-2352 is favourable to muster precisely
   because the proxy uses CIMD. The reverse question is whether muster
   should ever fall back to DCR for authorization servers that refuse to
   resolve a CIMD URL, and if so, where the per-AS DCR state lives. That
   is the only path on which SEP-837 (`application_type`) becomes a
-  blocking concern instead of a defensive one.
+  blocking concern instead of a defensive one.~~ **Resolved** (issue
+  #1083): the server-side proxy now checks
+  `client_id_metadata_document_supported` on the discovered AS metadata
+  and prefers CIMD whenever advertised; otherwise it registers itself via
+  RFC 7591 when a `registration_endpoint` is advertised (requesting
+  `token_endpoint_auth_method: none`, sending `application_type: "web"`
+  per SEP-837), storing the issued credentials keyed by issuer per
+  SEP-2352 (`internal/oauth/credential_store.go`, Valkey-backed when
+  configured). When neither is advertised the CIMD URL is sent as before,
+  and the auth challenge marks the flow `cimd-fallback` so front-ends can
+  warn up front.
 
 ## 6. References
 

--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -299,8 +299,17 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 
 // authChallengeResult builds the tool result for a pending auth challenge.
 // The sign-in URL is carried both in the prose and as structuredContent.authUrl
-// so clients can read it without parsing the text.
+// so clients can read it without parsing the text. structuredContent also
+// carries clientIdMethod ("cimd", "dcr", or "cimd-fallback") so front-ends
+// can tell users how muster identifies itself to the authorization server —
+// and warn up front when the AS advertises neither mechanism.
 func authChallengeResult(serverName string, challenge *api.AuthChallenge) *api.CallToolResult {
+	structured := map[string]any{
+		"authUrl": challenge.AuthURL,
+	}
+	if challenge.ClientIDMethod != "" {
+		structured["clientIdMethod"] = challenge.ClientIDMethod
+	}
 	return &api.CallToolResult{
 		Content: []any{fmt.Sprintf(
 			"Authentication Required\n\n"+
@@ -313,10 +322,8 @@ func authChallengeResult(serverName string, challenge *api.AuthChallenge) *api.C
 			challenge.Message,
 			challenge.AuthURL,
 		)},
-		IsError: false,
-		StructuredContent: map[string]any{
-			"authUrl": challenge.AuthURL,
-		},
+		IsError:           false,
+		StructuredContent: structured,
 	}
 }
 

--- a/internal/aggregator/auth_tools_test.go
+++ b/internal/aggregator/auth_tools_test.go
@@ -57,6 +57,10 @@ func (m *issuerMockOAuthHandler) CreateAuthChallenge(_ context.Context, _, _, _,
 	return nil, nil
 }
 
+func (m *issuerMockOAuthHandler) GetClientCredentialsForIssuer(_ context.Context, _ string) (string, string) {
+	return "", ""
+}
+
 func (m *issuerMockOAuthHandler) GetHTTPHandler() http.Handler {
 	return nil
 }

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -119,7 +119,8 @@ func establishConnection(
 	var client internalmcp.MCPClient
 	if oauthHandler != nil && oauthHandler.IsEnabled() && issuer != "" {
 		tokenStore := internalmcp.NewMusterTokenStore(sessionID, sub, issuer, oauthHandler)
-		client = internalmcp.NewDynamicAuthClient(serverURL, tokenStore, scope)
+		clientID, clientSecret := oauthHandler.GetClientCredentialsForIssuer(ctx, issuer)
+		client = internalmcp.NewDynamicAuthClient(serverURL, tokenStore, scope, clientID, clientSecret)
 		logging.Debug("Connection", "Using DynamicAuthClient for session %s, server %s (issuer=%s)",
 			logging.TruncateIdentifier(sessionID), serverName, issuer)
 	} else {

--- a/internal/aggregator/connection_helper_test.go
+++ b/internal/aggregator/connection_helper_test.go
@@ -62,6 +62,10 @@ func (m *mockOAuthHandler) CreateAuthChallenge(_ context.Context, _, _, _, _, _ 
 	return nil, nil
 }
 
+func (m *mockOAuthHandler) GetClientCredentialsForIssuer(_ context.Context, _ string) (string, string) {
+	return "", ""
+}
+
 func (m *mockOAuthHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, error) {
 	return "", nil
 }

--- a/internal/aggregator/manager.go
+++ b/internal/aggregator/manager.go
@@ -73,10 +73,11 @@ func NewAggregatorManager(config AggregatorConfig, orchestratorAPI api.Orchestra
 		if vClient := manager.aggregatorServer.getValkeyClient(); vClient != nil {
 			keyPrefix := manager.aggregatorServer.getValkeyKeyPrefix()
 			enc := manager.aggregatorServer.getValkeyEncryptor()
-			logging.Info("Aggregator-Manager", "Using Valkey-backed OAuth token and state stores")
+			logging.Info("Aggregator-Manager", "Using Valkey-backed OAuth token, state, and client credential stores")
 			oauthOpts = append(oauthOpts,
 				oauth.WithValkeyTokenStore(oauth.NewValkeyTokenStore(vClient, oauth.DefaultTokenStoreTTL, keyPrefix, enc)),
 				oauth.WithValkeyStateStore(oauth.NewValkeyStateStore(vClient, keyPrefix, enc)),
+				oauth.WithValkeyClientCredentialStore(oauth.NewValkeyClientCredentialStore(vClient, keyPrefix, enc)),
 			)
 		}
 

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -2963,7 +2963,8 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 		issuer := serverInfo.AuthInfo.Issuer
 		scope := serverInfo.AuthInfo.Scope
 		tokenStore := internalmcp.NewMusterTokenStore(sessionID, sub, issuer, oauthHandler)
-		client = internalmcp.NewDynamicAuthClient(serverInfo.URL, tokenStore, scope)
+		clientID, clientSecret := oauthHandler.GetClientCredentialsForIssuer(ctx, issuer)
+		client = internalmcp.NewDynamicAuthClient(serverInfo.URL, tokenStore, scope, clientID, clientSecret)
 
 	} else {
 		return nil, nil, fmt.Errorf("unable to determine auth method for server %s", serverName)

--- a/internal/aggregator/server_logout_test.go
+++ b/internal/aggregator/server_logout_test.go
@@ -392,6 +392,10 @@ func (d *deleteCaptureMockHandler) DeleteTokensByUser(userID string) {
 	}
 }
 func (d *deleteCaptureMockHandler) DeleteTokensBySession(_ string) {}
+func (d *deleteCaptureMockHandler) GetClientCredentialsForIssuer(_ context.Context, _ string) (string, string) {
+	return "", ""
+}
+
 func (d *deleteCaptureMockHandler) CreateAuthChallenge(_ context.Context, _, _, _, _, _ string) (*api.AuthChallenge, error) {
 	return nil, nil
 }
@@ -441,6 +445,10 @@ func (c *clearCaptureMockHandler) ClearTokenByIssuer(sessionID, issuer string) {
 }
 func (c *clearCaptureMockHandler) DeleteTokensByUser(_ string)    {}
 func (c *clearCaptureMockHandler) DeleteTokensBySession(_ string) {}
+func (c *clearCaptureMockHandler) GetClientCredentialsForIssuer(_ context.Context, _ string) (string, string) {
+	return "", ""
+}
+
 func (c *clearCaptureMockHandler) CreateAuthChallenge(_ context.Context, _, _, _, _, _ string) (*api.AuthChallenge, error) {
 	return nil, nil
 }

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -75,6 +75,13 @@ type OAuthHandler interface {
 	// Returns the challenge containing the auth URL for the user to visit.
 	CreateAuthChallenge(ctx context.Context, sessionID, userID, serverName, issuer, scope string) (*AuthChallenge, error)
 
+	// GetClientCredentialsForIssuer returns the client_id and client_secret
+	// the OAuth flows use against the given issuer (the CIMD URL, or
+	// DCR-issued credentials), without triggering a new registration. Used
+	// to configure transport-level token refresh so it presents the same
+	// client identification the token was issued under.
+	GetClientCredentialsForIssuer(ctx context.Context, issuer string) (clientID, clientSecret string)
+
 	// GetHTTPHandler returns the HTTP handler for OAuth callback endpoints.
 	GetHTTPHandler() http.Handler
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -532,6 +532,12 @@ type AuthChallenge struct {
 
 	// Message is a human-readable description of why auth is needed.
 	Message string `json:"message,omitempty"`
+
+	// ClientIDMethod reports how muster identifies itself to the
+	// authorization server for this flow: "cimd" (AS advertises CIMD
+	// support), "dcr" (RFC 7591 registered credentials), or "cimd-fallback"
+	// (neither advertised — the AS may reject the sign-in).
+	ClientIDMethod string `json:"client_id_method,omitempty"`
 }
 
 // OAuthToken represents an OAuth access token for use by handlers.

--- a/internal/mcpserver/client_dynamic_auth.go
+++ b/internal/mcpserver/client_dynamic_auth.go
@@ -28,9 +28,11 @@ import (
 //   - Transparent token refresh via the TokenStore
 type DynamicAuthClient struct {
 	baseMCPClient
-	url        string
-	tokenStore transport.TokenStore
-	scope      string
+	url          string
+	tokenStore   transport.TokenStore
+	scope        string
+	clientID     string
+	clientSecret string
 }
 
 // NewDynamicAuthClient creates a new StreamableHTTP-based MCP client with mcp-go's
@@ -41,13 +43,19 @@ type DynamicAuthClient struct {
 //   - url: The MCP server URL
 //   - tokenStore: Adapter providing OAuth tokens (implements transport.TokenStore)
 //   - scope: The OAuth scope for this connection
+//   - clientID: The OAuth client_id the tokens were issued under (CIMD URL or
+//     DCR-registered id); mcp-go sends it on token refresh requests
+//   - clientSecret: The client secret when the issuer registered muster as a
+//     confidential client via DCR; empty for public clients
 //
 // Returns a new DynamicAuthClient ready for initialization.
-func NewDynamicAuthClient(url string, tokenStore transport.TokenStore, scope string) *DynamicAuthClient {
+func NewDynamicAuthClient(url string, tokenStore transport.TokenStore, scope, clientID, clientSecret string) *DynamicAuthClient {
 	return &DynamicAuthClient{
-		url:        url,
-		tokenStore: tokenStore,
-		scope:      scope,
+		url:          url,
+		tokenStore:   tokenStore,
+		scope:        scope,
+		clientID:     clientID,
+		clientSecret: clientSecret,
 	}
 }
 
@@ -66,8 +74,10 @@ func (c *DynamicAuthClient) Initialize(ctx context.Context) error {
 	var opts []transport.StreamableHTTPCOption
 	if c.tokenStore != nil {
 		opts = append(opts, transport.WithHTTPOAuth(transport.OAuthConfig{
-			TokenStore: c.tokenStore,
-			Scopes:     []string{c.scope},
+			ClientID:     c.clientID,
+			ClientSecret: c.clientSecret,
+			TokenStore:   c.tokenStore,
+			Scopes:       []string{c.scope},
 		}))
 	}
 

--- a/internal/mcpserver/client_test.go
+++ b/internal/mcpserver/client_test.go
@@ -187,7 +187,7 @@ func TestNewSSEClientWithNilHeaders(t *testing.T) {
 
 // TestNewDynamicAuthClientWithNilStore tests that nil token store is handled gracefully
 func TestNewDynamicAuthClientWithNilStore(t *testing.T) {
-	client := NewDynamicAuthClient("http://example.com/mcp", nil, "openid")
+	client := NewDynamicAuthClient("http://example.com/mcp", nil, "openid", "https://muster.example.com/.well-known/oauth-client.json", "")
 
 	assert.NotNil(t, client)
 	assert.Equal(t, "http://example.com/mcp", client.url)
@@ -261,7 +261,7 @@ func TestClientOperationsWithoutConnection(t *testing.T) {
 	})
 
 	t.Run("DynamicAuthClient", func(t *testing.T) {
-		client := NewDynamicAuthClient("http://example.com/mcp", nil, "openid")
+		client := NewDynamicAuthClient("http://example.com/mcp", nil, "openid", "https://muster.example.com/.well-known/oauth-client.json", "")
 		testClientNotConnected(t, client)
 	})
 }

--- a/internal/mcpserver/oauth_token_store_adapter_test.go
+++ b/internal/mcpserver/oauth_token_store_adapter_test.go
@@ -58,6 +58,9 @@ func (m *stubOAuthHandler) Stop()                                               
 func (m *stubOAuthHandler) CreateAuthChallenge(_ context.Context, _, _, _, _, _ string) (*api.AuthChallenge, error) {
 	return nil, nil
 }
+func (m *stubOAuthHandler) GetClientCredentialsForIssuer(_ context.Context, _ string) (string, string) {
+	return "", ""
+}
 func (m *stubOAuthHandler) ExchangeTokenForRemoteCluster(_ context.Context, _, _ string, _ *api.TokenExchangeConfig) (string, error) {
 	return "", nil
 }

--- a/internal/oauth/api_adapter.go
+++ b/internal/oauth/api_adapter.go
@@ -147,11 +147,19 @@ func (a *Adapter) CreateAuthChallenge(ctx context.Context, sessionID, userID, se
 	}
 
 	return &api.AuthChallenge{
-		Status:     challenge.Status,
-		AuthURL:    challenge.AuthURL,
-		ServerName: challenge.ServerName,
-		Message:    challenge.Message,
+		Status:         challenge.Status,
+		AuthURL:        challenge.AuthURL,
+		ServerName:     challenge.ServerName,
+		Message:        challenge.Message,
+		ClientIDMethod: challenge.ClientIDMethod,
 	}, nil
+}
+
+// GetClientCredentialsForIssuer returns the client_id and client_secret the
+// OAuth flows use against the given issuer, without triggering a new
+// registration.
+func (a *Adapter) GetClientCredentialsForIssuer(ctx context.Context, issuer string) (clientID, clientSecret string) {
+	return a.manager.GetClientCredentialsForIssuer(ctx, issuer)
 }
 
 // GetHTTPHandler returns the HTTP handler for OAuth callback endpoints.

--- a/internal/oauth/client.go
+++ b/internal/oauth/client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/giantswarm/muster/internal/config"
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
@@ -15,6 +17,33 @@ import (
 // softwareVersion is the version string reported in the Client ID Metadata Document.
 // This is informational only and helps identify the muster version during OAuth debugging.
 const softwareVersion = "1.0.0"
+
+// Client identification methods, reported on auth challenges so front-ends
+// can tell users how muster identifies itself to the authorization server.
+const (
+	// ClientIDMethodCIMD: the AS advertises
+	// client_id_metadata_document_supported, so muster's self-hosted CIMD URL
+	// is used as client_id (stateless, spec-preferred).
+	ClientIDMethodCIMD = "cimd"
+
+	// ClientIDMethodDCR: the AS does not advertise CIMD support but offers a
+	// registration_endpoint; muster registered itself via RFC 7591 and uses
+	// the issued, issuer-bound credentials.
+	ClientIDMethodDCR = "dcr"
+
+	// ClientIDMethodCIMDFallback: the AS advertises neither CIMD support nor
+	// a registration endpoint. Muster sends the CIMD URL anyway (some ASes
+	// resolve CIMDs without advertising the flag), but the AS may reject the
+	// flow with a client-not-registered error.
+	ClientIDMethodCIMDFallback = "cimd-fallback"
+)
+
+// resolvedClient is the client identification chosen for one issuer.
+type resolvedClient struct {
+	ClientID     string
+	ClientSecret string
+	Method       string
+}
 
 // Client handles OAuth 2.1 flows for remote MCP server authentication.
 type Client struct {
@@ -27,6 +56,11 @@ type Client struct {
 	// Stores (interface-backed; defaults to in-memory, can be swapped to Valkey)
 	tokenStore TokenStorer
 	stateStore StateStorer
+	credStore  ClientCredentialStorer
+
+	// registerMu serializes DCR registrations so concurrent auth flows for
+	// the same issuer don't register muster twice.
+	registerMu sync.Mutex
 
 	// Shared OAuth client for protocol operations
 	oauthClient *pkgoauth.Client
@@ -49,6 +83,14 @@ func WithStateStorer(ss StateStorer) ClientOption {
 	}
 }
 
+// WithClientCredentialStorer sets a custom ClientCredentialStorer
+// implementation (e.g., Valkey-backed) for DCR-issued client credentials.
+func WithClientCredentialStorer(cs ClientCredentialStorer) ClientOption {
+	return func(c *Client) {
+		c.credStore = cs
+	}
+}
+
 // NewClient creates a new OAuth client with the given configuration.
 // By default, in-memory stores are used. Use WithTokenStorer / WithStateStorer
 // to inject Valkey-backed implementations.
@@ -60,6 +102,7 @@ func NewClient(clientID, publicURL, callbackPath, cimdScopes string, opts ...Cli
 		cimdScopes:   cimdScopes,
 		tokenStore:   NewTokenStore(),
 		stateStore:   NewStateStore(),
+		credStore:    NewClientCredentialStore(),
 		oauthClient:  pkgoauth.NewClient(),
 	}
 	for _, opt := range opts {
@@ -105,12 +148,67 @@ func (c *Client) GetToken(sessionID, issuer, scope string) *pkgoauth.Token {
 	return c.tokenStore.GetByIssuer(sessionID, issuer)
 }
 
+// resolveClient decides how muster identifies itself to the given issuer:
+// CIMD when the AS advertises support for it, previously registered
+// DCR credentials when present, a fresh RFC 7591 registration when the AS
+// offers one (and allowRegistration is set), and the CIMD URL as a last
+// resort. Registration failures fall back to the CIMD URL rather than
+// aborting — that is never worse than the pre-DCR behavior.
+func (c *Client) resolveClient(ctx context.Context, issuer string, metadata *pkgoauth.Metadata, allowRegistration bool) *resolvedClient {
+	if metadata.ClientIDMetadataDocumentSupported {
+		return &resolvedClient{ClientID: c.clientID, Method: ClientIDMethodCIMD}
+	}
+
+	if creds := c.credStore.Get(issuer); creds != nil {
+		return &resolvedClient{ClientID: creds.ClientID, ClientSecret: creds.ClientSecret, Method: ClientIDMethodDCR}
+	}
+
+	if allowRegistration && metadata.RegistrationEndpoint != "" {
+		c.registerMu.Lock()
+		defer c.registerMu.Unlock()
+
+		// Re-check after acquiring the lock: a concurrent flow may have
+		// registered while we waited.
+		if creds := c.credStore.Get(issuer); creds != nil {
+			return &resolvedClient{ClientID: creds.ClientID, ClientSecret: creds.ClientSecret, Method: ClientIDMethodDCR}
+		}
+
+		registration, err := c.oauthClient.RegisterClient(ctx, metadata.RegistrationEndpoint, c.GetRegistrationMetadata())
+		if err != nil {
+			logging.Warn("OAuth", "Dynamic client registration with %s failed, falling back to CIMD URL as client_id: %v",
+				issuer, err)
+			return &resolvedClient{ClientID: c.clientID, Method: ClientIDMethodCIMDFallback}
+		}
+
+		creds := &pkgoauth.ClientCredentials{
+			Issuer:                  issuer,
+			ClientID:                registration.ClientID,
+			ClientSecret:            registration.ClientSecret,
+			RegistrationAccessToken: registration.RegistrationAccessToken,
+			RegistrationClientURI:   registration.RegistrationClientURI,
+			CreatedAt:               time.Now(),
+		}
+		if registration.ClientSecretExpiresAt > 0 {
+			creds.ClientSecretExpiresAt = time.Unix(registration.ClientSecretExpiresAt, 0)
+		}
+		c.credStore.Store(issuer, creds)
+
+		logging.Info("OAuth", "Registered muster as an OAuth client with %s via RFC 7591 (client_id=%s)",
+			issuer, registration.ClientID)
+		return &resolvedClient{ClientID: creds.ClientID, ClientSecret: creds.ClientSecret, Method: ClientIDMethodDCR}
+	}
+
+	return &resolvedClient{ClientID: c.clientID, Method: ClientIDMethodCIMDFallback}
+}
+
 // GenerateAuthURL creates an OAuth authorization URL for user authentication.
-// Returns the URL. The code verifier is stored with the state for later retrieval.
-func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverName, issuer, scope string) (string, error) {
+// Returns the URL and the client identification method used (one of the
+// ClientIDMethod* constants). The code verifier is stored with the state for
+// later retrieval.
+func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverName, issuer, scope string) (string, string, error) {
 	metadata, err := c.oauthClient.DiscoverMetadata(ctx, issuer)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch OAuth metadata: %w", err)
+		return "", "", fmt.Errorf("failed to fetch OAuth metadata: %w", err)
 	}
 
 	// MCP 2025-11-25 §"Authorization Code Protection" requires refusing the
@@ -118,12 +216,16 @@ func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverN
 	// doesn't list it may silently ignore code_challenge_method=S256 and
 	// produce confusing token-endpoint errors later.
 	if !metadata.SupportsS256PKCE() {
-		return "", fmt.Errorf("authorization server %q does not advertise S256 PKCE in code_challenge_methods_supported (MCP 2025-11-25 requires refusal)", issuer)
+		return "", "", fmt.Errorf("authorization server %q does not advertise S256 PKCE in code_challenge_methods_supported (MCP 2025-11-25 requires refusal)", issuer)
 	}
+
+	// Resolve the client identification for this issuer, registering via
+	// RFC 7591 when the AS supports DCR but not CIMD.
+	resolved := c.resolveClient(ctx, issuer, metadata, true)
 
 	pkce, err := pkgoauth.GeneratePKCE()
 	if err != nil {
-		return "", fmt.Errorf("failed to generate PKCE: %w", err)
+		return "", "", fmt.Errorf("failed to generate PKCE: %w", err)
 	}
 
 	// The upstream authorization URL is stored with the state in a single
@@ -135,7 +237,7 @@ func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverN
 		func(encodedState string) (string, error) {
 			return c.oauthClient.BuildAuthorizationURL(
 				metadata.AuthorizationEndpoint,
-				c.clientID,
+				resolved.ClientID,
 				c.GetRedirectURI(),
 				encodedState,
 				scope,
@@ -143,13 +245,13 @@ func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverN
 			)
 		})
 	if err != nil {
-		return "", fmt.Errorf("failed to generate state: %w", err)
+		return "", "", fmt.Errorf("failed to generate state: %w", err)
 	}
 
-	logging.Debug("OAuth", "Generated auth URL for session=%s server=%s issuer=%s",
-		logging.TruncateIdentifier(sessionID), serverName, issuer)
+	logging.Debug("OAuth", "Generated auth URL for session=%s server=%s issuer=%s clientIdMethod=%s",
+		logging.TruncateIdentifier(sessionID), serverName, issuer, resolved.Method)
 
-	return c.GetStartURL(state), nil
+	return c.GetStartURL(state), resolved.Method, nil
 }
 
 // GetStartURL returns the muster-hosted start URL for an encoded state. The
@@ -167,13 +269,19 @@ func (c *Client) ExchangeCode(ctx context.Context, code, codeVerifier, issuer st
 		return nil, fmt.Errorf("failed to fetch OAuth metadata: %w", err)
 	}
 
+	// Resolve the same client identification the authorization request used.
+	// Registration is not attempted here: any DCR registration happened in
+	// GenerateAuthURL, and its credentials are read back from the store.
+	resolved := c.resolveClient(ctx, issuer, metadata, false)
+
 	// Exchange code using shared client
 	token, err := c.oauthClient.ExchangeCode(
 		ctx,
 		metadata.TokenEndpoint,
 		code,
 		c.GetRedirectURI(),
-		c.clientID,
+		resolved.ClientID,
+		resolved.ClientSecret,
 		codeVerifier,
 	)
 	if err != nil {
@@ -203,9 +311,13 @@ func (c *Client) StoreToken(sessionID, userID string, token *pkgoauth.Token) {
 func (c *Client) Stop() {
 	c.tokenStore.Stop()
 	c.stateStore.Stop()
+	c.credStore.Stop()
 }
 
 // GetClientMetadata returns the Client ID Metadata Document for this client.
+// ApplicationType "web" is included per SEP-837: authorization servers that
+// resolve the CIMD and synthesize a registration would otherwise apply an
+// OIDC default that can reject non-localhost redirect URIs.
 func (c *Client) GetClientMetadata() *pkgoauth.ClientMetadata {
 	return &pkgoauth.ClientMetadata{
 		ClientID:                c.clientID,
@@ -218,7 +330,37 @@ func (c *Client) GetClientMetadata() *pkgoauth.ClientMetadata {
 		Scope:                   c.cimdScopes,
 		SoftwareID:              "giantswarm-muster",
 		SoftwareVersion:         softwareVersion,
+		ApplicationType:         "web",
 	}
+}
+
+// GetRegistrationMetadata returns the RFC 7591 client metadata muster sends
+// on Dynamic Client Registration requests. It mirrors the CIMD content but
+// omits client_id (forbidden on registration requests) and requests
+// token_endpoint_auth_method "none" — muster is a public client protected by
+// PKCE, and staying secret-free keeps the DCR path as close to the CIMD path
+// as the AS allows. ASes that insist on issuing a secret still can; the
+// response's client_secret is honored either way.
+func (c *Client) GetRegistrationMetadata() *pkgoauth.ClientMetadata {
+	metadata := c.GetClientMetadata()
+	metadata.ClientID = ""
+	return metadata
+}
+
+// GetClientCredentialsForIssuer returns the client_id and client_secret the
+// OAuth flows use against the given issuer, without triggering a new DCR
+// registration. This backs mcp-go's transport-level token refresh, which
+// must present the same client identification the token was issued under.
+func (c *Client) GetClientCredentialsForIssuer(ctx context.Context, issuer string) (clientID, clientSecret string) {
+	metadata, err := c.oauthClient.DiscoverMetadata(ctx, issuer)
+	if err != nil {
+		// Metadata should be cached from the original flow; on a cold cache
+		// with an unreachable AS the CIMD URL is the only sensible answer.
+		logging.Debug("OAuth", "GetClientCredentialsForIssuer: metadata discovery for %s failed, using CIMD URL: %v", issuer, err)
+		return c.clientID, ""
+	}
+	resolved := c.resolveClient(ctx, issuer, metadata, false)
+	return resolved.ClientID, resolved.ClientSecret
 }
 
 // DiscoverMetadata fetches OAuth metadata for an issuer.

--- a/internal/oauth/client_dcr_test.go
+++ b/internal/oauth/client_dcr_test.go
@@ -1,0 +1,309 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
+)
+
+// dcrTestServer is a minimal AS stub: RFC 8414 metadata plus an RFC 7591
+// registration endpoint that records requests and issues configurable
+// credentials.
+type dcrTestServer struct {
+	server *httptest.Server
+
+	// Metadata switches
+	advertiseCIMD bool
+	advertiseDCR  bool
+
+	// Registration behavior
+	registrationStatus int // 0 → 201
+	issueSecret        bool
+
+	registrationCount atomic.Int64
+	lastRegistration  atomic.Value // *pkgoauth.ClientMetadata
+}
+
+func newDCRTestServer(t *testing.T) *dcrTestServer {
+	t.Helper()
+	s := &dcrTestServer{}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pkgoauth.WellKnownAuthorizationServer:
+			metadata := map[string]any{
+				"issuer":                                s.server.URL,
+				"authorization_endpoint":                s.server.URL + "/authorize",
+				"token_endpoint":                        s.server.URL + "/token",
+				"code_challenge_methods_supported":      []string{"S256"},
+				"token_endpoint_auth_methods_supported": []string{"none"},
+			}
+			if s.advertiseCIMD {
+				metadata["client_id_metadata_document_supported"] = true
+			}
+			if s.advertiseDCR {
+				metadata["registration_endpoint"] = s.server.URL + "/register"
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(metadata)
+
+		case "/register":
+			s.registrationCount.Add(1)
+			var req pkgoauth.ClientMetadata
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			s.lastRegistration.Store(&req)
+
+			if s.registrationStatus != 0 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(s.registrationStatus)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":             "invalid_client_metadata",
+					"error_description": "rejected for testing",
+				})
+				return
+			}
+
+			resp := map[string]any{
+				"client_id": "dcr-client-123",
+			}
+			if s.issueSecret {
+				resp["client_secret"] = "dcr-secret-456"
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case "/token":
+			_ = r.ParseForm()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "at-" + r.Form.Get("client_id") + "|" + r.Form.Get("client_secret"),
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+// upstreamClientID extracts the client_id from the upstream authorization URL
+// stored with the state behind a muster-hosted start URL.
+func upstreamClientID(t *testing.T, client *Client, startURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(startURL)
+	if err != nil {
+		t.Fatalf("failed to parse start URL: %v", err)
+	}
+	state := client.stateStore.Update(parsed.Query().Get("state"), func(*OAuthState) {})
+	if state == nil {
+		t.Fatal("state should be stored")
+	}
+	upstream, err := url.Parse(state.AuthorizationURL)
+	if err != nil {
+		t.Fatalf("failed to parse upstream URL: %v", err)
+	}
+	return upstream.Query().Get("client_id")
+}
+
+func TestClient_GenerateAuthURL_PrefersCIMDWhenAdvertised(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseCIMD = true
+	as.advertiseDCR = true // both advertised — CIMD must win, no registration
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+
+	startURL, method, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
+	if err != nil {
+		t.Fatalf("GenerateAuthURL failed: %v", err)
+	}
+	if method != ClientIDMethodCIMD {
+		t.Errorf("expected method %q, got %q", ClientIDMethodCIMD, method)
+	}
+	if got := upstreamClientID(t, client, startURL); got != "https://muster.example.com/.well-known/oauth-client.json" {
+		t.Errorf("expected CIMD URL as client_id, got %q", got)
+	}
+	if n := as.registrationCount.Load(); n != 0 {
+		t.Errorf("expected no DCR registration when CIMD is advertised, got %d", n)
+	}
+}
+
+func TestClient_GenerateAuthURL_FallsBackToDCR(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseDCR = true
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+
+	startURL, method, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
+	if err != nil {
+		t.Fatalf("GenerateAuthURL failed: %v", err)
+	}
+	if method != ClientIDMethodDCR {
+		t.Errorf("expected method %q, got %q", ClientIDMethodDCR, method)
+	}
+	if got := upstreamClientID(t, client, startURL); got != "dcr-client-123" {
+		t.Errorf("expected DCR-issued client_id, got %q", got)
+	}
+
+	// SEP-837: registration requests from the server-side proxy carry
+	// application_type "web"; RFC 7591 forbids client_id on the request.
+	reg, _ := as.lastRegistration.Load().(*pkgoauth.ClientMetadata)
+	if reg == nil {
+		t.Fatal("expected a registration request to have been recorded")
+	}
+	if reg.ApplicationType != "web" {
+		t.Errorf("expected application_type web on the DCR request, got %q", reg.ApplicationType)
+	}
+	if reg.ClientID != "" {
+		t.Errorf("DCR request must not carry client_id, got %q", reg.ClientID)
+	}
+	if reg.TokenEndpointAuthMethod != "none" {
+		t.Errorf("expected token_endpoint_auth_method none, got %q", reg.TokenEndpointAuthMethod)
+	}
+
+	// A second flow for the same issuer reuses the stored credentials.
+	_, method2, err := client.GenerateAuthURL(context.Background(), "session-2", "user-2", "server-1", as.server.URL, "openid")
+	if err != nil {
+		t.Fatalf("second GenerateAuthURL failed: %v", err)
+	}
+	if method2 != ClientIDMethodDCR {
+		t.Errorf("expected method %q on reuse, got %q", ClientIDMethodDCR, method2)
+	}
+	if n := as.registrationCount.Load(); n != 1 {
+		t.Errorf("expected exactly one DCR registration, got %d", n)
+	}
+}
+
+func TestClient_GenerateAuthURL_CIMDFallbackWhenRegistrationFails(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseDCR = true
+	as.registrationStatus = http.StatusBadRequest
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+
+	startURL, method, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
+	if err != nil {
+		t.Fatalf("GenerateAuthURL failed: %v", err)
+	}
+	if method != ClientIDMethodCIMDFallback {
+		t.Errorf("expected method %q, got %q", ClientIDMethodCIMDFallback, method)
+	}
+	if got := upstreamClientID(t, client, startURL); got != "https://muster.example.com/.well-known/oauth-client.json" {
+		t.Errorf("expected CIMD URL as fallback client_id, got %q", got)
+	}
+}
+
+func TestClient_ExchangeCode_UsesDCRCredentials(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseDCR = true
+	as.issueSecret = true
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+
+	// The auth flow registers via DCR and stores the credentials.
+	_, _, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
+	if err != nil {
+		t.Fatalf("GenerateAuthURL failed: %v", err)
+	}
+
+	// The code exchange must present the same registered credentials. The
+	// stub token endpoint echoes client_id|client_secret in the access token.
+	token, err := client.ExchangeCode(context.Background(), "code-1", "verifier-1", as.server.URL)
+	if err != nil {
+		t.Fatalf("ExchangeCode failed: %v", err)
+	}
+	if token.AccessToken != "at-dcr-client-123|dcr-secret-456" {
+		t.Errorf("token exchange did not use the DCR credentials: %q", token.AccessToken)
+	}
+}
+
+func TestClient_GetClientCredentialsForIssuer(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseDCR = true
+	as.issueSecret = true
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+
+	// Before any flow: no stored credentials, no registration triggered —
+	// the CIMD URL is returned and the registration endpoint stays untouched.
+	clientID, secret := client.GetClientCredentialsForIssuer(context.Background(), as.server.URL)
+	if clientID != "https://muster.example.com/.well-known/oauth-client.json" || secret != "" {
+		t.Errorf("expected CIMD URL with no secret before registration, got %q / %q", clientID, secret)
+	}
+	if n := as.registrationCount.Load(); n != 0 {
+		t.Errorf("credential lookup must not register, got %d registrations", n)
+	}
+
+	// After a flow registered via DCR, the stored credentials are returned.
+	if _, _, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid"); err != nil {
+		t.Fatalf("GenerateAuthURL failed: %v", err)
+	}
+	clientID, secret = client.GetClientCredentialsForIssuer(context.Background(), as.server.URL)
+	if clientID != "dcr-client-123" || secret != "dcr-secret-456" {
+		t.Errorf("expected DCR credentials, got %q / %q", clientID, secret)
+	}
+}
+
+func TestClientCredentialStore_ExpiredSecretIsDropped(t *testing.T) {
+	store := NewClientCredentialStore()
+	defer store.Stop()
+
+	store.Store("https://as.example.com", &pkgoauth.ClientCredentials{
+		Issuer:                "https://as.example.com",
+		ClientID:              "abc",
+		ClientSecret:          "secret",
+		ClientSecretExpiresAt: time.Now().Add(-time.Minute),
+	})
+	if got := store.Get("https://as.example.com"); got != nil {
+		t.Errorf("expected expired credentials to be dropped, got %+v", got)
+	}
+
+	// Public-client credentials (no secret) never expire.
+	store.Store("https://as2.example.com", &pkgoauth.ClientCredentials{
+		Issuer:   "https://as2.example.com",
+		ClientID: "public",
+	})
+	if got := store.Get("https://as2.example.com"); got == nil || got.ClientID != "public" {
+		t.Errorf("expected public-client credentials to be returned, got %+v", got)
+	}
+}
+
+func TestClient_ServesCIMDWithApplicationType(t *testing.T) {
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+
+	cimd := client.GetClientMetadata()
+	if cimd.ApplicationType != "web" {
+		t.Errorf("expected CIMD application_type web (SEP-837), got %q", cimd.ApplicationType)
+	}
+	if cimd.ClientID == "" {
+		t.Error("CIMD must carry its own client_id")
+	}
+	if !strings.Contains(cimd.ClientID, ".well-known/oauth-client.json") {
+		t.Errorf("CIMD client_id should be the CIMD URL, got %q", cimd.ClientID)
+	}
+}

--- a/internal/oauth/client_test.go
+++ b/internal/oauth/client_test.go
@@ -256,9 +256,15 @@ func TestClient_GenerateAuthURL(t *testing.T) {
 	defer client.Stop()
 
 	ctx := context.Background()
-	authURL, err := client.GenerateAuthURL(ctx, testSubject, "test-user", testServerName, server.URL, testScopes)
+	authURL, clientIDMethod, err := client.GenerateAuthURL(ctx, testSubject, "test-user", testServerName, server.URL, testScopes)
 	if err != nil {
 		t.Fatalf("Failed to generate auth URL: %v", err)
+	}
+
+	// The AS advertises neither CIMD support nor a registration endpoint, so
+	// the status-quo fallback (CIMD URL as client_id) is used.
+	if clientIDMethod != ClientIDMethodCIMDFallback {
+		t.Errorf("Expected clientIDMethod %q, got %q", ClientIDMethodCIMDFallback, clientIDMethod)
 	}
 
 	// The user-facing URL is the muster-hosted start endpoint carrying the state.
@@ -331,7 +337,7 @@ func TestClient_GenerateAuthURL_RefusesWithoutS256PKCE(t *testing.T) {
 	client := NewClient("client-id", "https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
 	defer client.Stop()
 
-	_, err := client.GenerateAuthURL(context.Background(), testSubject, "test-user", testServerName, server.URL, testScopes)
+	_, _, err := client.GenerateAuthURL(context.Background(), testSubject, "test-user", testServerName, server.URL, testScopes)
 	if err == nil {
 		t.Fatal("expected refusal error when AS does not advertise S256 PKCE")
 	}

--- a/internal/oauth/credential_store.go
+++ b/internal/oauth/credential_store.go
@@ -1,0 +1,86 @@
+package oauth
+
+import (
+	"sync"
+
+	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
+)
+
+// ClientCredentialStorer is the interface for issuer-keyed OAuth client
+// credentials obtained via Dynamic Client Registration (RFC 7591).
+// Implementations must be safe for concurrent use.
+//
+// Per SEP-2352 credentials are bound to the issuer they were registered
+// with; there is deliberately no way to look up credentials without naming
+// the issuer.
+type ClientCredentialStorer interface {
+	// Get returns the credentials registered with the given issuer, or nil
+	// when none are stored or the stored secret has expired.
+	Get(issuer string) *pkgoauth.ClientCredentials
+
+	// Store saves credentials for the issuer, replacing any previous entry.
+	Store(issuer string, creds *pkgoauth.ClientCredentials)
+
+	// Delete removes the credentials for the issuer (e.g. after the AS
+	// stopped accepting them, so the next flow re-registers).
+	Delete(issuer string)
+
+	// Stop releases resources (background goroutines, connections, etc.).
+	Stop()
+}
+
+// ClientCredentialStore provides thread-safe in-memory storage for
+// DCR-issued client credentials, keyed by issuer. Registrations represent
+// muster itself (not a user or session), so there is one entry per
+// authorization server. Losing the store on restart is harmless: the next
+// auth flow simply registers again.
+type ClientCredentialStore struct {
+	mu    sync.RWMutex
+	creds map[string]*pkgoauth.ClientCredentials
+}
+
+// NewClientCredentialStore creates a new in-memory client credential store.
+func NewClientCredentialStore() *ClientCredentialStore {
+	return &ClientCredentialStore{
+		creds: make(map[string]*pkgoauth.ClientCredentials),
+	}
+}
+
+// Get returns the credentials for the issuer, or nil if absent or expired.
+func (s *ClientCredentialStore) Get(issuer string) *pkgoauth.ClientCredentials {
+	s.mu.RLock()
+	creds := s.creds[issuer]
+	s.mu.RUnlock()
+
+	if creds == nil {
+		return nil
+	}
+	if creds.IsExpired() {
+		s.Delete(issuer)
+		return nil
+	}
+	return creds
+}
+
+// Store saves credentials for the issuer, replacing any previous entry.
+func (s *ClientCredentialStore) Store(issuer string, creds *pkgoauth.ClientCredentials) {
+	if creds == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creds[issuer] = creds
+}
+
+// Delete removes the credentials for the issuer.
+func (s *ClientCredentialStore) Delete(issuer string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.creds, issuer)
+}
+
+// Stop is a no-op for the in-memory store.
+func (s *ClientCredentialStore) Stop() {}
+
+// Ensure ClientCredentialStore implements ClientCredentialStorer.
+var _ ClientCredentialStorer = (*ClientCredentialStore)(nil)

--- a/internal/oauth/credential_store_valkey.go
+++ b/internal/oauth/credential_store_valkey.go
@@ -1,0 +1,132 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/valkey-io/valkey-go"
+
+	"github.com/giantswarm/muster/internal/config"
+	"github.com/giantswarm/muster/pkg/logging"
+	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
+)
+
+// ValkeyClientCredentialStore stores DCR-issued client credentials in Valkey
+// with optional AES-256-GCM encryption at rest. Sharing the store across
+// replicas matters more here than for tokens: the authorization request and
+// the callback's code exchange may land on different replicas, and both must
+// resolve the same issuer-bound client_id.
+//
+// Data model:
+//
+//	Key:    {keyPrefix}oauth:client_creds
+//	Fields: {issuer} -> [encrypted] JSON(pkgoauth.ClientCredentials)
+//	TTL:    none — registrations represent muster itself and stay valid
+//	        until the AS revokes them; expired secrets are dropped on read.
+type ValkeyClientCredentialStore struct {
+	valkeyEncryption
+	client    valkey.Client
+	keyPrefix string
+}
+
+// NewValkeyClientCredentialStore creates a Valkey-backed client credential
+// store. keyPrefix is prepended to all Valkey keys (default "muster:" if
+// empty). encryptor enables AES-256-GCM encryption at rest; pass nil to
+// disable.
+func NewValkeyClientCredentialStore(client valkey.Client, keyPrefix string, encryptor *security.Encryptor) *ValkeyClientCredentialStore {
+	if keyPrefix == "" {
+		keyPrefix = config.DefaultValkeyKeyPrefix
+	}
+	return &ValkeyClientCredentialStore{
+		valkeyEncryption: valkeyEncryption{encryptor: encryptor},
+		client:           client,
+		keyPrefix:        keyPrefix,
+	}
+}
+
+func (s *ValkeyClientCredentialStore) key() string {
+	return s.keyPrefix + "oauth:client_creds"
+}
+
+// Get returns the credentials for the issuer, or nil if absent or expired.
+func (s *ValkeyClientCredentialStore) Get(issuer string) *pkgoauth.ClientCredentials {
+	ctx := context.Background()
+
+	cmd := s.client.B().Hget().Key(s.key()).Field(issuer).Build()
+	result := s.client.Do(ctx, cmd)
+	if err := result.Error(); err != nil {
+		if valkey.IsValkeyNil(err) {
+			return nil
+		}
+		logging.Warn("OAuth", "ValkeyClientCredentialStore: Get failed: %v", err)
+		return nil
+	}
+
+	stored, err := result.ToString()
+	if err != nil {
+		return nil
+	}
+
+	plaintext, err := s.decryptValue(stored)
+	if err != nil {
+		logging.Warn("OAuth", "ValkeyClientCredentialStore: decryption failed: %v", err)
+		return nil
+	}
+
+	var creds pkgoauth.ClientCredentials
+	if err := json.Unmarshal(plaintext, &creds); err != nil {
+		logging.Warn("OAuth", "ValkeyClientCredentialStore: unmarshal failed: %v", err)
+		return nil
+	}
+
+	if creds.IsExpired() {
+		s.Delete(issuer)
+		return nil
+	}
+	return &creds
+}
+
+// Store saves credentials for the issuer, replacing any previous entry.
+func (s *ValkeyClientCredentialStore) Store(issuer string, creds *pkgoauth.ClientCredentials) {
+	if creds == nil {
+		return
+	}
+	ctx := context.Background()
+
+	jsonData, err := json.Marshal(creds) //nolint:gosec
+	if err != nil {
+		logging.Warn("OAuth", "ValkeyClientCredentialStore: failed to marshal credentials: %v", err)
+		return
+	}
+
+	value, err := s.encryptValue(jsonData)
+	if err != nil {
+		logging.Warn("OAuth", "ValkeyClientCredentialStore: failed to encrypt credentials: %v", err)
+		return
+	}
+
+	cmd := s.client.B().Hset().Key(s.key()).FieldValue().FieldValue(issuer, value).Build()
+	if err := s.client.Do(ctx, cmd).Error(); err != nil {
+		logging.Warn("OAuth", "ValkeyClientCredentialStore: Store failed: %v", err)
+		return
+	}
+
+	logging.Debug("OAuth", "ValkeyClientCredentialStore: stored client credentials for issuer=%s", issuer)
+}
+
+// Delete removes the credentials for the issuer.
+func (s *ValkeyClientCredentialStore) Delete(issuer string) {
+	ctx := context.Background()
+
+	cmd := s.client.B().Hdel().Key(s.key()).Field(issuer).Build()
+	if err := s.client.Do(ctx, cmd).Error(); err != nil {
+		logging.Warn("OAuth", "ValkeyClientCredentialStore: Delete failed: %v", err)
+	}
+}
+
+// Stop is a no-op; the Valkey client lifecycle is owned by the caller.
+func (s *ValkeyClientCredentialStore) Stop() {}
+
+// Ensure ValkeyClientCredentialStore implements ClientCredentialStorer.
+var _ ClientCredentialStorer = (*ValkeyClientCredentialStore)(nil)

--- a/internal/oauth/doc.go
+++ b/internal/oauth/doc.go
@@ -20,9 +20,35 @@
 //
 //   - TokenStore: In-memory storage for OAuth tokens, indexed by session and issuer
 //   - StateStore: Manages OAuth state parameters for CSRF protection
+//   - ClientCredentialStore: Issuer-keyed storage for DCR-issued client credentials
 //   - Client: Handles OAuth flows, code exchange, and token refresh
 //   - Handler: HTTP handler for the /oauth/callback endpoint
 //   - Manager: Coordinates OAuth flows and integrates with the aggregator
+//
+// # Client Identification (CIMD vs DCR)
+//
+// Muster identifies itself to upstream authorization servers per issuer, in
+// this order:
+//
+//  1. CIMD: when the AS metadata advertises
+//     client_id_metadata_document_supported, muster's self-hosted Client ID
+//     Metadata Document URL is used as client_id. This is stateless,
+//     secret-free, and portable across authorization servers (SEP-2352).
+//  2. DCR: otherwise, when the AS advertises a registration_endpoint, muster
+//     registers itself once via RFC 7591 Dynamic Client Registration
+//     (requesting token_endpoint_auth_method "none" and sending
+//     application_type "web" per SEP-837) and uses the issued credentials.
+//     Credentials are keyed by issuer and stored in the
+//     ClientCredentialStore (in-memory by default, Valkey-backed when
+//     configured) — they are never reused against a different issuer.
+//  3. Fallback: when the AS advertises neither, the CIMD URL is sent anyway
+//     (some servers resolve CIMDs without advertising the flag). The auth
+//     challenge marks this case ("cimd-fallback") so front-ends can warn
+//     that the AS may reject the sign-in.
+//
+// The resolved client_id (and secret, if any) is used consistently across
+// the authorization request, the authorization-code exchange, and mcp-go's
+// transport-level token refresh.
 //
 // # Security
 //

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -80,6 +80,15 @@ func WithValkeyStateStore(ss StateStorer) ManagerOption {
 	}
 }
 
+// WithValkeyClientCredentialStore injects a Valkey-backed
+// ClientCredentialStorer into the OAuth client, so DCR-issued client
+// credentials are shared across replicas.
+func WithValkeyClientCredentialStore(cs ClientCredentialStorer) ManagerOption {
+	return func(o *managerOptions) {
+		o.clientOpts = append(o.clientOpts, WithClientCredentialStorer(cs))
+	}
+}
+
 // NewManager creates a new OAuth manager with the given configuration.
 // The cfg parameter contains the OAuth MCP client/proxy configuration for
 // authenticating TO remote MCP servers.
@@ -338,16 +347,22 @@ func (m *Manager) CreateAuthChallenge(ctx context.Context, sessionID, userID, se
 	m.RegisterServer(serverName, issuer, scope)
 
 	// Generate authorization URL (code verifier is stored with the state)
-	authURL, err := m.client.GenerateAuthURL(ctx, sessionID, userID, serverName, issuer, scope)
+	authURL, clientIDMethod, err := m.client.GenerateAuthURL(ctx, sessionID, userID, serverName, issuer, scope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate auth URL: %w", err)
 	}
 
+	message := fmt.Sprintf("Authentication required for %s. Please visit the link below to authenticate.", serverName)
+	if clientIDMethod == ClientIDMethodCIMDFallback {
+		message += " Note: this server's authorization server advertises neither Client ID Metadata Document support nor dynamic client registration; the sign-in may be rejected if it requires pre-registered clients."
+	}
+
 	challenge := &AuthRequiredResponse{
-		Status:     "auth_required",
-		AuthURL:    authURL,
-		ServerName: serverName,
-		Message:    fmt.Sprintf("Authentication required for %s. Please visit the link below to authenticate.", serverName),
+		Status:         "auth_required",
+		AuthURL:        authURL,
+		ServerName:     serverName,
+		Message:        message,
+		ClientIDMethod: clientIDMethod,
 	}
 
 	logging.Info("OAuth", "Created auth challenge for session=%s server=%s",
@@ -449,6 +464,17 @@ func (m *Manager) GetTokenExchanger() *TokenExchanger {
 		return nil
 	}
 	return m.tokenExchanger
+}
+
+// GetClientCredentialsForIssuer returns the client_id and client_secret the
+// OAuth flows use against the given issuer (CIMD URL or DCR-issued
+// credentials), without triggering a new registration. Used to configure
+// mcp-go's transport-level token refresh.
+func (m *Manager) GetClientCredentialsForIssuer(ctx context.Context, issuer string) (clientID, clientSecret string) {
+	if m == nil {
+		return "", ""
+	}
+	return m.client.GetClientCredentialsForIssuer(ctx, issuer)
 }
 
 // Stop stops the OAuth manager and cleans up resources.

--- a/internal/oauth/types.go
+++ b/internal/oauth/types.go
@@ -69,4 +69,10 @@ type AuthRequiredResponse struct {
 
 	// Message is a human-readable description of why auth is needed.
 	Message string `json:"message,omitempty"`
+
+	// ClientIDMethod reports how muster identifies itself to the
+	// authorization server for this flow: "cimd" (AS advertises CIMD
+	// support), "dcr" (RFC 7591 registered credentials), or "cimd-fallback"
+	// (neither advertised — the AS may reject the sign-in).
+	ClientIDMethod string `json:"client_id_method,omitempty"`
 }

--- a/internal/testing/mock/oauth_server.go
+++ b/internal/testing/mock/oauth_server.go
@@ -109,6 +109,20 @@ type OAuthServerConfig struct {
 	// (e.g. muster's broker) can verify against this server's JWKS. Default false
 	// keeps the legacy alg:none ID tokens and empty JWKS used by most scenarios.
 	SignTokens bool
+
+	// SupportsCIMD advertises client_id_metadata_document_supported in the
+	// AS metadata, signalling that CIMD URLs are accepted as client_id.
+	SupportsCIMD bool
+
+	// SupportsDCR advertises a registration_endpoint in the AS metadata and
+	// serves RFC 7591 Dynamic Client Registration at /register.
+	SupportsDCR bool
+
+	// RequireRegisteredClient makes the token endpoint reject authorization
+	// codes issued to client_ids that are neither the configured ClientID
+	// nor a DCR-registered client — mimicking DCR-only authorization servers
+	// that treat unknown client_ids (e.g. CIMD URLs) as unregistered.
+	RequireRegisteredClient bool
 }
 
 // OAuthErrorSimulation allows simulating error conditions
@@ -139,6 +153,10 @@ type OAuthServer struct {
 	authCodes    map[string]*authCodeEntry // code -> entry
 	issuedTokens map[string]*issuedToken   // access_token -> token info
 
+	// DCR state (populated when config.SupportsDCR is true)
+	registeredClients map[string]*registeredClient // client_id -> registration
+	registrationCount int                          // total /register requests served
+
 	// clock is the clock used for time operations
 	clock Clock
 
@@ -149,6 +167,13 @@ type OAuthServer struct {
 	// JWT signing material (populated when config.SignTokens is true)
 	signingKey *ecdsa.PrivateKey
 	signingKID string
+}
+
+// registeredClient records one RFC 7591 dynamic client registration.
+type registeredClient struct {
+	ClientID        string
+	RedirectURIs    []string
+	ApplicationType string
 }
 
 type authCodeEntry struct {
@@ -201,10 +226,11 @@ func NewOAuthServer(config OAuthServerConfig) *OAuthServer {
 	}
 
 	s := &OAuthServer{
-		config:       config,
-		authCodes:    make(map[string]*authCodeEntry),
-		issuedTokens: make(map[string]*issuedToken),
-		clock:        clock,
+		config:            config,
+		authCodes:         make(map[string]*authCodeEntry),
+		issuedTokens:      make(map[string]*issuedToken),
+		registeredClients: make(map[string]*registeredClient),
+		clock:             clock,
 	}
 
 	if config.SignTokens {
@@ -270,6 +296,7 @@ func (s *OAuthServer) Start(ctx context.Context) (int, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/oauth-authorization-server", s.handleMetadata)
 	mux.HandleFunc("/.well-known/openid-configuration", s.handleMetadata)
+	mux.HandleFunc("/register", s.handleRegister)
 	mux.HandleFunc("/authorize", s.handleAuthorize)
 	mux.HandleFunc("/token", s.handleToken)
 	mux.HandleFunc("/userinfo", s.handleUserInfo)
@@ -614,8 +641,98 @@ func (s *OAuthServer) handleMetadata(w http.ResponseWriter, r *http.Request) {
 		"id_token_signing_alg_values_supported": []string{"RS256"},
 	}
 
+	if s.config.SupportsCIMD {
+		metadata["client_id_metadata_document_supported"] = true
+	}
+	if s.config.SupportsDCR {
+		metadata["registration_endpoint"] = s.config.Issuer + "/register"
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(metadata)
+}
+
+// handleRegister implements RFC 7591 Dynamic Client Registration. Only
+// served when SupportsDCR is enabled; the issued client_id is accepted at
+// the authorize and token endpoints.
+func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
+	if !s.config.SupportsDCR {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		RedirectURIs    []string `json:"redirect_uris"`
+		ApplicationType string   `json:"application_type"`
+		ClientID        string   `json:"client_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			pkgoauth.JSONFieldError:            "invalid_client_metadata",
+			pkgoauth.JSONFieldErrorDescription: "request body is not valid JSON",
+		})
+		return
+	}
+
+	// RFC 7591 §2: the client must not pick its own client_id.
+	if req.ClientID != "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			pkgoauth.JSONFieldError:            "invalid_client_metadata",
+			pkgoauth.JSONFieldErrorDescription: "client_id must not be present on registration requests",
+		})
+		return
+	}
+
+	client := &registeredClient{
+		ClientID:        "dcr-" + generateOpaqueToken(),
+		RedirectURIs:    req.RedirectURIs,
+		ApplicationType: req.ApplicationType,
+	}
+
+	s.mu.Lock()
+	s.registeredClients[client.ClientID] = client
+	s.registrationCount++
+	s.mu.Unlock()
+
+	if s.config.Debug {
+		fmt.Fprintf(os.Stderr, "🔐 DCR registration: client_id=%s application_type=%s\n",
+			client.ClientID, client.ApplicationType)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"client_id":                  client.ClientID,
+		"redirect_uris":              client.RedirectURIs,
+		"token_endpoint_auth_method": "none",
+	})
+}
+
+// isAcceptedClientID reports whether the client_id is the statically
+// configured one or a DCR-registered one.
+func (s *OAuthServer) isAcceptedClientID(clientID string) bool {
+	if clientID == s.config.ClientID {
+		return true
+	}
+	s.mu.RLock()
+	_, registered := s.registeredClients[clientID]
+	s.mu.RUnlock()
+	return registered
+}
+
+// RegistrationCount returns the number of RFC 7591 registrations served.
+func (s *OAuthServer) RegistrationCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.registrationCount
 }
 
 // handleAuthorize handles authorization requests
@@ -644,8 +761,9 @@ func (s *OAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate client ID
-	if s.config.ClientID != "" && clientID != s.config.ClientID {
+	// Validate client ID: the statically configured client is always
+	// accepted; DCR-registered clients are accepted too.
+	if s.config.ClientID != "" && !s.isAcceptedClientID(clientID) {
 		http.Error(w, "invalid_client", http.StatusBadRequest)
 		return
 	}
@@ -763,6 +881,19 @@ func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Requ
 	if s.config.Debug {
 		fmt.Fprintf(os.Stderr, "🔐 Token exchange request: code=%s..., client_id=%s\n",
 			code[:min(16, len(code))], clientID)
+	}
+
+	// DCR-only servers look unknown client_ids up as literal strings in
+	// their client registry and reject them — the "Client Not Registered"
+	// failure mode this flag exists to reproduce.
+	if s.config.RequireRegisteredClient && !s.isAcceptedClientID(clientID) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			pkgoauth.JSONFieldError:            pkgoauth.ErrInvalidClient,
+			pkgoauth.JSONFieldErrorDescription: "client not registered",
+		})
+		return
 	}
 
 	s.mu.Lock()

--- a/internal/testing/muster_manager_oauth.go
+++ b/internal/testing/muster_manager_oauth.go
@@ -60,16 +60,19 @@ func (m *musterInstanceManager) startMockOAuthServers(
 		useTLS := oauthCfg.UseAsMusterOAuthServer || oauthCfg.UseTLS || len(oauthCfg.TrustedIssuers) > 0 || signTokens
 
 		serverConfig := mock.OAuthServerConfig{
-			Issuer:         oauthCfg.Issuer,
-			AcceptedScopes: oauthCfg.Scopes,
-			TokenLifetime:  tokenLifetime,
-			PKCERequired:   oauthCfg.PKCERequired,
-			AutoApprove:    oauthCfg.AutoApprove,
-			ClientID:       oauthCfg.ClientID,
-			ClientSecret:   oauthCfg.ClientSecret,
-			Debug:          m.debug,
-			UseTLS:         useTLS,
-			SignTokens:     signTokens,
+			Issuer:                  oauthCfg.Issuer,
+			AcceptedScopes:          oauthCfg.Scopes,
+			TokenLifetime:           tokenLifetime,
+			PKCERequired:            oauthCfg.PKCERequired,
+			AutoApprove:             oauthCfg.AutoApprove,
+			ClientID:                oauthCfg.ClientID,
+			ClientSecret:            oauthCfg.ClientSecret,
+			Debug:                   m.debug,
+			UseTLS:                  useTLS,
+			SignTokens:              signTokens,
+			SupportsCIMD:            oauthCfg.SupportsCIMD,
+			SupportsDCR:             oauthCfg.SupportsDCR,
+			RequireRegisteredClient: oauthCfg.RequireRegisteredClient,
 		}
 
 		// Use mock clock if configured (enables test_advance_oauth_clock tool)

--- a/internal/testing/scenarios/oauth-cimd-preferred.yaml
+++ b/internal/testing/scenarios/oauth-cimd-preferred.yaml
@@ -1,0 +1,75 @@
+name: "oauth-cimd-preferred"
+category: "behavioral"
+concept: "mcpserver"
+description: "AS advertising CIMD support: muster keeps using its CIMD URL as client_id and never calls the registration endpoint"
+tags: ["oauth", "authentication", "mcpserver", "dcr"]
+timeout: "2m"
+
+# The IdP advertises BOTH client_id_metadata_document_supported and an
+# RFC 7591 registration endpoint. CIMD is spec-preferred and stateless, so
+# muster must use its CIMD URL as client_id and leave the registration
+# endpoint untouched.
+pre_configuration:
+  mock_oauth_servers:
+    - name: "cimd-idp"
+      scopes: ["openid", "profile", "mcp:read"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      supports_cimd: true
+      supports_dcr: true
+
+  mcp_servers:
+    - name: "cimd-protected-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "cimd-idp"
+          scope: "mcp:read"
+        tools:
+          - name: "get_data"
+            description: "Returns data that requires authentication"
+            responses:
+              - response:
+                  data: "authenticated-data"
+
+steps:
+  - id: request-auth-challenge
+    description: "core_auth_login returns a sign-in URL without registering a client"
+    tool: "core_auth_login"
+    args:
+      server: "cimd-protected-server"
+    expected:
+      success: true
+      contains:
+        - "Authentication Required"
+
+  - id: complete-oauth-flow
+    description: "Complete the OAuth flow with the CIMD URL as client_id"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "cimd-protected-server"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: call-protected-tool
+    description: "Call the protected tool after CIMD-based authentication"
+    tool: "x_cimd-protected-server_get_data"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "authenticated-data"
+
+  - id: verify-no-dcr-registration
+    description: "The registration endpoint was never called — CIMD is preferred whenever advertised"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "cimd-idp"
+    expected:
+      success: true
+      json_path:
+        dcr_registrations: 0

--- a/internal/testing/scenarios/oauth-dcr-fallback.yaml
+++ b/internal/testing/scenarios/oauth-dcr-fallback.yaml
@@ -1,0 +1,105 @@
+name: "oauth-dcr-fallback"
+category: "behavioral"
+concept: "mcpserver"
+description: "DCR-only authorization server: muster registers itself via RFC 7591 instead of sending its CIMD URL as client_id"
+tags: ["oauth", "authentication", "mcpserver", "dcr"]
+timeout: "2m"
+
+# The IdP does NOT advertise client_id_metadata_document_supported, offers an
+# RFC 7591 registration endpoint, and rejects token requests from client_ids
+# that are not in its registry — the Miro-style "Client Not Registered"
+# behavior. The flow can only complete when muster registers itself via DCR
+# and uses the issued client_id consistently across the authorization request
+# and the code exchange.
+pre_configuration:
+  mock_oauth_servers:
+    - name: "dcr-only-idp"
+      scopes: ["openid", "profile", "mcp:read"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      supports_dcr: true
+      require_registered_client: true
+
+  mcp_servers:
+    - name: "dcr-protected-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "dcr-only-idp"
+          scope: "mcp:read"
+        tools:
+          - name: "get_data"
+            description: "Returns data that requires authentication"
+            responses:
+              - response:
+                  data: "authenticated-data"
+
+steps:
+  - id: verify-idp-running
+    description: "Verify the DCR-only IdP is running and has no registrations yet"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "dcr-only-idp"
+    expected:
+      success: true
+      json_path:
+        dcr_registrations: 0
+
+  - id: request-auth-challenge
+    description: "core_auth_login triggers DCR registration and returns a sign-in URL"
+    tool: "core_auth_login"
+    args:
+      server: "dcr-protected-server"
+    expected:
+      success: true
+      contains:
+        - "Authentication Required"
+
+  - id: verify-dcr-registration-happened
+    description: "Muster registered itself with the IdP via RFC 7591"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "dcr-only-idp"
+    expected:
+      success: true
+      json_path:
+        dcr_registrations: 1
+
+  - id: complete-oauth-flow
+    description: "Complete the OAuth flow — the strict token endpoint only accepts the DCR-registered client_id"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "dcr-protected-server"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: establish-connection
+    description: "Establish the session connection with the stored token"
+    tool: "core_auth_login"
+    args:
+      server: "dcr-protected-server"
+    expected:
+      success: true
+
+  - id: call-protected-tool
+    description: "Call the protected tool after DCR-based authentication"
+    tool: "x_dcr-protected-server_get_data"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "authenticated-data"
+
+  - id: verify-no-repeat-registration
+    description: "The issuer-keyed credentials are reused — still exactly one registration"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "dcr-only-idp"
+    expected:
+      success: true
+      json_path:
+        dcr_registrations: 1

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -683,11 +683,21 @@ func (h *TestToolsHandler) handleGetOAuthServerInfo(ctx context.Context, args ma
 		return nil, fmt.Errorf("OAuth server %s not found", serverName)
 	}
 
-	return map[string]interface{}{
+	result := map[string]interface{}{
 		api.FieldName: info.Name,
 		"port":        info.Port,
 		"issuer_url":  info.IssuerURL,
-	}, nil
+	}
+
+	// Live DCR state, so scenarios can assert whether (and how often)
+	// muster registered itself via RFC 7591.
+	if h.instanceManager != nil {
+		if server := h.instanceManager.GetMockOAuthServer(h.currentInstance.ID, serverName); server != nil {
+			result["dcr_registrations"] = server.RegistrationCount()
+		}
+	}
+
+	return result, nil
 }
 
 // handleAdvanceOAuthClock advances the mock OAuth server's clock for testing token expiry.

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -319,6 +319,19 @@ type MockOAuthServerConfig struct {
 	// JWKS, so muster's broker can validate its tokens as a trusted issuer.
 	// Automatically enabled (with UseTLS) when referenced by muster_broker.
 	SignTokens bool `yaml:"sign_tokens,omitempty"`
+
+	// SupportsCIMD advertises client_id_metadata_document_supported in the
+	// AS metadata (CIMD URLs are accepted as client_id).
+	SupportsCIMD bool `yaml:"supports_cimd,omitempty"`
+
+	// SupportsDCR advertises a registration_endpoint and serves RFC 7591
+	// Dynamic Client Registration.
+	SupportsDCR bool `yaml:"supports_dcr,omitempty"`
+
+	// RequireRegisteredClient makes the token endpoint reject client_ids
+	// that are neither the configured client_id nor DCR-registered —
+	// mimicking DCR-only authorization servers ("Client Not Registered").
+	RequireRegisteredClient bool `yaml:"require_registered_client,omitempty"`
 }
 
 // TrustedIssuerConfig defines a trusted issuer for RFC 8693 token exchange

--- a/pkg/oauth/client.go
+++ b/pkg/oauth/client.go
@@ -210,8 +210,11 @@ func (c *Client) cacheMetadata(issuer string, metadata *Metadata) {
 		"token_endpoint", metadata.TokenEndpoint)
 }
 
-// ExchangeCode exchanges an authorization code for tokens.
-func (c *Client) ExchangeCode(ctx context.Context, tokenEndpoint, code, redirectURI, clientID, codeVerifier string) (*Token, error) {
+// ExchangeCode exchanges an authorization code for tokens. clientSecret is
+// empty for public clients (CIMD, or DCR registrations with
+// token_endpoint_auth_method "none"); when set it is sent as
+// client_secret_post, which every AS that issues secrets via DCR accepts.
+func (c *Client) ExchangeCode(ctx context.Context, tokenEndpoint, code, redirectURI, clientID, clientSecret, codeVerifier string) (*Token, error) {
 	data := url.Values{
 		"grant_type":    {"authorization_code"},
 		"code":          {code},
@@ -219,8 +222,66 @@ func (c *Client) ExchangeCode(ctx context.Context, tokenEndpoint, code, redirect
 		"client_id":     {clientID},
 		"code_verifier": {codeVerifier},
 	}
+	if clientSecret != "" {
+		data.Set(FormFieldClientSecret, clientSecret)
+	}
 
 	return c.doTokenRequest(ctx, tokenEndpoint, data)
+}
+
+// RegisterClient performs OAuth 2.0 Dynamic Client Registration (RFC 7591)
+// against the given registration endpoint. The metadata must not carry a
+// client_id — the authorization server assigns one in the response.
+func (c *Client) RegisterClient(ctx context.Context, registrationEndpoint string, metadata *ClientMetadata) (*ClientRegistrationResponse, error) {
+	body, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal client metadata: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationEndpoint, strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create registration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("registration request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registration response: %w", err)
+	}
+
+	// RFC 7591 §3.2.1 specifies 201 Created; accept any 2xx for
+	// interoperability with servers that answer 200.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// RFC 7591 §3.2.2 error response.
+		var regErr struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		if err := json.Unmarshal(respBody, &regErr); err == nil && regErr.Error != "" {
+			if regErr.ErrorDescription != "" {
+				return nil, fmt.Errorf("client registration failed: %s - %s", regErr.Error, regErr.ErrorDescription)
+			}
+			return nil, fmt.Errorf("client registration failed: %s", regErr.Error)
+		}
+		return nil, fmt.Errorf("client registration failed with status %d", resp.StatusCode)
+	}
+
+	var registration ClientRegistrationResponse
+	if err := json.Unmarshal(respBody, &registration); err != nil {
+		return nil, fmt.Errorf("failed to parse registration response: %w", err)
+	}
+	if registration.ClientID == "" {
+		return nil, fmt.Errorf("registration response is missing client_id")
+	}
+
+	return &registration, nil
 }
 
 // doTokenRequest performs a token endpoint request.

--- a/pkg/oauth/client_test.go
+++ b/pkg/oauth/client_test.go
@@ -277,6 +277,7 @@ func TestExchangeCode(t *testing.T) {
 			"auth-code",
 			"http://localhost:8080/callback",
 			"test-client",
+			"",
 			"verifier123",
 		)
 
@@ -308,6 +309,7 @@ func TestExchangeCode(t *testing.T) {
 			"invalid-code",
 			"http://localhost:8080/callback",
 			"test-client",
+			"",
 			"verifier123",
 		)
 

--- a/pkg/oauth/types.go
+++ b/pkg/oauth/types.go
@@ -172,6 +172,12 @@ type Metadata struct {
 
 	// CodeChallengeMethodsSupported lists the PKCE code challenge methods.
 	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+
+	// ClientIDMetadataDocumentSupported reports whether the authorization
+	// server resolves Client ID Metadata Document URLs as client_id values
+	// (MCP authorization / SEP-991). When absent or false, the AS may treat a
+	// CIMD URL as an unknown literal client identifier and reject the flow.
+	ClientIDMetadataDocumentSupported bool `json:"client_id_metadata_document_supported,omitempty"`
 }
 
 // SupportsS256PKCE reports whether the AS metadata advertises S256 PKCE.
@@ -260,9 +266,11 @@ type PKCEChallenge struct {
 }
 
 // ClientMetadata represents OAuth 2.0 Client Metadata as defined in RFC 7591.
-// Used for Client ID Metadata Documents (CIMD) in MCP OAuth.
+// Used for Client ID Metadata Documents (CIMD) in MCP OAuth and as the request
+// body for Dynamic Client Registration. ClientID is omitted on DCR requests
+// (RFC 7591 forbids it there); the AS assigns it in the response.
 type ClientMetadata struct {
-	ClientID                string   `json:"client_id"`
+	ClientID                string   `json:"client_id,omitempty"`
 	ClientName              string   `json:"client_name,omitempty"`
 	ClientURI               string   `json:"client_uri,omitempty"`
 	RedirectURIs            []string `json:"redirect_uris"`
@@ -275,6 +283,64 @@ type ClientMetadata struct {
 	TermsOfServiceURI       string   `json:"tos_uri,omitempty"`
 	SoftwareID              string   `json:"software_id,omitempty"`
 	SoftwareVersion         string   `json:"software_version,omitempty"`
+
+	// ApplicationType is the OIDC DCR client type hint ("web" or "native").
+	// MCP (SEP-837) requires clients to send it on DCR requests to OIDC-aware
+	// servers; muster's server-side proxy is a remote browser-based client,
+	// so it sends "web". Non-OIDC servers ignore the field.
+	ApplicationType string `json:"application_type,omitempty"`
+}
+
+// ClientRegistrationResponse is the RFC 7591 §3.2.1 client information
+// response returned by an authorization server's registration endpoint.
+type ClientRegistrationResponse struct {
+	ClientID              string `json:"client_id"`
+	ClientSecret          string `json:"client_secret,omitempty"`
+	ClientIDIssuedAt      int64  `json:"client_id_issued_at,omitempty"`
+	ClientSecretExpiresAt int64  `json:"client_secret_expires_at,omitempty"`
+
+	// RegistrationAccessToken and RegistrationClientURI enable RFC 7592
+	// management of the registration. Stored for completeness; muster does
+	// not manage registrations after creation.
+	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
+}
+
+// ClientCredentials are issuer-bound OAuth client credentials obtained via
+// Dynamic Client Registration. Per SEP-2352 ("Authorization Server Binding"),
+// DCR-issued credentials MUST be keyed by the issuer they were registered
+// with and MUST NOT be reused against a different authorization server.
+type ClientCredentials struct {
+	// Issuer is the authorization server these credentials were issued by.
+	Issuer string `json:"issuer"`
+
+	// ClientID is the registered client identifier.
+	ClientID string `json:"client_id"`
+
+	// ClientSecret is set only when the AS issued one; muster requests
+	// token_endpoint_auth_method "none" but must honor what it gets.
+	ClientSecret string `json:"client_secret,omitempty"`
+
+	// ClientSecretExpiresAt is when the secret expires (RFC 7591); zero
+	// means no expiry.
+	ClientSecretExpiresAt time.Time `json:"client_secret_expires_at,omitempty"`
+
+	// RegistrationAccessToken and RegistrationClientURI enable RFC 7592
+	// management of the registration (unused today, kept for completeness).
+	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
+	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
+
+	// CreatedAt is when muster performed the registration.
+	CreatedAt time.Time `json:"created_at,omitempty"`
+}
+
+// IsExpired reports whether the credentials carry an expired client secret.
+// Credentials without a secret (public clients) never expire.
+func (c *ClientCredentials) IsExpired() bool {
+	if c.ClientSecret == "" || c.ClientSecretExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().After(c.ClientSecretExpiresAt)
 }
 
 // SessionServerStatus represents the per-user session authentication status

--- a/pkg/oauth/wire.go
+++ b/pkg/oauth/wire.go
@@ -13,6 +13,7 @@ const (
 const (
 	FormFieldGrantType     = "grant_type"
 	FormFieldClientID      = "client_id"
+	FormFieldClientSecret  = "client_secret"
 	FormFieldCode          = "code"
 	FormFieldCodeVerifier  = "code_verifier"
 	FormFieldRefreshToken  = "refresh_token"


### PR DESCRIPTION
Closes #1083.

## What

The server-side OAuth proxy now resolves its client identification per issuer instead of sending the self-hosted CIMD URL as `client_id` unconditionally:

1. **CIMD when advertised** — `client_id_metadata_document_supported: true` in the discovered AS metadata keeps the current behavior (stateless, secret-free, portable per SEP-2352).
2. **DCR fallback** — otherwise, when a `registration_endpoint` is advertised, muster registers itself once via RFC 7591 (requesting `token_endpoint_auth_method: none`, sending `application_type: "web"` per SEP-837) and uses the issued credentials. Credentials are keyed by issuer and never reused across authorization servers (SEP-2352); stored in-memory by default, Valkey-backed with AES-256-GCM encryption when configured — the same layer as tokens and flow state, so the authorization request and the callback's code exchange resolve the same client across replicas.
3. **Status-quo fallback** — when neither is advertised, the CIMD URL is sent as before (some ASes resolve CIMDs without advertising the flag).

The resolved `client_id`/`client_secret` is used consistently across the authorization request, the code exchange, and mcp-go's transport-level token refresh — which previously sent an **empty** `client_id` on every refresh request (latent bug, fixed here).

`core_auth_login` challenges now carry `structuredContent.clientIdMethod` (`cimd` | `dcr` | `cimd-fallback`) so front-ends can tell users what to expect — the `cimd-fallback` case also appends a note to the challenge message, since those ASes may still reject the sign-in with a client-not-registered error.

## Why

DCR-only authorization servers (e.g. Miro's hosted MCP at `https://mcp.miro.com/`) look the CIMD URL up as a literal string in their client registry and reject the flow with "Client Not Registered" — after muster already produced a sign-in URL, so it reads like a muster bug, and the workaround (connecting the client directly to the SaaS server) is what the gateway exists to prevent. Found while validating the MCP registration wizard (giantswarm/giantswarm#37434) against real-world servers. This resolves the "CIMD-vs-DCR matrix" open question in `docs/explanation/mcp-2026-07-28/05-authorization-hardening.md`.

## Testing

- Unit tests for the resolution order, DCR request shape (SEP-837 `application_type`, no `client_id`), credential reuse (exactly one registration per issuer), registration-failure fallback, code exchange with registered credentials, and secret expiry.
- Behavioral scenarios:
  - `oauth-dcr-fallback` — a DCR-only mock AS with a **strict client registry** (rejects unregistered `client_id`s the way Miro does): login completes end to end via the DCR-registered client, and the issuer-keyed credentials are reused (registration count stays 1).
  - `oauth-cimd-preferred` — an AS advertising both CIMD support and a registration endpoint: the flow completes with the CIMD URL and the registration endpoint is never called.
- Full behavioral mcpserver suite green locally (79/79) — the mock AS advertises neither flag by default, pinning the status-quo fallback for existing scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)