### PR TITLE
docs(helm): document when to install muster-crds, list all three CRDs

### DIFF
--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -137,6 +137,7 @@ For container orchestration environments.
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/giantswarm/muster/main/helm/muster-crds/files/crds/muster.giantswarm.io_mcpservers.yaml
 kubectl apply -f https://raw.githubusercontent.com/giantswarm/muster/main/helm/muster-crds/files/crds/muster.giantswarm.io_workflows.yaml
+kubectl apply -f https://raw.githubusercontent.com/giantswarm/muster/main/helm/muster-crds/files/crds/muster.giantswarm.io_workflowexecutions.yaml
 ```
 
 #### Deploy Muster Server
@@ -427,6 +428,7 @@ sudo systemctl start muster
 # Update CRDs
 kubectl apply -f https://raw.githubusercontent.com/giantswarm/muster/main/helm/muster-crds/files/crds/muster.giantswarm.io_mcpservers.yaml
 kubectl apply -f https://raw.githubusercontent.com/giantswarm/muster/main/helm/muster-crds/files/crds/muster.giantswarm.io_workflows.yaml
+kubectl apply -f https://raw.githubusercontent.com/giantswarm/muster/main/helm/muster-crds/files/crds/muster.giantswarm.io_workflowexecutions.yaml
 
 # Update deployment image
 kubectl set image deployment/muster-server muster=giantswarm/muster:latest -n muster-system

--- a/helm/muster-crds/README.md
+++ b/helm/muster-crds/README.md
@@ -21,3 +21,39 @@ CRD-only Helm chart for muster - ships the MCPServer and Workflow CustomResource
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | crds.annotations."helm.sh/resource-policy" | string | `"keep"` |  |
+
+## When to use this chart
+
+Install `muster-crds` only if you upgrade muster with plain Helm and you want
+Helm to upgrade the CRDs as well.
+
+The `muster` application chart already ships the same CRDs in its Helm 3
+`crds/` directory, so `helm install muster` on a clean cluster creates them.
+Helm never touches that directory again on `helm upgrade`, so a later CRD
+schema change never reaches the cluster. This chart renders the same CRDs from
+`files/crds/` as ordinary templates, so `helm upgrade muster-crds` applies CRD
+changes like any other resource.
+
+| You install muster with | Use this chart | Reason |
+|---|---|---|
+| a single `helm install`, no upgrades | No | The app chart's `crds/` directory is enough |
+| plain `helm upgrade` | Yes | Helm never upgrades CRDs in `crds/` |
+| a Flux `HelmRelease` | No | Set `install.crds` and `upgrade.crds` to `CreateReplace` on the muster HelmRelease |
+| an umbrella chart | Yes | Order the CRD chart first with a chart dependency or a sync wave |
+
+Install order matters. Reconcile `muster-crds` before `muster`:
+
+```bash
+helm upgrade --install muster-crds giantswarm-catalog/muster-crds --version <version>
+helm upgrade --install muster giantswarm-catalog/muster --version <version>
+```
+
+The app chart's bundled CRDs are then a no-op, because Helm skips CRDs that
+already exist.
+
+Both copies of the CRDs come from the same Go types. `make generate-crds`
+writes `helm/muster-crds/files/crds/` and syncs `helm/muster/crds/`, and
+`make verify-crds` fails the build if either copy is stale.
+
+`UPGRADE.md` covers the install order in more detail, the CRD schema ratchet,
+and what `helm uninstall` leaves behind.

--- a/helm/muster-crds/README.md.gotmpl
+++ b/helm/muster-crds/README.md.gotmpl
@@ -14,3 +14,39 @@
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}
+
+## When to use this chart
+
+Install `muster-crds` only if you upgrade muster with plain Helm and you want
+Helm to upgrade the CRDs as well.
+
+The `muster` application chart already ships the same CRDs in its Helm 3
+`crds/` directory, so `helm install muster` on a clean cluster creates them.
+Helm never touches that directory again on `helm upgrade`, so a later CRD
+schema change never reaches the cluster. This chart renders the same CRDs from
+`files/crds/` as ordinary templates, so `helm upgrade muster-crds` applies CRD
+changes like any other resource.
+
+| You install muster with | Use this chart | Reason |
+|---|---|---|
+| a single `helm install`, no upgrades | No | The app chart's `crds/` directory is enough |
+| plain `helm upgrade` | Yes | Helm never upgrades CRDs in `crds/` |
+| a Flux `HelmRelease` | No | Set `install.crds` and `upgrade.crds` to `CreateReplace` on the muster HelmRelease |
+| an umbrella chart | Yes | Order the CRD chart first with a chart dependency or a sync wave |
+
+Install order matters. Reconcile `muster-crds` before `muster`:
+
+```bash
+helm upgrade --install muster-crds giantswarm-catalog/muster-crds --version <version>
+helm upgrade --install muster giantswarm-catalog/muster --version <version>
+```
+
+The app chart's bundled CRDs are then a no-op, because Helm skips CRDs that
+already exist.
+
+Both copies of the CRDs come from the same Go types. `make generate-crds`
+writes `helm/muster-crds/files/crds/` and syncs `helm/muster/crds/`, and
+`make verify-crds` fails the build if either copy is stale.
+
+`UPGRADE.md` covers the install order in more detail, the CRD schema ratchet,
+and what `helm uninstall` leaves behind.

--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -226,3 +226,18 @@ to an empty list **fails the render**: a RoleBinding bound to nobody looks
 enforced while granting nothing. To manage the grants entirely out of band,
 set `rbac.mcpServerEditor.create: false` / `rbac.workflowEditor.create: false`
 and bind the verbs yourself.
+
+## CRD lifecycle
+
+This chart owns its CRDs. They live in the Helm 3 `crds/` directory, so
+`helm install` creates them and `helm upgrade` never touches them again. The
+`crds.install` and `crds.annotations` values are an inert shim from an earlier
+design and change nothing.
+
+Two supported ways exist to upgrade the CRDs with the app:
+
+* Flux: set `install.crds` and `upgrade.crds` to `CreateReplace` on the muster
+  `HelmRelease`. This is the default path on Giant Swarm installations.
+* Plain Helm: install the standalone `muster-crds` chart before this one, then
+  upgrade it first on every release. Its CRDs are templated, so they upgrade.
+  See `helm/muster-crds/README.md`.

--- a/helm/muster/README.md.gotmpl
+++ b/helm/muster/README.md.gotmpl
@@ -69,3 +69,18 @@ to an empty list **fails the render**: a RoleBinding bound to nobody looks
 enforced while granting nothing. To manage the grants entirely out of band,
 set `rbac.mcpServerEditor.create: false` / `rbac.workflowEditor.create: false`
 and bind the verbs yourself.
+
+## CRD lifecycle
+
+This chart owns its CRDs. They live in the Helm 3 `crds/` directory, so
+`helm install` creates them and `helm upgrade` never touches them again. The
+`crds.install` and `crds.annotations` values are an inert shim from an earlier
+design and change nothing.
+
+Two supported ways exist to upgrade the CRDs with the app:
+
+* Flux: set `install.crds` and `upgrade.crds` to `CreateReplace` on the muster
+  `HelmRelease`. This is the default path on Giant Swarm installations.
+* Plain Helm: install the standalone `muster-crds` chart before this one, then
+  upgrade it first on every release. Its CRDs are templated, so they upgrade.
+  See `helm/muster-crds/README.md`.


### PR DESCRIPTION
## Problem

`helm/muster-crds/README.md` is helm-docs output only, so nothing tells an operator which install paths actually need the chart. The guidance existed only in `UPGRADE.md`. This was the last open acceptance criterion of #1089.

`docs/operations/installation.md` told readers to `kubectl apply` two CRD manifests, but the repository ships three. A raw-manifest install left the cluster without the WorkflowExecution CRD.

## Change

Add a "When to use this chart" section to `helm/muster-crds/README.md.gotmpl` with a per-install-path table (single `helm install`, plain `helm upgrade`, Flux `HelmRelease`, umbrella chart), the reconcile order, and a note that both CRD copies come from one `controller-gen` run. Add a matching CRD-lifecycle pointer to the muster chart README. Add the missing `muster.giantswarm.io_workflowexecutions.yaml` to both CRD apply blocks in the installation docs.

Closes #1089.