### PR TITLE
fix(oauth): omit scope from RFC 7591 registration requests

### DIFF
--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -300,7 +300,7 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 // authChallengeResult builds the tool result for a pending auth challenge.
 // The sign-in URL is carried both in the prose and as structuredContent.authUrl
 // so clients can read it without parsing the text. structuredContent also
-// carries clientIdMethod ("cimd", "dcr", or "cimd-fallback") so front-ends
+// carries clientIdMethod ("cimd", "dcr", "cimd-fallback", or "dcr-failed") so front-ends
 // can tell users how muster identifies itself to the authorization server —
 // and warn up front when the AS advertises neither mechanism.
 func authChallengeResult(serverName string, challenge *api.AuthChallenge) *api.CallToolResult {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -535,8 +535,9 @@ type AuthChallenge struct {
 
 	// ClientIDMethod reports how muster identifies itself to the
 	// authorization server for this flow: "cimd" (AS advertises CIMD
-	// support), "dcr" (RFC 7591 registered credentials), or "cimd-fallback"
-	// (neither advertised — the AS may reject the sign-in).
+	// support), "dcr" (RFC 7591 registered credentials), "cimd-fallback"
+	// (neither advertised — the AS may reject the sign-in), or "dcr-failed"
+	// (the AS rejected muster's registration; the CIMD URL is sent anyway).
 	ClientIDMethod string `json:"client_id_method,omitempty"`
 }
 

--- a/internal/oauth/client.go
+++ b/internal/oauth/client.go
@@ -36,6 +36,13 @@ const (
 	// resolve CIMDs without advertising the flag), but the AS may reject the
 	// flow with a client-not-registered error.
 	ClientIDMethodCIMDFallback = "cimd-fallback"
+
+	// ClientIDMethodDCRFailed: the AS advertises a registration endpoint but
+	// rejected muster's RFC 7591 registration request. Muster sends the CIMD
+	// URL anyway, like the plain fallback, but the challenge carries the
+	// rejection so front-ends can show the real reason instead of claiming
+	// the AS supports neither mechanism.
+	ClientIDMethodDCRFailed = "dcr-failed"
 )
 
 // resolvedClient is the client identification chosen for one issuer.
@@ -43,6 +50,10 @@ type resolvedClient struct {
 	ClientID     string
 	ClientSecret string
 	Method       string
+
+	// RegistrationError is the RFC 7591 rejection that led to
+	// ClientIDMethodDCRFailed; nil for every other method.
+	RegistrationError error
 }
 
 // Client handles OAuth 2.1 flows for remote MCP server authentication.
@@ -177,7 +188,7 @@ func (c *Client) resolveClient(ctx context.Context, issuer string, metadata *pkg
 		if err != nil {
 			logging.Warn("OAuth", "Dynamic client registration with %s failed, falling back to CIMD URL as client_id: %v",
 				issuer, err)
-			return &resolvedClient{ClientID: c.clientID, Method: ClientIDMethodCIMDFallback}
+			return &resolvedClient{ClientID: c.clientID, Method: ClientIDMethodDCRFailed, RegistrationError: err}
 		}
 
 		creds := &pkgoauth.ClientCredentials{
@@ -202,13 +213,13 @@ func (c *Client) resolveClient(ctx context.Context, issuer string, metadata *pkg
 }
 
 // GenerateAuthURL creates an OAuth authorization URL for user authentication.
-// Returns the URL and the client identification method used (one of the
-// ClientIDMethod* constants). The code verifier is stored with the state for
-// later retrieval.
-func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverName, issuer, scope string) (string, string, error) {
+// Returns the URL and the resolved client identification (its Method is one
+// of the ClientIDMethod* constants). The code verifier is stored with the
+// state for later retrieval.
+func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverName, issuer, scope string) (string, *resolvedClient, error) {
 	metadata, err := c.oauthClient.DiscoverMetadata(ctx, issuer)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to fetch OAuth metadata: %w", err)
+		return "", nil, fmt.Errorf("failed to fetch OAuth metadata: %w", err)
 	}
 
 	// MCP 2025-11-25 §"Authorization Code Protection" requires refusing the
@@ -216,7 +227,7 @@ func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverN
 	// doesn't list it may silently ignore code_challenge_method=S256 and
 	// produce confusing token-endpoint errors later.
 	if !metadata.SupportsS256PKCE() {
-		return "", "", fmt.Errorf("authorization server %q does not advertise S256 PKCE in code_challenge_methods_supported (MCP 2025-11-25 requires refusal)", issuer)
+		return "", nil, fmt.Errorf("authorization server %q does not advertise S256 PKCE in code_challenge_methods_supported (MCP 2025-11-25 requires refusal)", issuer)
 	}
 
 	// Resolve the client identification for this issuer, registering via
@@ -225,7 +236,7 @@ func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverN
 
 	pkce, err := pkgoauth.GeneratePKCE()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate PKCE: %w", err)
+		return "", nil, fmt.Errorf("failed to generate PKCE: %w", err)
 	}
 
 	// The upstream authorization URL is stored with the state in a single
@@ -245,13 +256,13 @@ func (c *Client) GenerateAuthURL(ctx context.Context, sessionID, userID, serverN
 			)
 		})
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate state: %w", err)
+		return "", nil, fmt.Errorf("failed to generate state: %w", err)
 	}
 
 	logging.Debug("OAuth", "Generated auth URL for session=%s server=%s issuer=%s clientIdMethod=%s",
 		logging.TruncateIdentifier(sessionID), serverName, issuer, resolved.Method)
 
