### PR TITLE
fix(aggregator): drop pending-auth registrations when their server is deleted

### DIFF
--- a/internal/aggregator/manager.go
+++ b/internal/aggregator/manager.go
@@ -569,8 +569,10 @@ func (am *AggregatorManager) ManualRefresh(ctx context.Context) error {
 	return am.registerHealthyMCPServers(ctx)
 }
 
-// retryFailedRegistrations runs a periodic background task that attempts to
-// register services that are healthy but not yet registered with the aggregator.
+// retryFailedRegistrations runs a periodic background task that reconciles the
+// aggregator registry against the service registry in both directions: it
+// registers services that are healthy but not yet registered, and drops
+// registrations whose service no longer exists.
 //
 // This mechanism provides resilience against temporary failures during
 // initial registration or when services recover from unhealthy states.
@@ -588,6 +590,42 @@ func (am *AggregatorManager) retryFailedRegistrations(ctx context.Context) {
 			return
 		case <-ticker.C:
 			am.attemptPendingRegistrations(ctx)
+			am.pruneOrphanedRegistrations()
+		}
+	}
+}
+
+// pruneOrphanedRegistrations deregisters aggregator entries whose MCPServer
+// service no longer exists in the service registry.
+//
+// Deregistration is otherwise driven purely by service state-change events, and
+// the event handler deliberately skips servers in auth_required state so a
+// server waiting for OAuth keeps its pending-auth entry (see
+// EventHandler.processEvent). Deleting such a server produces exactly that
+// event: RemoveService stops the service — publishing a state change the
+// handler declines to act on — and then unregisters it, leaving the aggregator
+// entry behind with nothing left to ever remove it. The server then lingers in
+// list_tools' servers_requiring_auth and auth://status, prompting sign-ins for
+// a definition that no longer exists, until muster restarts (issue #1093).
+//
+// Both registration paths require a live service (registerSingleServer reads
+// the service's MCP client; the pending-auth registration is driven by the
+// service's own auth-required hook), so a registry entry without a service is
+// always stale. Reconciling on the tick rather than at delete time also heals
+// entries orphaned by a missed event or by an earlier muster version.
+func (am *AggregatorManager) pruneOrphanedRegistrations() {
+	if am.serviceRegistry == nil || am.aggregatorServer == nil {
+		return
+	}
+
+	for name := range am.aggregatorServer.GetRegistry().GetAllServers() {
+		if _, exists := am.serviceRegistry.Get(name); exists {
+			continue
+		}
+
+		logging.Info("Aggregator-Manager", "Deregistering %s - no service exists for this registration", name)
+		if err := am.deregisterSingleServer(name); err != nil {
+			logging.Debug("Aggregator-Manager", "Failed to deregister orphaned server %s: %v", name, err)
 		}
 	}
 }

--- a/internal/aggregator/manager_prune_test.go
+++ b/internal/aggregator/manager_prune_test.go
@@ -1,0 +1,94 @@
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+// stubServiceRegistry implements api.ServiceRegistryHandler with a fixed set of
+// service names. Only Get is exercised by pruneOrphanedRegistrations.
+type stubServiceRegistry struct {
+	names map[string]struct{}
+}
+
+func newStubServiceRegistry(names ...string) *stubServiceRegistry {
+	s := &stubServiceRegistry{names: make(map[string]struct{}, len(names))}
+	for _, name := range names {
+		s.names[name] = struct{}{}
+	}
+	return s
+}
+
+func (s *stubServiceRegistry) Get(name string) (api.ServiceInfo, bool) {
+	_, exists := s.names[name]
+	return nil, exists
+}
+
+func (s *stubServiceRegistry) GetAll() []api.ServiceInfo { return nil }
+
+func (s *stubServiceRegistry) GetByType(api.ServiceType) []api.ServiceInfo { return nil }
+
+func registerPendingAuthServer(t *testing.T, reg *ServerRegistry, name string) {
+	t.Helper()
+	require.NoError(t, reg.RegisterPendingAuth(PendingAuthRegistration{
+		ServerRegistration: ServerRegistration{Name: name, ToolPrefix: name},
+		URL:                "https://" + name + ".example.com",
+		AuthInfo:           &AuthInfo{Issuer: "https://dex.example.com", Scope: "openid"},
+	}))
+}
+
+func TestPruneOrphanedRegistrations(t *testing.T) {
+	// The regression: an OAuth-protected server is registered pending auth, its
+	// definition is deleted (so the service disappears), and the event handler
+	// deliberately skips deregistering auth_required servers. Nothing else ever
+	// removes the entry, so it keeps showing up in servers_requiring_auth.
+	t.Run("drops a pending-auth registration whose service is gone", func(t *testing.T) {
+		reg := NewServerRegistry("x")
+		registerPendingAuthServer(t, reg, "deleted-oauth")
+		registerPendingAuthServer(t, reg, "live-oauth")
+
+		am := &AggregatorManager{
+			aggregatorServer: &AggregatorServer{registry: reg},
+			serviceRegistry:  newStubServiceRegistry("live-oauth"),
+		}
+
+		am.pruneOrphanedRegistrations()
+
+		_, exists := reg.GetServerInfo("deleted-oauth")
+		assert.False(t, exists, "registration without a service should be pruned")
+		_, exists = reg.GetServerInfo("live-oauth")
+		assert.True(t, exists, "registration backed by a live service must survive")
+	})
+
+	t.Run("keeps every registration while all services exist", func(t *testing.T) {
+		reg := NewServerRegistry("x")
+		registerPendingAuthServer(t, reg, "one")
+		registerPendingAuthServer(t, reg, "two")
+
+		am := &AggregatorManager{
+			aggregatorServer: &AggregatorServer{registry: reg},
+			serviceRegistry:  newStubServiceRegistry("one", "two"),
+		}
+
+		am.pruneOrphanedRegistrations()
+
+		assert.Len(t, reg.GetAllServers(), 2)
+	})
+
+	// Without a service registry the manager cannot tell an orphan from a
+	// service it simply cannot see, so it must not guess and drop everything.
+	t.Run("no-ops without a service registry", func(t *testing.T) {
+		reg := NewServerRegistry("x")
+		registerPendingAuthServer(t, reg, "one")
+
+		am := &AggregatorManager{aggregatorServer: &AggregatorServer{registry: reg}}
+
+		am.pruneOrphanedRegistrations()
+
+		assert.Len(t, reg.GetAllServers(), 1)
+	})
+}

