### PR TITLE
fix(oauth): complete the callback flow despite duplicate delivery and client disconnect

### DIFF
--- a/internal/oauth/client_dcr_test.go
+++ b/internal/oauth/client_dcr_test.go
@@ -30,6 +30,7 @@ type dcrTestServer struct {
 	issueSecret        bool
 
 	registrationCount atomic.Int64
+	tokenCount        atomic.Int64
 	lastRegistration  atomic.Value // *pkgoauth.ClientMetadata
 }
 
@@ -95,6 +96,7 @@ func newDCRTestServer(t *testing.T) *dcrTestServer {
 			_ = json.NewEncoder(w).Encode(resp)
 
 		case "/token":
+			s.tokenCount.Add(1)
 			_ = r.ParseForm()
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"encoding/json"
 	"html"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/muster/pkg/logging"
 )
@@ -187,6 +189,17 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	// Validate and extract state
 	state := h.client.stateStore.ValidateState(stateParam)
 	if state == nil {
+		// Browsers and IdP redirect pages deliver the callback navigation
+		// more than once (double redirect, prefetch); the first delivery
+		// consumed the single-use state. A flow that recently completed
+		// re-renders its outcome instead of a scary error over a successful
+		// sign-in. The code exchange is NOT re-run — the completion record
+		// carries no secrets, only what finishSuccess renders.
+		if done := h.client.stateStore.Completed(stateParam); done != nil {
+			logging.Info("OAuth", "Duplicate OAuth callback delivery for completed flow (server=%s) — re-rendering the outcome", done.ServerName)
+			h.finishSuccess(w, r, &OAuthState{ServerName: done.ServerName, RedirectURI: done.RedirectURI})
+			return
+		}
 		logging.Warn("OAuth", "OAuth callback with invalid or expired state")
 		h.renderErrorPage(w, "Authentication session expired. Please try again.")
 		return
@@ -212,7 +225,16 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.client.ExchangeCode(r.Context(), code, state.CodeVerifier, state.Issuer)
+	// Detached from the request's cancellation: browsers and IdP redirect
+	// pages re-navigate to the callback, aborting the first request while it
+	// is still exchanging the code or establishing the session connection.
+	// The single-use state is already consumed — the flow can only complete
+	// on this request, so it must run to completion even if the client hangs
+	// up. Bounded so nothing leaks.
+	ctx, cancelFlow := context.WithTimeout(context.WithoutCancel(r.Context()), 2*time.Minute)
+	defer cancelFlow()
+
+	token, err := h.client.ExchangeCode(ctx, code, state.CodeVerifier, state.Issuer)
 	if err != nil {
 		logging.Error("OAuth", err, "Failed to exchange authorization code")
 		h.renderErrorPage(w, "Failed to complete authentication. Please try again.")
@@ -220,6 +242,14 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.client.StoreToken(state.SessionID, state.UserID, token)
+
+	// Recorded before the completion callback: a duplicate delivery arrives
+	// within milliseconds, while the callback is still establishing the
+	// session connection.
+	h.client.stateStore.MarkCompleted(stateParam, &CompletedFlow{
+		ServerName:  state.ServerName,
+		RedirectURI: state.RedirectURI,
+	})
 
 	logging.Info("OAuth", "Successfully authenticated session=%s server=%s",
 		logging.TruncateIdentifier(state.SessionID), state.ServerName)
@@ -230,7 +260,7 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		h.manager.mu.RUnlock()
 
 		if callback != nil {
-			if err := callback(r.Context(), state.SessionID, state.UserID, state.ServerName, token.AccessToken); err != nil {
+			if err := callback(ctx, state.SessionID, state.UserID, state.ServerName, token.AccessToken); err != nil {
 				logging.Warn("OAuth", "Auth completion callback failed for session=%s server=%s: %v",
 					logging.TruncateIdentifier(state.SessionID), state.ServerName, err)
 			}

--- a/internal/oauth/handler_test.go
+++ b/internal/oauth/handler_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/giantswarm/muster/internal/config"
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 )
 
@@ -591,5 +593,179 @@ func TestHandler_FinishSuccess_NoRedirectRendersSuccessPage(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "test-server") {
 		t.Errorf("Expected success page to mention the server, got %q", rr.Body.String())
+	}
+}
+
+// startCallbackFlow drives GenerateAuthURL against the stub AS and returns
+// the handler plus the callback path a browser would be redirected to.
+func startCallbackFlow(t *testing.T, client *Client, issuer string) string {
+	t.Helper()
+	startURL, _, err := client.GenerateAuthURL(context.Background(), "session-1", "user-1", "server-1", issuer, "openid")
+	if err != nil {
+		t.Fatalf("GenerateAuthURL failed: %v", err)
+	}
+	parsed, err := url.Parse(startURL)
+	if err != nil {
+		t.Fatalf("failed to parse start URL: %v", err)
+	}
+	state := parsed.Query().Get("state")
+	if state == "" {
+		t.Fatal("start URL carries no state")
+	}
+	return "/oauth/proxy/callback?code=code-1&state=" + url.QueryEscape(state)
+}
+
+// Browsers and IdP redirect pages deliver the callback navigation more than
+// once (observed live: a second navigation 430ms after the first). The
+// duplicate must re-render the success outcome, not "session expired" over a
+// successful sign-in — and the code exchange must run exactly once.
+func TestHandler_HandleCallback_DuplicateDeliveryRendersOutcome(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseCIMD = true
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+	handler := NewHandler(client)
+
+	callbackPath := startCallbackFlow(t, client, as.server.URL)
+
+	first := httptest.NewRecorder()
+	handler.HandleCallback(first, httptest.NewRequest("GET", callbackPath, nil))
+	if first.Code != http.StatusOK || !strings.Contains(first.Body.String(), "Authentication Successful") {
+		t.Fatalf("first delivery: expected success page, got status %d body %q", first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	handler.HandleCallback(second, httptest.NewRequest("GET", callbackPath, nil))
+	if second.Code != http.StatusOK {
+		t.Errorf("duplicate delivery: expected status %d, got %d (body %q)", http.StatusOK, second.Code, second.Body.String())
+	}
+	if !strings.Contains(second.Body.String(), "Authentication Successful") {
+		t.Errorf("duplicate delivery: expected the success outcome re-rendered, got %q", second.Body.String())
+	}
+	if !strings.Contains(second.Body.String(), "server-1") {
+		t.Errorf("duplicate delivery: expected the server name on the page, got %q", second.Body.String())
+	}
+
+	if n := as.tokenCount.Load(); n != 1 {
+		t.Errorf("expected exactly one code exchange, got %d", n)
+	}
+
+	// A state that never completed still renders the error page.
+	unknown := httptest.NewRecorder()
+	handler.HandleCallback(unknown, httptest.NewRequest("GET", "/oauth/proxy/callback?code=x&state=never-issued", nil))
+	if unknown.Code != http.StatusBadRequest {
+		t.Errorf("unknown state: expected status %d, got %d", http.StatusBadRequest, unknown.Code)
+	}
+}
+
+// A flow that recorded a post-login redirect re-issues the same redirect on a
+// duplicate delivery, so the second navigation lands where the first did.
+func TestHandler_HandleCallback_DuplicateDeliveryRepeatsRedirect(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseCIMD = true
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+	handler := NewHandler(client)
+	prefix, err := parsePostLoginRedirect("https://portal.example.com/servers")
+	if err != nil {
+		t.Fatalf("parsePostLoginRedirect: %v", err)
+	}
+	handler.SetPostLoginRedirectAllowlist([]*url.URL{prefix})
+
+	callbackPath := startCallbackFlow(t, client, as.server.URL)
+	state := httptest.NewRequest("GET", callbackPath, nil).URL.Query().Get("state")
+
+	// The browser reaches the start endpoint with an allowlisted redirect
+	// target, which is recorded on the state.
+	start := httptest.NewRecorder()
+	handler.HandleStart(start, httptest.NewRequest("GET",
+		"/oauth/proxy/start?state="+url.QueryEscape(state)+"&redirect="+url.QueryEscape("https://portal.example.com/servers"), nil))
+	if start.Code != http.StatusFound {
+		t.Fatalf("start endpoint: expected redirect, got %d", start.Code)
+	}
+
+	first := httptest.NewRecorder()
+	handler.HandleCallback(first, httptest.NewRequest("GET", callbackPath, nil))
+	if first.Code != http.StatusSeeOther {
+		t.Fatalf("first delivery: expected redirect %d, got %d (body %q)", http.StatusSeeOther, first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	handler.HandleCallback(second, httptest.NewRequest("GET", callbackPath, nil))
+	if second.Code != http.StatusSeeOther {
+		t.Fatalf("duplicate delivery: expected redirect %d, got %d (body %q)", http.StatusSeeOther, second.Code, second.Body.String())
+	}
+	if got, want := second.Header().Get("Location"), first.Header().Get("Location"); got != want {
+		t.Errorf("duplicate delivery: expected Location %q, got %q", want, got)
+	}
+}
+
+// The browser aborting the callback request (re-navigation, closed tab) must
+// not cancel the flow: the state is already consumed, so the exchange and the
+// session-connection setup can only complete on this request.
+func TestHandler_HandleCallback_SurvivesClientDisconnect(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseCIMD = true
+
+	manager := NewManager(config.OAuthMCPClientConfig{
+		Enabled:      true,
+		PublicURL:    "https://muster.example.com",
+		ClientID:     "https://muster.example.com/.well-known/oauth-client.json",
+		CallbackPath: "/oauth/proxy/callback",
+	})
+	defer manager.Stop()
+
+	reqCtx, abortRequest := context.WithCancel(context.Background())
+	defer abortRequest()
+	callbackCtxErr := make(chan error, 1)
+	manager.SetAuthCompletionCallback(func(ctx context.Context, sessionID, userID, serverName, accessToken string) error {
+		// The browser re-navigates mid-callback: the request context dies
+		// while the session connection is being established.
+		abortRequest()
+		callbackCtxErr <- ctx.Err()
+		return nil
+	})
+
+	callbackPath := startCallbackFlow(t, manager.client, as.server.URL)
+
+	rr := httptest.NewRecorder()
+	manager.handler.HandleCallback(rr, httptest.NewRequest("GET", callbackPath, nil).WithContext(reqCtx))
+
+	if err := <-callbackCtxErr; err != nil {
+		t.Errorf("completion callback context must survive the client disconnect, got %v", err)
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d (body %q)", http.StatusOK, rr.Code, rr.Body.String())
+	}
+}
+
+// Even a request whose context is already dead when processing starts (the
+// connection dropped right after delivery) completes the consumed flow.
+func TestHandler_HandleCallback_ExchangeSurvivesClientDisconnect(t *testing.T) {
+	as := newDCRTestServer(t)
+	as.advertiseCIMD = true
+
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json",
+		"https://muster.example.com", "/oauth/proxy/callback", "openid profile email")
+	defer client.Stop()
+	handler := NewHandler(client)
+
+	callbackPath := startCallbackFlow(t, client, as.server.URL)
+
+	deadCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rr := httptest.NewRecorder()
+	handler.HandleCallback(rr, httptest.NewRequest("GET", callbackPath, nil).WithContext(deadCtx))
+
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), "Authentication Successful") {
+		t.Errorf("expected the flow to complete despite the dead request context, got status %d body %q", rr.Code, rr.Body.String())
+	}
+	if n := as.tokenCount.Load(); n != 1 {
+		t.Errorf("expected the code exchange to have run, got %d", n)
 	}
 }

--- a/internal/oauth/state_store.go
+++ b/internal/oauth/state_store.go
@@ -31,11 +31,50 @@ type StateStorer interface {
 	// expired, or absent. The TTL is unchanged.
 	Update(encodedState string, mutate func(*OAuthState)) *OAuthState
 
+	// MarkCompleted records that the flow behind an encoded state finished
+	// successfully. Browsers and IdP redirect pages deliver the callback
+	// navigation more than once; the record lets a duplicate delivery of an
+	// already-consumed state render the flow's outcome again instead of an
+	// error. The record expires after completionGrace.
+	MarkCompleted(encodedState string, done *CompletedFlow)
+
+	// Completed returns the recorded outcome for an encoded state whose flow
+	// recently completed, or nil. The record is not consumed — every
+	// duplicate within the grace window renders the same outcome.
+	Completed(encodedState string) *CompletedFlow
+
 	// Delete removes a state entry by nonce.
 	Delete(nonce string)
 
 	// Stop releases resources (background goroutines, connections, etc.).
 	Stop()
+}
+
+// CompletedFlow is what a duplicate callback delivery needs to re-render a
+// completed flow's outcome: the server name for the success page and the
+// allowlist-validated post-login redirect target, if the flow recorded one.
+// Deliberately no tokens, code verifier, or session identifiers.
+type CompletedFlow struct {
+	ServerName  string `json:"srv"`
+	RedirectURI string `json:"ru,omitempty"`
+}
+
+// completionGrace bounds how long a completed flow's outcome is re-rendered
+// for duplicate callback deliveries. Duplicates arrive within milliseconds
+// (double navigation) — minutes is generous without keeping records around.
+const completionGrace = 2 * time.Minute
+
+// decodeStateNonce extracts the nonce from an encoded state parameter.
+func decodeStateNonce(encodedState string) (string, error) {
+	stateJSON, err := base64.URLEncoding.DecodeString(encodedState)
+	if err != nil {
+		return "", err
+	}
+	var state OAuthState
+	if err := json.Unmarshal(stateJSON, &state); err != nil {
+		return "", err
+	}
+	return state.Nonce, nil
 }
 
 // StateStore provides thread-safe in-memory storage for OAuth state parameters.
@@ -49,15 +88,26 @@ type StateStore struct {
 	mu     sync.RWMutex
 	states map[string]*OAuthState
 
+	// completed records recently finished flows by nonce, so duplicate
+	// callback deliveries can re-render the outcome (see MarkCompleted).
+	completed map[string]*completedEntry
+
 	// Expiration configuration
 	stateExpiry time.Duration
 	stopCleanup chan struct{}
+}
+
+// completedEntry is one recently completed flow with its recording time.
+type completedEntry struct {
+	flow *CompletedFlow
+	at   time.Time
 }
 
 // NewStateStore creates a new state store with default expiration.
 func NewStateStore() *StateStore {
 	ss := &StateStore{
 		states:      make(map[string]*OAuthState),
+		completed:   make(map[string]*completedEntry),
 		stateExpiry: 10 * time.Minute, // State expires after 10 minutes
 		stopCleanup: make(chan struct{}),
 	}
@@ -191,6 +241,35 @@ func (ss *StateStore) Update(encodedState string, mutate func(*OAuthState)) *OAu
 	return &updated
 }
 
+// MarkCompleted records a finished flow's outcome for duplicate callback
+// deliveries (see StateStorer).
+func (ss *StateStore) MarkCompleted(encodedState string, done *CompletedFlow) {
+	nonce, err := decodeStateNonce(encodedState)
+	if err != nil {
+		logging.Warn("OAuth", "Failed to decode state for completion record: %v", err)
+		return
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	ss.completed[nonce] = &completedEntry{flow: done, at: time.Now()}
+}
+
+// Completed returns the recorded outcome for a recently completed flow, or
+// nil (see StateStorer).
+func (ss *StateStore) Completed(encodedState string) *CompletedFlow {
+	nonce, err := decodeStateNonce(encodedState)
+	if err != nil {
+		return nil
+	}
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	entry, exists := ss.completed[nonce]
+	if !exists || time.Since(entry.at) > completionGrace {
+		return nil
+	}
+	return entry.flow
+}
+
 // Delete removes a state from the store.
 func (ss *StateStore) Delete(nonce string) {
 	ss.mu.Lock()
@@ -228,6 +307,11 @@ func (ss *StateStore) cleanup() {
 		if time.Since(state.CreatedAt) > ss.stateExpiry {
 			delete(ss.states, nonce)
 			count++
+		}
+	}
+	for nonce, entry := range ss.completed {
+		if time.Since(entry.at) > completionGrace {
+			delete(ss.completed, nonce)
 		}
 	}
 

--- a/internal/oauth/state_store_test.go
+++ b/internal/oauth/state_store_test.go
@@ -272,3 +272,56 @@ func TestStateStore_Update_InvalidState(t *testing.T) {
 		t.Error("Update must return nil for an unknown state")
 	}
 }
+
+func TestStateStore_CompletedFlowRecord(t *testing.T) {
+	ss := NewStateStore()
+	defer ss.Stop()
+
+	encoded, err := ss.GenerateState("session-1", "user-1", "server-1", "https://idp.example.com", "verifier", nil)
+	if err != nil {
+		t.Fatalf("GenerateState: %v", err)
+	}
+
+	if ss.Completed(encoded) != nil {
+		t.Error("no completion recorded yet — Completed must return nil")
+	}
+
+	ss.MarkCompleted(encoded, &CompletedFlow{ServerName: "server-1", RedirectURI: "https://portal.example.com/servers"})
+
+	// Every duplicate within the grace window sees the same outcome — the
+	// record is not consumed.
+	for range 2 {
+		done := ss.Completed(encoded)
+		if done == nil {
+			t.Fatal("expected the completion record")
+		}
+		if done.ServerName != "server-1" || done.RedirectURI != "https://portal.example.com/servers" {
+			t.Errorf("unexpected completion record: %+v", done)
+		}
+	}
+
+	// Expired records are neither returned nor kept around.
+	nonce, err := decodeStateNonce(encoded)
+	if err != nil {
+		t.Fatalf("decodeStateNonce: %v", err)
+	}
+	ss.mu.Lock()
+	ss.completed[nonce].at = time.Now().Add(-completionGrace - time.Minute)
+	ss.mu.Unlock()
+
+	if ss.Completed(encoded) != nil {
+		t.Error("expired completion record must not be returned")
+	}
+	ss.cleanup()
+	ss.mu.RLock()
+	_, exists := ss.completed[nonce]
+	ss.mu.RUnlock()
+	if exists {
+		t.Error("cleanup must purge expired completion records")
+	}
+
+	// Garbage input is not an error, just a miss.
+	if ss.Completed("not-a-real-state") != nil {
+		t.Error("Completed must return nil for undecodable state")
+	}
+}

--- a/internal/oauth/state_store_valkey.go
+++ b/internal/oauth/state_store_valkey.go
@@ -95,6 +95,10 @@ func (s *ValkeyStateStore) stateKey(nonce string) string {
 	return s.keyPrefix + "oauth:state:" + nonce
 }
 
+func (s *ValkeyStateStore) completedKey(nonce string) string {
+	return s.keyPrefix + "oauth:statedone:" + nonce
+}
+
 func (s *ValkeyStateStore) GenerateState(sessionID, userID, serverName, issuer, codeVerifier string,
 	buildAuthorizationURL func(encodedState string) (string, error)) (string, error) {
 	nonceBytes := make([]byte, 32)
@@ -282,6 +286,63 @@ func (s *ValkeyStateStore) Update(encodedState string, mutate func(*OAuthState))
 	}
 
 	return updated
+}
+
+// MarkCompleted records a finished flow's outcome for duplicate callback
+// deliveries (see StateStorer). The record shares the state keyspace under
+// its own suffix, encrypted like the states themselves, and Valkey's TTL
+// enforces the grace window across replicas.
+func (s *ValkeyStateStore) MarkCompleted(encodedState string, done *CompletedFlow) {
+	nonce, err := decodeStateNonce(encodedState)
+	if err != nil {
+		logging.Warn("OAuth", "ValkeyStateStore: failed to decode state for completion record: %v", err)
+		return
+	}
+	data, err := json.Marshal(done)
+	if err != nil {
+		logging.Warn("OAuth", "ValkeyStateStore: failed to marshal completion record: %v", err)
+		return
+	}
+	value, err := s.encryptValue(data)
+	if err != nil {
+		logging.Warn("OAuth", "ValkeyStateStore: encryption failed on completion record: %v", err)
+		return
+	}
+	cmd := s.client.B().Set().Key(s.completedKey(nonce)).Value(value).Ex(completionGrace).Build()
+	if err := s.client.Do(context.Background(), cmd).Error(); err != nil {
+		logging.Warn("OAuth", "ValkeyStateStore: SET completion record failed: %v", err)
+	}
+}
+
+// Completed returns the recorded outcome for a recently completed flow, or
+// nil (see StateStorer).
+func (s *ValkeyStateStore) Completed(encodedState string) *CompletedFlow {
+	nonce, err := decodeStateNonce(encodedState)
+	if err != nil {
+		return nil
+	}
+	result := s.client.Do(context.Background(), s.client.B().Get().Key(s.completedKey(nonce)).Build())
+	if err := result.Error(); err != nil {
+		if !valkey.IsValkeyNil(err) {
+			logging.Warn("OAuth", "ValkeyStateStore: GET completion record failed: %v", err)
+		}
+		return nil
+	}
+	stored, err := result.ToString()
+	if err != nil {
+		return nil
+	}
+	plaintext, err := s.decryptValue(stored)
+	if err != nil {
+		logging.Warn("OAuth", "ValkeyStateStore: decryption failed on completion record: %v", err)
+		return nil
+	}
+	var done CompletedFlow
+	if err := json.Unmarshal(plaintext, &done); err != nil {
+		logging.Warn("OAuth", "ValkeyStateStore: failed to unmarshal completion record: %v", err)
+		return nil
+	}
+	return &done
 }
 
 func (s *ValkeyStateStore) Delete(nonce string) {

--- a/internal/testing/scenarios/oauth-duplicate-callback.yaml
+++ b/internal/testing/scenarios/oauth-duplicate-callback.yaml
@@ -1,0 +1,75 @@
+name: "oauth-duplicate-callback"
+category: "behavioral"
+concept: "mcpserver"
+description: "Duplicate OAuth callback delivery: the second navigation re-renders the outcome instead of 'Authentication session expired'"
+tags: ["oauth", "authentication", "mcpserver"]
+timeout: "2m"
+
+# Browsers and IdP redirect pages deliver the callback navigation more than
+# once (double redirect, prefetch). The first delivery consumes the
+# single-use state and completes the flow; before this fix the second
+# delivery rendered "Authentication session expired" over a successful
+# sign-in (observed live with Miro's authorization server). Both deliveries
+# must now render a success outcome, and the flow must stay completed —
+# the code exchange runs exactly once.
+pre_configuration:
+  mock_oauth_servers:
+    - name: "dup-idp"
+      scopes: ["openid", "profile", "mcp:read"]
+      auto_approve: true
+      pkce_required: true
+      token_lifetime: "1h"
+
+  mcp_servers:
+    - name: "dup-protected-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "dup-idp"
+          scope: "mcp:read"
+        tools:
+          - name: "get_data"
+            description: "Returns data that requires authentication"
+            responses:
+              - response:
+                  data: "authenticated-data"
+
+steps:
+  - id: request-auth-challenge
+    description: "core_auth_login issues a sign-in challenge"
+    tool: "core_auth_login"
+    args:
+      server: "dup-protected-server"
+    expected:
+      success: true
+      contains:
+        - "Authentication Required"
+
+  - id: complete-oauth-flow-twice
+    description: "Deliver the same callback twice — both navigations must render success"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "dup-protected-server"
+      deliveries: 2
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: establish-connection
+    description: "The flow completed despite the duplicate delivery"
+    tool: "core_auth_login"
+    args:
+      server: "dup-protected-server"
+    expected:
+      success: true
+
+  - id: call-protected-tool
+    description: "Call the protected tool after the double-delivered callback"
+    tool: "x_dup-protected-server_get_data"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "authenticated-data"

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -386,12 +386,23 @@ func (h *TestToolsHandler) handleSimulateOAuthCallback(ctx context.Context, args
 		h.logger.Debug("🔐 Generated auth code: %s...\n", authCode[:min(16, len(authCode))])
 	}
 
-	// Step 4: Call muster's callback endpoint with the real state and auth code
-	callbackURL := fmt.Sprintf("%s?code=%s&state=%s", redirectURI, url.QueryEscape(authCode), url.QueryEscape(state))
-
-	if h.debug {
-		h.logger.Debug("🔐 Calling muster callback: %s\n", callbackURL)
+	// Step 4: Call muster's callback endpoint with the real state and auth
+	// code. Browsers and IdP redirect pages deliver this navigation more than
+	// once (double redirect, prefetch); the optional "deliveries" argument
+	// repeats the same callback URL to exercise muster's duplicate-delivery
+	// tolerance. Every delivery must render a success outcome.
+	deliveries := 1
+	switch v := args["deliveries"].(type) {
+	case float64:
+		deliveries = int(v)
+	case int:
+		deliveries = v
 	}
+	if deliveries < 1 {
+		deliveries = 1
+	}
+
+	callbackURL := fmt.Sprintf("%s?code=%s&state=%s", redirectURI, url.QueryEscape(authCode), url.QueryEscape(state))
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -401,44 +412,52 @@ func (h *TestToolsHandler) handleSimulateOAuthCallback(ctx context.Context, args
 		},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create callback request: %w", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("callback request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if h.debug {
-		h.logger.Debug("🔐 Callback response status: %d\n", resp.StatusCode)
-	}
-
-	// Check for success (200 OK or redirect to success page)
-	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+	lastStatus := 0
+	for i := range deliveries {
 		if h.debug {
-			h.logger.Debug("🔐 Callback succeeded - token stored in muster's OAuth manager\n")
+			h.logger.Debug("🔐 Calling muster callback (delivery %d/%d): %s\n", i+1, deliveries, callbackURL)
 		}
 
-		// Note: The token is now stored in muster's OAuth manager.
-		// The NEXT call to any protected tool (or the authenticate tool) will:
-		// 1. Find the token via GetTokenByIssuer(subject, issuer)
-		// 2. Use it to connect to the protected MCP server
-		// 3. Make the protected tools available
-		// We do NOT call authenticate a second time here - that was a workaround
-		// that masked aggregator bugs and didn't match real user behavior.
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create callback request: %w", err)
+		}
 
-		return map[string]interface{}{
-			api.FieldSuccess: true,
-			api.FieldMessage: "OAuth callback completed successfully - token stored",
-			api.FieldServer:  serverName,
-			"status_code":    resp.StatusCode,
-		}, nil
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("callback request %d failed: %w", i+1, err)
+		}
+		_ = resp.Body.Close()
+
+		if h.debug {
+			h.logger.Debug("🔐 Callback response status (delivery %d/%d): %d\n", i+1, deliveries, resp.StatusCode)
+		}
+
+		// Check for success (200 OK or redirect to success page)
+		if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("callback delivery %d/%d returned error status: %d", i+1, deliveries, resp.StatusCode)
+		}
+		lastStatus = resp.StatusCode
 	}
 
-	return nil, fmt.Errorf("callback returned error status: %d", resp.StatusCode)
+	if h.debug {
+		h.logger.Debug("🔐 Callback succeeded - token stored in muster's OAuth manager\n")
+	}
+
+	// Note: The token is now stored in muster's OAuth manager.
+	// The NEXT call to any protected tool (or the authenticate tool) will:
+	// 1. Find the token via GetTokenByIssuer(subject, issuer)
+	// 2. Use it to connect to the protected MCP server
+	// 3. Make the protected tools available
+	// We do NOT call authenticate a second time here - that was a workaround
+	// that masked aggregator bugs and didn't match real user behavior.
+
+	return map[string]interface{}{
+		api.FieldSuccess: true,
+		api.FieldMessage: "OAuth callback completed successfully - token stored",
+		api.FieldServer:  serverName,
+		"status_code":    lastStatus,
+	}, nil
 }
 
 // resolveStartRedirect follows the muster-hosted start URL one hop (without


### PR DESCRIPTION
## What

The browser sign-in for a DCR-authenticated server (verified live against Miro's authorization server) ended on **"Authentication Failed — Authentication session expired"** even though the flow succeeded. Production logs show the mechanism — the browser delivered the callback navigation twice, 430ms apart:

```
08:09:47.051 INFO  Successfully authenticated session=… server=miro
08:09:47.480 WARN  ValkeyStateStore: state not found: nonce=…
08:09:47.480 WARN  OAuth callback with invalid or expired state
08:09:47.534 WARN  Auth completion callback failed …: Post "https://mcp.miro.com": context canceled
```

Two defects, one trigger (browsers and IdP redirect pages re-navigate to the callback — double redirect, prefetch):

1. **The second navigation aborts the first request**, whose `r.Context()` was driving the token exchange and the session-connection establishment. The token was stored but the connection died with `context canceled`.
2. **The second navigation finds the single-use state consumed** and paints the "session expired" error page over a successful sign-in.

## Fix

- The callback runs the code exchange and the auth-completion callback on `context.WithoutCancel(r.Context())` bounded at two minutes: once the single-use state is consumed, the flow can only complete on that request, so it must survive the client hanging up.
- A completed flow records a short-lived (2 min) outcome — server name and the allowlist-validated post-login redirect only, no tokens/verifier/session ids — keyed by the state nonce, in both the in-memory and Valkey-backed state stores. A duplicate delivery of the same state re-renders that outcome (success page or the same redirect). The code exchange is never re-run, and unknown states still get the error page.

## Testing

- `oauth-duplicate-callback` scenario: `test_simulate_oauth_callback` gains a `deliveries` argument; the scenario delivers the same callback twice and requires both navigations to succeed, then completes the connection. ✅
- Unit tests: duplicate delivery re-renders the outcome with exactly one code exchange; a recorded post-login redirect is re-issued identically; the completion callback's context survives a mid-flight client disconnect; a request whose context is already dead still completes the flow. Completion-record expiry/cleanup covered in the state store tests. ✅
- OAuth regression scenarios green: `oauth-dcr-fallback`, `oauth-cimd-preferred`, `oauth-dcr-scope-rejected`, `oauth-protected-mcp-server`, `oauth-full-stack`, `oauth-restart-preserves-pending-auth`. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)