-	return c.GetStartURL(state), resolved.Method, nil
+	return c.GetStartURL(state), resolved, nil
 }
 
 // GetStartURL returns the muster-hosted start URL for an encoded state. The
@@ -341,9 +352,16 @@ func (c *Client) GetClientMetadata() *pkgoauth.ClientMetadata {
 // PKCE, and staying secret-free keeps the DCR path as close to the CIMD path
 // as the AS allows. ASes that insist on issuing a secret still can; the
 // response's client_secret is honored either way.
+//
+// scope is omitted as well: RFC 7591 makes it optional, and ASes reject
+// registrations naming scopes they don't know (Miro answers
+// invalid_client_metadata for the dex-oriented CIMD scopes). The
+// authorization request carries the per-server scope discovered from the
+// protected-resource metadata, so registration never needs one.
 func (c *Client) GetRegistrationMetadata() *pkgoauth.ClientMetadata {
 	metadata := c.GetClientMetadata()
 	metadata.ClientID = ""
+	metadata.Scope = ""
 	return metadata
 }
 

--- a/internal/oauth/client_dcr_test.go
+++ b/internal/oauth/client_dcr_test.go
@@ -25,7 +25,8 @@ type dcrTestServer struct {
 	advertiseDCR  bool
 
 	// Registration behavior
-	registrationStatus int // 0 → 201
+	registrationStatus int  // 0 → 201
+	rejectScope        bool // reject requests carrying a scope member (Miro-style)
 	issueSecret        bool
 
 	registrationCount atomic.Int64
@@ -73,6 +74,16 @@ func newDCRTestServer(t *testing.T) *dcrTestServer {
 				return
 			}
 
+			if s.rejectScope && req.Scope != "" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":             "invalid_client_metadata",
+					"error_description": "Requested scopes are not valid: " + req.Scope,
+				})
+				return
+			}
+
 			resp := map[string]any{
 				"client_id": "dcr-client-123",
 			}
@@ -100,9 +111,9 @@ func newDCRTestServer(t *testing.T) *dcrTestServer {
 	return s
 }
 
-// upstreamClientID extracts the client_id from the upstream authorization URL
+// upstreamAuthQuery extracts the query of the upstream authorization URL
 // stored with the state behind a muster-hosted start URL.