--- a/internal/api/aggregator.go
+++ b/internal/api/aggregator.go
@@ -126,6 +126,17 @@ type AggregatorHandler interface {
 	// AuthConfig within registration may be nil; in either case the server
 	// is flagged as requiring per-session authentication.
 	RegisterServerPendingAuth(registration PendingAuthRegistration) error
+
+	// DeregisterServer removes a server from the aggregator, along with its
+	// cached capabilities, per-session auth state and pooled connections.
+	//
+	// Deregistration is otherwise driven by service state-change events, which
+	// deliberately leave servers in auth_required state registered so a server
+	// waiting for OAuth keeps its pending-auth entry. Removing the service
+	// itself therefore has to say so explicitly.
+	//
+	// Returns an error if the server is not registered.
+	DeregisterServer(name string) error
 }
 
 // PendingAuthRegistration describes a remote MCP server that responded with

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -533,8 +533,34 @@ func (o *Orchestrator) RemoveService(name string) error {
 		return err
 	}
 
+	o.deregisterFromAggregator(name)
+
 	logging.Info("Orchestrator", "Removed service: %s", name)
 	return nil
+}
+
+// deregisterFromAggregator drops a removed service's aggregator registration.
+//
+// The aggregator normally deregisters on service state-change events, but it
+// deliberately ignores those for servers in auth_required state so that a
+// server waiting for OAuth keeps the pending-auth entry handleAuthRequiredServer
+// created for it. Removing the service produces exactly such an event — Stop
+// publishes a state change the aggregator declines to act on — so without this
+// call the entry outlives the definition and keeps prompting for a sign-in to a
+// server that no longer exists (issue #1093).
+//
+// Servers that were never registered (autoStart=false, or removed while
+// starting) report "not found"; that is the expected outcome for them, not a
+// failure worth surfacing.
+func (o *Orchestrator) deregisterFromAggregator(name string) {
+	aggregator := api.GetAggregator()
+	if aggregator == nil {
+		return
+	}
+
+	if err := aggregator.DeregisterServer(name); err != nil {
+		logging.Debug("Orchestrator", "Nothing to deregister from aggregator for %s: %v", name, err)
+	}
 }
 
 // RestartService restarts a specific service by name.

--- a/internal/services/aggregator/api_adapter.go
+++ b/internal/services/aggregator/api_adapter.go
@@ -220,6 +220,25 @@ func (a *APIAdapter) RegisterServerPendingAuth(registration api.PendingAuthRegis
 	})
 }
 