-func upstreamClientID(t *testing.T, client *Client, startURL string) string {
+func upstreamAuthQuery(t *testing.T, client *Client, startURL string) url.Values {
 	t.Helper()
 	parsed, err := url.Parse(startURL)
 	if err != nil {
@@ -116,7 +127,14 @@ func upstreamClientID(t *testing.T, client *Client, startURL string) string {
 	if err != nil {
 		t.Fatalf("failed to parse upstream URL: %v", err)
 	}
-	return upstream.Query().Get("client_id")
+	return upstream.Query()
+}
+
+// upstreamClientID extracts the client_id from the upstream authorization URL
+// stored with the state behind a muster-hosted start URL.
+func upstreamClientID(t *testing.T, client *Client, startURL string) string {
+	t.Helper()
+	return upstreamAuthQuery(t, client, startURL).Get("client_id")
 }
 
 func TestClient_GenerateAuthURL_PrefersCIMDWhenAdvertised(t *testing.T) {
@@ -128,12 +146,12 @@ func TestClient_GenerateAuthURL_PrefersCIMDWhenAdvertised(t *testing.T) {
 		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
 	defer client.Stop()
 
-	startURL, method, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
+	startURL, resolved, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
 	if err != nil {
 		t.Fatalf("GenerateAuthURL failed: %v", err)
 	}
-	if method != ClientIDMethodCIMD {
-		t.Errorf("expected method %q, got %q", ClientIDMethodCIMD, method)
+	if resolved.Method != ClientIDMethodCIMD {
+		t.Errorf("expected method %q, got %q", ClientIDMethodCIMD, resolved.Method)
 	}
 	if got := upstreamClientID(t, client, startURL); got != "https://muster.example.com/.well-known/oauth-client.json" {
 		t.Errorf("expected CIMD URL as client_id, got %q", got)
@@ -151,19 +169,20 @@ func TestClient_GenerateAuthURL_FallsBackToDCR(t *testing.T) {
 		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
 	defer client.Stop()
 
-	startURL, method, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
+	startURL, resolved, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
 	if err != nil {
 		t.Fatalf("GenerateAuthURL failed: %v", err)
 	}
-	if method != ClientIDMethodDCR {
-		t.Errorf("expected method %q, got %q", ClientIDMethodDCR, method)
+	if resolved.Method != ClientIDMethodDCR {
+		t.Errorf("expected method %q, got %q", ClientIDMethodDCR, resolved.Method)
 	}
 	if got := upstreamClientID(t, client, startURL); got != "dcr-client-123" {
 		t.Errorf("expected DCR-issued client_id, got %q", got)
 	}
 
 	// SEP-837: registration requests from the server-side proxy carry
-	// application_type "web"; RFC 7591 forbids client_id on the request.
+	// application_type "web"; RFC 7591 forbids client_id on the request, and
+	// scope is omitted — ASes like Miro's reject scopes they don't know.
 	reg, _ := as.lastRegistration.Load().(*pkgoauth.ClientMetadata)
 	if reg == nil {
 		t.Fatal("expected a registration request to have been recorded")
@@ -174,24 +193,27 @@ func TestClient_GenerateAuthURL_FallsBackToDCR(t *testing.T) {
 	if reg.ClientID != "" {
 		t.Errorf("DCR request must not carry client_id, got %q", reg.ClientID)
 	}
+	if reg.Scope != "" {
+		t.Errorf("DCR request must not carry scope, got %q", reg.Scope)
+	}
 	if reg.TokenEndpointAuthMethod != "none" {
 		t.Errorf("expected token_endpoint_auth_method none, got %q", reg.TokenEndpointAuthMethod)
 	}
 
 	// A second flow for the same issuer reuses the stored credentials.
-	_, method2, err := client.GenerateAuthURL(context.Background(), "session-2", "user-2", "server-1", as.server.URL, "openid")
+	_, resolved2, err := client.GenerateAuthURL(context.Background(), "session-2", "user-2", "server-1", as.server.URL, "openid")
 	if err != nil {
 		t.Fatalf("second GenerateAuthURL failed: %v", err)
 	}
-	if method2 != ClientIDMethodDCR {
-		t.Errorf("expected method %q on reuse, got %q", ClientIDMethodDCR, method2)
+	if resolved2.Method != ClientIDMethodDCR {
+		t.Errorf("expected method %q on reuse, got %q", ClientIDMethodDCR, resolved2.Method)
 	}
 	if n := as.registrationCount.Load(); n != 1 {
 		t.Errorf("expected exactly one DCR registration, got %d", n)
 	}
 }
 
-func TestClient_GenerateAuthURL_CIMDFallbackWhenRegistrationFails(t *testing.T) {
+func TestClient_GenerateAuthURL_DCRFailedWhenRegistrationRejected(t *testing.T) {
 	as := newDCRTestServer(t)
 	as.advertiseDCR = true
 	as.registrationStatus = http.StatusBadRequest
@@ -200,15 +222,56 @@ func TestClient_GenerateAuthURL_CIMDFallbackWhenRegistrationFails(t *testing.T) 
 		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
 	defer client.Stop()
 
-	startURL, method, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
+	startURL, resolved, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "openid")
 	if err != nil {
 		t.Fatalf("GenerateAuthURL failed: %v", err)
 	}
-	if method != ClientIDMethodCIMDFallback {
-		t.Errorf("expected method %q, got %q", ClientIDMethodCIMDFallback, method)
+	// A rejected registration is reported as "dcr-failed" — not as
+	// "cimd-fallback", which would falsely claim the AS advertises neither
+	// mechanism — and carries the AS's rejection for the challenge message.
+	if resolved.Method != ClientIDMethodDCRFailed {
+		t.Errorf("expected method %q, got %q", ClientIDMethodDCRFailed, resolved.Method)
+	}
+	if resolved.RegistrationError == nil {
+		t.Error("expected the registration rejection to be carried on the resolved client")
+	} else if !strings.Contains(resolved.RegistrationError.Error(), "invalid_client_metadata") {
+		t.Errorf("expected the AS's error on the resolved client, got %v", resolved.RegistrationError)
 	}
 	if got := upstreamClientID(t, client, startURL); got != "https://muster.example.com/.well-known/oauth-client.json" {
 		t.Errorf("expected CIMD URL as fallback client_id, got %q", got)
+	}
+}
+
+func TestClient_GenerateAuthURL_OmitsScopeFromRegistration(t *testing.T) {
+	// Miro-style AS: any scope member on the RFC 7591 request is rejected
+	// with invalid_client_metadata. Registration must still succeed because
+	// muster omits scope entirely — the per-server scope rides on the
+	// authorization request instead.
+	as := newDCRTestServer(t)
+	as.advertiseDCR = true
+	as.rejectScope = true
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email groups offline_access")
+	defer client.Stop()
+
+	startURL, resolved, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", as.server.URL, "mcp:read")
+	if err != nil {
+		t.Fatalf("GenerateAuthURL failed: %v", err)
+	}
+	if resolved.Method != ClientIDMethodDCR {
+		t.Errorf("expected method %q, got %q", ClientIDMethodDCR, resolved.Method)
+	}
+	authQuery := upstreamAuthQuery(t, client, startURL)
+	if got := authQuery.Get("client_id"); got != "dcr-client-123" {
+		t.Errorf("expected DCR-issued client_id, got %q", got)
+	}
+	if reg, _ := as.lastRegistration.Load().(*pkgoauth.ClientMetadata); reg == nil || reg.Scope != "" {
+		t.Errorf("registration request must not carry scope, got %+v", reg)
+	}
+	// The per-server scope still rides on the authorization request.
+	if got := authQuery.Get("scope"); got != "mcp:read" {
+		t.Errorf("expected the per-server scope on the authorization request, got %q", got)
 	}
 }
 

--- a/internal/oauth/client_test.go
+++ b/internal/oauth/client_test.go
@@ -256,15 +256,15 @@ func TestClient_GenerateAuthURL(t *testing.T) {
 	defer client.Stop()
 
 	ctx := context.Background()
-	authURL, clientIDMethod, err := client.GenerateAuthURL(ctx, testSubject, "test-user", testServerName, server.URL, testScopes)
+	authURL, resolved, err := client.GenerateAuthURL(ctx, testSubject, "test-user", testServerName, server.URL, testScopes)
 	if err != nil {
 		t.Fatalf("Failed to generate auth URL: %v", err)
 	}
 
 	// The AS advertises neither CIMD support nor a registration endpoint, so
 	// the status-quo fallback (CIMD URL as client_id) is used.
-	if clientIDMethod != ClientIDMethodCIMDFallback {
-		t.Errorf("Expected clientIDMethod %q, got %q", ClientIDMethodCIMDFallback, clientIDMethod)
+	if resolved.Method != ClientIDMethodCIMDFallback {
+		t.Errorf("Expected clientIDMethod %q, got %q", ClientIDMethodCIMDFallback, resolved.Method)
 	}
 
 	// The user-facing URL is the muster-hosted start endpoint carrying the state.

--- a/internal/oauth/doc.go
+++ b/internal/oauth/doc.go
@@ -37,14 +37,17 @@
 //  2. DCR: otherwise, when the AS advertises a registration_endpoint, muster
 //     registers itself once via RFC 7591 Dynamic Client Registration
 //     (requesting token_endpoint_auth_method "none" and sending
-//     application_type "web" per SEP-837) and uses the issued credentials.
-//     Credentials are keyed by issuer and stored in the
+//     application_type "web" per SEP-837, with no scope — RFC 7591 makes it
+//     optional and ASes reject scopes they don't know) and uses the issued
+//     credentials. Credentials are keyed by issuer and stored in the
 //     ClientCredentialStore (in-memory by default, Valkey-backed when
 //     configured) — they are never reused against a different issuer.
 //  3. Fallback: when the AS advertises neither, the CIMD URL is sent anyway
 //     (some servers resolve CIMDs without advertising the flag). The auth
 //     challenge marks this case ("cimd-fallback") so front-ends can warn
-//     that the AS may reject the sign-in.
+//     that the AS may reject the sign-in. A rejected registration falls
+//     back the same way but is marked "dcr-failed", with the AS's rejection
+//     carried in the challenge message.
 //
 // The resolved client_id (and secret, if any) is used consistently across
 // the authorization request, the authorization-code exchange, and mcp-go's

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -347,14 +347,17 @@ func (m *Manager) CreateAuthChallenge(ctx context.Context, sessionID, userID, se
 	m.RegisterServer(serverName, issuer, scope)
 
 	// Generate authorization URL (code verifier is stored with the state)
-	authURL, clientIDMethod, err := m.client.GenerateAuthURL(ctx, sessionID, userID, serverName, issuer, scope)
+	authURL, resolved, err := m.client.GenerateAuthURL(ctx, sessionID, userID, serverName, issuer, scope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate auth URL: %w", err)
 	}
 
 	message := fmt.Sprintf("Authentication required for %s. Please visit the link below to authenticate.", serverName)
-	if clientIDMethod == ClientIDMethodCIMDFallback {
+	switch resolved.Method {
+	case ClientIDMethodCIMDFallback:
 		message += " Note: this server's authorization server advertises neither Client ID Metadata Document support nor dynamic client registration; the sign-in may be rejected if it requires pre-registered clients."
+	case ClientIDMethodDCRFailed:
+		message += fmt.Sprintf(" Note: this server's authorization server rejected muster's dynamic client registration (%v); muster falls back to its client metadata URL as client_id, which the server may reject as an unregistered client.", resolved.RegistrationError)
 	}
 
 	challenge := &AuthRequiredResponse{
@@ -362,7 +365,7 @@ func (m *Manager) CreateAuthChallenge(ctx context.Context, sessionID, userID, se
 		AuthURL:        authURL,
 		ServerName:     serverName,
 		Message:        message,
-		ClientIDMethod: clientIDMethod,
+		ClientIDMethod: resolved.Method,
 	}
 
 	logging.Info("OAuth", "Created auth challenge for session=%s server=%s",

--- a/internal/oauth/types.go
+++ b/internal/oauth/types.go
@@ -72,7 +72,8 @@ type AuthRequiredResponse struct {
 
 	// ClientIDMethod reports how muster identifies itself to the
 	// authorization server for this flow: "cimd" (AS advertises CIMD
-	// support), "dcr" (RFC 7591 registered credentials), or "cimd-fallback"
-	// (neither advertised — the AS may reject the sign-in).
+	// support), "dcr" (RFC 7591 registered credentials), "cimd-fallback"
+	// (neither advertised — the AS may reject the sign-in), or "dcr-failed"
+	// (the AS rejected muster's registration; the CIMD URL is sent anyway).
 	ClientIDMethod string `json:"client_id_method,omitempty"`
 }

--- a/internal/testing/mock/oauth_server.go
+++ b/internal/testing/mock/oauth_server.go
@@ -123,6 +123,12 @@ type OAuthServerConfig struct {
 	// nor a DCR-registered client — mimicking DCR-only authorization servers
 	// that treat unknown client_ids (e.g. CIMD URLs) as unregistered.
 	RequireRegisteredClient bool
+
+	// RejectRegistrationScope makes the registration endpoint reject RFC 7591
+	// requests that carry a scope member with invalid_client_metadata —
+	// mimicking authorization servers (e.g. Miro's) that reject scopes they
+	// don't know instead of ignoring them.
+	RejectRegistrationScope bool
 }
 
 // OAuthErrorSimulation allows simulating error conditions
@@ -669,6 +675,7 @@ func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 		RedirectURIs    []string `json:"redirect_uris"`
 		ApplicationType string   `json:"application_type"`
 		ClientID        string   `json:"client_id"`
+		Scope           string   `json:"scope"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -687,6 +694,17 @@ func (s *OAuthServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			pkgoauth.JSONFieldError:            "invalid_client_metadata",
 			pkgoauth.JSONFieldErrorDescription: "client_id must not be present on registration requests",
+		})
+		return
+	}
+
+	// Miro-style strictness: any scope member is rejected as unknown.
+	if s.config.RejectRegistrationScope && req.Scope != "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			pkgoauth.JSONFieldError:            "invalid_client_metadata",
+			pkgoauth.JSONFieldErrorDescription: "Requested scopes are not valid: " + req.Scope,
 		})
 		return
 	}

--- a/internal/testing/muster_manager_oauth.go
+++ b/internal/testing/muster_manager_oauth.go
@@ -73,6 +73,7 @@ func (m *musterInstanceManager) startMockOAuthServers(
 			SupportsCIMD:            oauthCfg.SupportsCIMD,
 			SupportsDCR:             oauthCfg.SupportsDCR,
 			RequireRegisteredClient: oauthCfg.RequireRegisteredClient,
+			RejectRegistrationScope: oauthCfg.RejectRegistrationScope,
 		}
 
 		// Use mock clock if configured (enables test_advance_oauth_clock tool)

--- a/internal/testing/scenarios/oauth-dcr-scope-rejected.yaml
+++ b/internal/testing/scenarios/oauth-dcr-scope-rejected.yaml
@@ -1,0 +1,88 @@
+name: "oauth-dcr-scope-rejected"
+category: "behavioral"
+concept: "mcpserver"
+description: "Scope-strict DCR authorization server (Miro-style): registration succeeds because muster omits scope from the RFC 7591 request"
+tags: ["oauth", "authentication", "mcpserver", "dcr"]
+timeout: "2m"
+
+# The IdP rejects any RFC 7591 registration request that carries a scope
+# member ("Requested scopes are not valid: ..."), the way Miro's MCP
+# authorization server does. RFC 7591 makes scope optional on registration
+# requests, so muster must not send one — the per-server scope rides on the
+# authorization request instead. Because the IdP also rejects unregistered
+# client_ids at the token endpoint, the flow can only complete when the
+# registration actually succeeded: a scope-carrying request would fail
+# registration, fall back to the CIMD URL, and be rejected at the exchange.
+pre_configuration:
+  mock_oauth_servers:
+    - name: "scope-strict-idp"
+      scopes: ["openid", "profile", "mcp:read"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+      supports_dcr: true
+      require_registered_client: true
+      reject_registration_scope: true
+
+  mcp_servers:
+    - name: "scope-strict-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "scope-strict-idp"
+          scope: "mcp:read"
+        tools:
+          - name: "get_data"
+            description: "Returns data that requires authentication"
+            responses:
+              - response:
+                  data: "authenticated-data"
+
+steps:
+  - id: request-auth-challenge
+    description: "core_auth_login registers muster via RFC 7591 despite the scope-strict IdP"
+    tool: "core_auth_login"
+    args:
+      server: "scope-strict-server"
+    expected:
+      success: true
+      contains:
+        - "Authentication Required"
+
+  - id: verify-registration-succeeded
+    description: "The registration went through — muster's request carried no scope member"
+    tool: "test_get_oauth_server_info"
+    args:
+      server: "scope-strict-idp"
+    expected:
+      success: true
+      json_path:
+        dcr_registrations: 1
+
+  - id: complete-oauth-flow
+    description: "Complete the OAuth flow — the strict token endpoint only accepts the DCR-registered client_id"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "scope-strict-server"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: establish-connection
+    description: "Establish the session connection with the stored token"
+    tool: "core_auth_login"
+    args:
+      server: "scope-strict-server"
+    expected:
+      success: true
+
+  - id: call-protected-tool
+    description: "Call the protected tool after DCR-based authentication"
+    tool: "x_scope-strict-server_get_data"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "authenticated-data"

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -332,6 +332,12 @@ type MockOAuthServerConfig struct {
 	// that are neither the configured client_id nor DCR-registered —
 	// mimicking DCR-only authorization servers ("Client Not Registered").
 	RequireRegisteredClient bool `yaml:"require_registered_client,omitempty"`
+
+	// RejectRegistrationScope makes the registration endpoint reject RFC 7591
+	// requests that carry a scope member with invalid_client_metadata —
+	// mimicking authorization servers (e.g. Miro's) that reject scopes they
+	// don't know instead of ignoring them.
+	RejectRegistrationScope bool `yaml:"reject_registration_scope,omitempty"`
 }
 
 // TrustedIssuerConfig defines a trusted issuer for RFC 8693 token exchange


### PR DESCRIPTION
## What

Dynamic Client Registration against scope-strict authorization servers (e.g. Miro's MCP server at `https://mcp.miro.com/`) failed with:

```
client registration failed: invalid_client_metadata - Requested scopes are not valid: groups, profile, offline_access
```

`GetRegistrationMetadata()` reused the CIMD's dex-oriented scope string on the RFC 7591 request. RFC 7591 makes `scope` optional, and ASes reject scopes they don't know instead of ignoring them. The per-server scope discovered from the protected-resource metadata rides on the authorization request, so registration never needs one — this PR omits it entirely (no intersection with `scopes_supported`; omission is the interoperable choice).

## Truthful failure reporting

A rejected registration was previously reported as `cimd-fallback`, whose challenge message claims the AS *"advertises neither Client ID Metadata Document support nor dynamic client registration"* — false when the AS advertises a registration endpoint and rejected the request. Rejected registrations now report `clientIdMethod: "dcr-failed"`, and the challenge message carries the AS's actual rejection text. The fallback behavior itself is unchanged (CIMD URL as client_id).

## Testing

- `oauth-dcr-scope-rejected` scenario: new mock mode `reject_registration_scope` mirrors Miro's behavior (any `scope` member → `invalid_client_metadata`), combined with `require_registered_client` so the flow can only complete when the registration actually succeeded. ✅
- Unit tests: registration request asserted to carry no `scope` (while the authorization request keeps the per-server scope); rejected registration asserted to resolve as `dcr-failed` carrying the AS error. `oauth-dcr-fallback` and `oauth-cimd-preferred` scenarios stay green. ✅

Follow-up: backstage's `ClientIdMethod` allowlist drops unknown values, so old portals degrade gracefully; a backstage PR adds `dcr-failed` with a truthful warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)