+// DeregisterServer removes a server from the aggregator.
+func (a *APIAdapter) DeregisterServer(name string) error {
+	if a.service == nil {
+		return fmt.Errorf("aggregator service not available")
+	}
+
+	manager := a.service.GetManager()
+	if manager == nil {
+		return fmt.Errorf("aggregator manager not available")
+	}
+
+	server := manager.GetAggregatorServer()
+	if server == nil {
+		return fmt.Errorf("aggregator server not available")
+	}
+
+	return server.DeregisterServer(name)
+}
+
 // Register registers this adapter with the API package
 func (a *APIAdapter) Register() {
 	api.RegisterAggregator(a)

--- a/internal/testing/scenarios/oauth-delete-clears-pending-auth.yaml
+++ b/internal/testing/scenarios/oauth-delete-clears-pending-auth.yaml
@@ -1,0 +1,107 @@
+name: "oauth-delete-clears-pending-auth"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  Verify that deleting an OAuth-protected MCP server clears its pending-auth
+  registration from the aggregator.
+
+  Deregistration is driven by service state-change events, and the aggregator
+  deliberately ignores those for servers in auth_required state so a server
+  waiting for OAuth keeps its pending-auth entry across a restart (see
+  oauth-restart-preserves-pending-auth). A delete produces exactly such an
+  event, so without an explicit deregistration the entry outlives the
+  definition: the server disappears from core_mcpserver_list but keeps showing
+  up in list_tools' servers_requiring_auth, prompting clients to sign in to a
+  server that no longer exists.
+tags: ["oauth", "authentication", "mcpserver", "delete"]
+timeout: "2m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "ghost-idp"
+      scopes: ["openid", "profile"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "ghost-client"
+
+  mcp_servers:
+    - name: "ghost-oauth-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "ghost-idp"
+        tools:
+          - name: "get_secret"
+            description: "Returns a secret value that requires authentication"
+            responses:
+              - response:
+                  secret: "ghost-secret"
+
+steps:
+  - id: "verify-server-registered"
+    description: "The protected server exists as a definition before the delete"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "ghost-oauth-server"
+
+  # The server 401s on initialisation, so it holds a pending-auth registration
+  # and contributes no tools. Its only appearance in list_tools is the
+  # servers_requiring_auth entry this scenario is about.
+  - id: "verify-auth-prompt-present"
+    description: "list_tools reports the server as requiring authentication"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "list_tools"
+      arguments: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains:
+        - "ghost-oauth-server"
+
+  - id: "delete-protected-server"
+    description: "Delete the OAuth-protected server"
+    tool: "core_mcpserver_delete"
+    args:
+      name: "ghost-oauth-server"
+    expected:
+      success: true
+
+  - id: "verify-definition-gone"
+    description: "The definition is gone"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      not_contains:
+        - "ghost-oauth-server"
+
+  # The regression: this kept listing the deleted server, so every client was
+  # still told to sign in to it.
+  - id: "verify-auth-prompt-cleared"
+    description: "list_tools no longer asks for authentication to the deleted server"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "list_tools"
+      arguments: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      not_contains:
+        - "ghost-oauth-server"
+
+  - id: "verify-login-refused"
+    description: "core_auth_login has nothing left to authenticate against"
+    tool: "core_auth_login"
+    args:
+      server: "ghost-oauth-server"
+    expected:
+      success: false
+      error_contains:
+        - "not found"


### PR DESCRIPTION
Fixes #1093

## The bug

A deleted OAuth-protected MCPServer disappears from `core_mcpserver_list` but
keeps showing up in `list_tools`' `servers_requiring_auth`, so clients go on
offering a sign-in for a server that no longer exists. On a live installation
the Backstage MCP servers page listed 4 servers while its tool explorer asked
for sign-in to 5 — three of them long-deleted test servers.

## Why

`ListServersRequiringAuth` reads the aggregator's server registry, and the only
thing that removes an entry from it is `EventHandler.processEvent`. That path
deliberately returns early for servers in `auth_required` state, so a server
waiting for OAuth keeps its pending-auth entry — the behaviour
`oauth-restart-preserves-pending-auth` pins.

A delete produces exactly that event. `RemoveService` stops the service —
publishing a state change the event handler declines to act on — then
unregisters it from the service registry. Nothing is left that could ever
remove the aggregator entry, so it survives until the process restarts, taking
the stale per-session auth state and cached capabilities with it.

## The fix

The orchestrator registers pending-auth servers with the aggregator
(`handleAuthRequiredServer`), so it now also deregisters them on
`RemoveService`. `DeregisterServer` clears the cached capabilities, per-session
auth state and pooled connections along with the registry entry.

The existing 5s registration-retry loop gains the symmetric prune pass: an
aggregator entry whose service no longer exists is dropped. Both registration
paths require a live service, so such an entry is always stale. That heals
entries orphaned another way — a missed event, an older muster — without
waiting for a restart.

## Verification

- `internal/testing/scenarios/oauth-delete-clears-pending-auth.yaml` — the
  counterpart to `oauth-restart-preserves-pending-auth`: a protected server is
  registered pending auth, deleted, and must then be absent from `list_tools`
  and refused by `core_auth_login`. Fails on `main` (the entry never clears),
  passes here.
- `internal/aggregator/manager_prune_test.go` covers the prune pass directly.
- Full scenario suite: 193/193. `go test ./...` and `golangci-lint` on the
  changed packages clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)