### PR TITLE
feat(metatools): add filter_resources and filter_prompts, report per-server capability counts

### DIFF
--- a/internal/aggregator/server_helpers.go
+++ b/internal/aggregator/server_helpers.go
@@ -114,23 +114,49 @@ func (a *AggregatorServer) enrichServerList(ctx context.Context, result *mcp.Cal
 	return result
 }
 
-// enrichServerEntry adds sessionStatus and toolsCount to a single server map.
+// enrichServerEntry adds sessionStatus and the per-session capability counts
+// to a single server map.
+//
+// Counts come from the session capability store for OAuth servers, which see a
+// different catalogue per user, and fall back to the registry for servers that
+// expose the same capabilities to everyone. Reporting only the tool count made
+// a server's resources and prompts invisible to any consumer of this listing.
 func (a *AggregatorServer) enrichServerEntry(ctx context.Context, sub, sessionID string, entry map[string]interface{}) map[string]interface{} {
 	serverName, ok := entry["name"].(string)
 	if !ok || serverName == "" {
 		return entry
 	}
 
-	if info, found := a.registry.GetServerInfo(serverName); found {
+	info, found := a.registry.GetServerInfo(serverName)
+	if found {
 		status := a.determineSessionAuthStatus(sub, sessionID, serverName, info)
 		entry["sessionStatus"] = string(status)
 	}
 
-	if a.capabilityStore != nil {
-		caps, err := a.capabilityStore.Get(ctx, sessionID, serverName)
-		if err == nil && caps != nil && len(caps.Tools) > 0 {
-			entry["toolsCount"] = len(caps.Tools)
+	setCount := func(key string, count int) {
+		if count > 0 {
+			entry[key] = count
 		}
+	}
+
+	if a.capabilityStore != nil {
+		if caps, err := a.capabilityStore.Get(ctx, sessionID, serverName); err == nil && caps != nil {
+			setCount("toolsCount", len(caps.Tools))
+			setCount("resourcesCount", len(caps.Resources))
+			setCount("promptsCount", len(caps.Prompts))
+			return entry
+		}
+	}
+
+	// No per-session capabilities: a server that does not gate on the caller's
+	// identity exposes one catalogue, held on the registry entry.
+	if found && !info.RequiresSessionAuth() {
+		info.mu.RLock()
+		toolCount, resourceCount, promptCount := len(info.Tools), len(info.Resources), len(info.Prompts)
+		info.mu.RUnlock()
+		setCount("toolsCount", toolCount)
+		setCount("resourcesCount", resourceCount)
+		setCount("promptsCount", promptCount)
 	}
 
 	return entry

--- a/internal/api/mcpserver.go
+++ b/internal/api/mcpserver.go
@@ -574,6 +574,14 @@ type MCPServerInfo struct {
 	// based on user permissions.
 	ToolsCount int `json:"toolsCount,omitempty"`
 
+	// ResourcesCount is the number of resources available from this server for
+	// the current session, session-specific for the same reason as ToolsCount.
+	ResourcesCount int `json:"resourcesCount,omitempty"`
+
+	// PromptsCount is the number of prompts available from this server for the
+	// current session, session-specific for the same reason as ToolsCount.
+	PromptsCount int `json:"promptsCount,omitempty"`
+
 	// ConnectedAt indicates when the current session connected to this server.
 	// Only populated if there is an active session connection.
 	ConnectedAt *time.Time `json:"connectedAt,omitempty"`

--- a/internal/metatools/api_adapter_test.go
+++ b/internal/metatools/api_adapter_test.go
@@ -47,7 +47,7 @@ func TestAdapter_GetTools(t *testing.T) {
 	tools := adapter.GetTools()
 
 	// Should return all meta-tools
-	assert.Len(t, tools, 11)
+	assert.Len(t, tools, 13)
 
 	// Verify tool names
 	toolNames := make(map[string]bool)

--- a/internal/metatools/formatters.go
+++ b/internal/metatools/formatters.go
@@ -268,7 +268,7 @@ func (f *Formatters) FormatResourceDetailJSON(origin api.ResourceOrigin) (string
 		api.FieldName:            resource.Name,
 		api.SchemaKeyDescription: resource.Description,
 		api.FieldMimeType:        resource.MIMEType,
-		"server":                 origin.Server,
+		ArgServer:                origin.Server,
 	}
 
 	jsonData, err := json.MarshalIndent(resourceInfo, "", "  ")

--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -64,12 +64,16 @@ func (p *Provider) ExecuteTool(ctx context.Context, toolName string, args map[st
 		return p.handleCallTool(ctx, args)
 	case "list_resources":
 		return p.handleListResources(ctx, args)
+	case "filter_resources":
+		return p.handleFilterResources(ctx, args)
 	case "describe_resource":
 		return p.handleDescribeResource(ctx, args)
 	case "get_resource":
 		return p.handleGetResource(ctx, args)
 	case "list_prompts":
 		return p.handleListPrompts(ctx, args)
+	case "filter_prompts":
+		return p.handleFilterPrompts(ctx, args)
 	case "describe_prompt":
 		return p.handleDescribePrompt(ctx, args)
 	case "get_prompt":
@@ -558,7 +562,7 @@ func (p *Provider) handleDescribeResource(ctx context.Context, args map[string]a
 	}
 
 	// Optional: disambiguates a URI exposed by more than one server.
-	serverName, _ := args["server"].(string)
+	serverName, _ := args[ArgServer].(string)
 
 	handler, errResult := p.getHandler()
 	if errResult != nil {
@@ -618,7 +622,7 @@ func (p *Provider) handleGetResource(ctx context.Context, args map[string]any) (
 	}
 
 	// Optional: disambiguates a URI exposed by more than one server.
-	serverName, _ := args["server"].(string)
+	serverName, _ := args[ArgServer].(string)
 
 	handler, errResult := p.getHandler()
 	if errResult != nil {
@@ -641,6 +645,188 @@ func (p *Provider) handleGetResource(ctx context.Context, args map[string]any) (
 	}
 
 	return textResult(strings.Join(contentTexts, "\n")), nil
+}
+
+// capabilityFilterArgs parses the arguments shared by filter_resources and
+// filter_prompts. Unlike filter_tools these take no relevance query or label
+// facets -- resources and prompts carry neither.
+func parseCapabilityFilterArgs(args map[string]any) (CapabilityFilterCriteria, *api.CallToolResult) {
+	opts := CapabilityFilterCriteria{Limit: defaultFilterLimit}
+
+	if v, ok := args["pattern"].(string); ok {
+		opts.Pattern = v
+	}
+	if v, ok := args[ArgServer].(string); ok {
+		opts.Server = v
+	}
+	if v, ok := args["case_sensitive"].(bool); ok {
+		opts.CaseSensitive = v
+	}
+	if v, ok := args["limit"]; ok {
+		limit, err := toInt(v)
+		if err != nil {
+			return opts, errorResult("limit must be a number")
+		}
+		if limit < 1 {
+			return opts, errorResult("limit must be at least 1")
+		}
+		opts.Limit = limit
+	}
+	if v, ok := args["offset"]; ok {
+		offset, err := toInt(v)
+		if err != nil {
+			return opts, errorResult("offset must be a number")
+		}
+		if offset < 0 {
+			return opts, errorResult("offset must be at least 0")
+		}
+		opts.Offset = offset
+	}
+
+	if opts.Pattern != "" {
+		if _, err := filepath.Match(opts.Pattern, ""); err != nil {
+			return opts, errorResult(fmt.Sprintf("Invalid pattern %q: %v", opts.Pattern, err))
+		}
+	}
+	return opts, nil
+}
+
+// paginate returns the [start:end) window of total items for the given
+// limit/offset, plus whether matches remain beyond the returned page.
+func paginate(total, limit, offset int) (start, end int, truncated bool) {
+	start = min(offset, total)
+	end = total
+	if limit > 0 && start+limit < end {
+		end = start + limit
+	}
+	return start, end, end < total
+}
+
+// handleFilterResources handles the filter_resources meta-tool.
+//
+// Resources are scoped by source server rather than by name prefix: a URI
+// carrying a scheme is exposed unprefixed, so unlike filter_tools a pattern
+// alone cannot select one server's resources. The "server" argument is the
+// reliable way to do that; "pattern" additionally globs the URI.
+func (p *Provider) handleFilterResources(ctx context.Context, args map[string]any) (*api.CallToolResult, error) {
+	opts, errResult := parseCapabilityFilterArgs(args)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	handler, errResult := p.getHandler()
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	resources, err := handler.ListResources(ctx)
+	if err != nil {
+		return errorResult(fmt.Sprintf("Failed to list resources: %v", err)), nil
+	}
+
+	matched := make([]api.ResourceOrigin, 0, len(resources))
+	for _, origin := range resources {
+		if opts.Server != "" && origin.Server != opts.Server {
+			continue
+		}
+		if !matchesPattern(origin.Resource.URI, opts.Pattern, opts.CaseSensitive) {
+			continue
+		}
+		matched = append(matched, origin)
+	}
+
+	start, end, truncated := paginate(len(matched), opts.Limit, opts.Offset)
+	page := matched[start:end]
+
+	infos := make([]ResourceInfo, 0, len(page))
+	for _, origin := range page {
+		infos = append(infos, ResourceInfo{
+			URI:         origin.Resource.URI,
+			Name:        origin.Resource.Name,
+			Description: origin.Resource.Description,
+			MIMEType:    origin.Resource.MIMEType,
+			Server:      origin.Server,
+		})
+	}
+
+	resp := FilterResourcesResponse{
+		Filters:        opts,
+		TotalResources: len(resources),
+		FilteredCount:  len(infos),
+		Total:          len(matched),
+		Truncated:      truncated,
+		Resources:      infos,
+	}
+
+	jsonData, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return errorResult(fmt.Sprintf("Failed to format filtered resources: %v", err)), nil
+	}
+	return textResult(string(jsonData)), nil
+}
+
+// handleFilterPrompts handles the filter_prompts meta-tool.
+//
+// Prompt names are prefixed "x_<server>_<name>", so a pattern selects one
+// server's prompts exactly as it does for tools. The "server" argument is
+// accepted for symmetry with filter_resources and matches the same prefix.
+func (p *Provider) handleFilterPrompts(ctx context.Context, args map[string]any) (*api.CallToolResult, error) {
+	opts, errResult := parseCapabilityFilterArgs(args)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	handler, errResult := p.getHandler()
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	prompts, err := handler.ListPrompts(ctx)
+	if err != nil {
+		return errorResult(fmt.Sprintf("Failed to list prompts: %v", err)), nil
+	}
+
+	matched := make([]mcp.Prompt, 0, len(prompts))
+	for _, prompt := range prompts {
+		if opts.Server != "" && !matchesPattern(prompt.Name, serverPromptPattern(opts.Server), opts.CaseSensitive) {
+			continue
+		}
+		if !matchesPattern(prompt.Name, opts.Pattern, opts.CaseSensitive) {
+			continue
+		}
+		matched = append(matched, prompt)
+	}
+
+	start, end, truncated := paginate(len(matched), opts.Limit, opts.Offset)
+	page := matched[start:end]
+
+	infos := make([]PromptInfo, 0, len(page))
+	for _, prompt := range page {
+		infos = append(infos, PromptInfo{Name: prompt.Name, Description: prompt.Description})
+	}
+
+	resp := FilterPromptsResponse{
+		Filters:       opts,
+		TotalPrompts:  len(prompts),
+		FilteredCount: len(infos),
+		Total:         len(matched),
+		Truncated:     truncated,
+		Prompts:       infos,
+	}
+
+	jsonData, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return errorResult(fmt.Sprintf("Failed to format filtered prompts: %v", err)), nil
+	}
+	return textResult(string(jsonData)), nil
+}
+
+// serverPromptPattern builds the glob matching every prompt exposed by one
+// server. It mirrors the "x_<server>_" prefix ExposedPromptName applies; the
+// muster prefix is fixed at the aggregator's configured value, so the leading
+// segment is globbed rather than assumed to be "x".
+func serverPromptPattern(serverName string) string {
+	return fmt.Sprintf("*_%s_*", serverName)
 }
 
 // handleListPrompts handles the list_prompts meta-tool.

--- a/internal/metatools/provider.go
+++ b/internal/metatools/provider.go
@@ -157,6 +157,42 @@ func (p *Provider) GetTools() []api.ToolMetadata {
 			Args:        []api.ArgMetadata{},
 		},
 		{
+			Name:        "filter_resources",
+			Description: "Filter aggregated resources by URI pattern and/or source server. Resource URIs carrying a scheme are exposed unprefixed, so the \"server\" argument -- not the URI -- is the reliable way to scope to one server",
+			Args: []api.ArgMetadata{
+				{
+					Name:        "pattern",
+					Type:        api.ArgTypeString,
+					Required:    false,
+					Description: "Glob pattern to match against the resource URI (e.g. \"board://*\")",
+				},
+				{
+					Name:        ArgServer,
+					Type:        api.ArgTypeString,
+					Required:    false,
+					Description: "Only return resources exposed by this server",
+				},
+				{
+					Name:        "case_sensitive",
+					Type:        api.ArgTypeBoolean,
+					Required:    false,
+					Description: "Match case-sensitively (default false)",
+				},
+				{
+					Name:        "limit",
+					Type:        api.ArgTypeNumber,
+					Required:    false,
+					Description: "Maximum number of results to return per page",
+				},
+				{
+					Name:        "offset",
+					Type:        api.ArgTypeNumber,
+					Required:    false,
+					Description: "Number of matches to skip before the returned page",
+				},
+			},
+		},
+		{
 			Name:        "describe_resource",
 			Description: "Get detailed information about a specific resource",
 			Args: []api.ArgMetadata{
@@ -167,7 +203,7 @@ func (p *Provider) GetTools() []api.ToolMetadata {
 					Description: "URI of the resource to describe",
 				},
 				{
-					Name:        "server",
+					Name:        ArgServer,
 					Type:        api.ArgTypeString,
 					Required:    false,
 					Description: "Server to describe the resource from. Only needed when several servers expose the same URI; list_resources reports the server for every entry",
@@ -185,7 +221,7 @@ func (p *Provider) GetTools() []api.ToolMetadata {
 					Description: "URI of the resource to retrieve",
 				},
 				{
-					Name:        "server",
+					Name:        ArgServer,
 					Type:        api.ArgTypeString,
 					Required:    false,
 					Description: "Server to read from. Only needed when several servers expose the same URI; list_resources reports the server for every entry",
@@ -198,6 +234,42 @@ func (p *Provider) GetTools() []api.ToolMetadata {
 			Name:        "list_prompts",
 			Description: "List all available prompts from connected MCP servers",
 			Args:        []api.ArgMetadata{},
+		},
+		{
+			Name:        "filter_prompts",
+			Description: "Filter aggregated prompts by name pattern and/or source server. Prompt names are prefixed \"x_<server>_<name>\", so a pattern scopes to one server exactly as it does for tools",
+			Args: []api.ArgMetadata{
+				{
+					Name:        "pattern",
+					Type:        api.ArgTypeString,
+					Required:    false,
+					Description: "Glob pattern to match against the prompt name (e.g. \"x_myserver_*\")",
+				},
+				{
+					Name:        ArgServer,
+					Type:        api.ArgTypeString,
+					Required:    false,
+					Description: "Only return prompts exposed by this server",
+				},
+				{
+					Name:        "case_sensitive",
+					Type:        api.ArgTypeBoolean,
+					Required:    false,
+					Description: "Match case-sensitively (default false)",
+				},
+				{
+					Name:        "limit",
+					Type:        api.ArgTypeNumber,
+					Required:    false,
+					Description: "Maximum number of results to return per page",
+				},
+				{
+					Name:        "offset",
+					Type:        api.ArgTypeNumber,
+					Required:    false,
+					Description: "Number of matches to skip before the returned page",
+				},
+			},
 		},
 		{
 			Name:        "describe_prompt",

--- a/internal/metatools/provider_test.go
+++ b/internal/metatools/provider_test.go
@@ -17,8 +17,8 @@ func TestProvider_GetTools(t *testing.T) {
 	provider := NewProvider()
 	tools := provider.GetTools()
 
-	// Verify we have all 11 meta-tools
-	assert.Len(t, tools, 11, "Expected 11 meta-tools")
+	// Verify we have all 13 meta-tools
+	assert.Len(t, tools, 13, "Expected 13 meta-tools")
 
 	// Create a map for easy lookup
 	toolMap := make(map[string]bool)
@@ -34,9 +34,11 @@ func TestProvider_GetTools(t *testing.T) {
 		"filter_tools",
 		"call_tool",
 		"list_resources",
+		"filter_resources",
 		"describe_resource",
 		"get_resource",
 		"list_prompts",
+		"filter_prompts",
 		"describe_prompt",
 		"get_prompt",
 	}

--- a/internal/metatools/types.go
+++ b/internal/metatools/types.go
@@ -114,6 +114,68 @@ type FilterCriteria struct {
 	Offset            int               `json:"offset"`
 }
 
+// ArgServer is the argument name selecting which MCP server a resource or
+// prompt request applies to, and the response field naming the server an
+// aggregated capability came from. Resource URIs carrying a scheme are exposed
+// unprefixed, so this is the only way to express "this server's resources".
+const ArgServer = "server"
+
+// ResourceInfo is one entry in a filter_resources response.
+//
+// Server is always populated: resource URIs carrying a scheme are exposed
+// unprefixed, so unlike a tool or prompt name the URI does not identify where
+// the resource came from, and two servers can expose the same one.
+type ResourceInfo struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty"`
+	Server      string `json:"server"`
+}
+
+// FilterResourcesResponse is the response structure from the filter_resources
+// meta-tool, mirroring FilterToolsResponse.
+type FilterResourcesResponse struct {
+	Filters        CapabilityFilterCriteria `json:"filters"`
+	TotalResources int                      `json:"total_resources"`
+	FilteredCount  int                      `json:"filtered_count"`
+	Total          int                      `json:"total"`
+	Truncated      bool                     `json:"truncated"`
+	Resources      []ResourceInfo           `json:"resources"`
+}
+
+// PromptInfo is one entry in a filter_prompts response.
+//
+// Prompt names are prefixed "x_<server>_<name>", so unlike resources they can
+// be scoped to a server by pattern alone, exactly as tool names are.
+type PromptInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// FilterPromptsResponse is the response structure from the filter_prompts
+// meta-tool, mirroring FilterToolsResponse.
+type FilterPromptsResponse struct {
+	Filters       CapabilityFilterCriteria `json:"filters"`
+	TotalPrompts  int                      `json:"total_prompts"`
+	FilteredCount int                      `json:"filtered_count"`
+	Total         int                      `json:"total"`
+	Truncated     bool                     `json:"truncated"`
+	Prompts       []PromptInfo             `json:"prompts"`
+}
+
+// CapabilityFilterCriteria describes the filter parameters applied by
+// filter_resources and filter_prompts. It is deliberately narrower than
+// FilterCriteria: neither relevance ranking nor label facets apply to
+// resources or prompts.
+type CapabilityFilterCriteria struct {
+	Pattern       string `json:"pattern,omitempty"`
+	Server        string `json:"server,omitempty"`
+	CaseSensitive bool   `json:"case_sensitive"`
+	Limit         int    `json:"limit"`
+	Offset        int    `json:"offset"`
+}
+
 // DescribeToolResponse is the response structure from the describe_tool meta-tool.
 type DescribeToolResponse struct {
 	Name        string      `json:"name"`

--- a/internal/testing/scenarios/filter-resources-by-server.yaml
+++ b/internal/testing/scenarios/filter-resources-by-server.yaml
@@ -1,0 +1,157 @@
+name: "filter-resources-by-server"
+description: "filter_resources scopes aggregated resources by source server and URI pattern -- the only reliable per-server scoping for resources, whose scheme'd URIs are exposed unprefixed -- and core_mcpserver_list reports per-server resource and prompt counts alongside toolsCount (#1096)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["metatools", "filter_resources", "resources", "attribution", "counts"]
+timeout: "5m"
+
+# Acceptance for the discovery half of #1096:
+#
+# Given: Two servers expose resources, one of them sharing a URI with the other.
+# When:  filter_resources scopes by server and by URI pattern.
+# Then:  Each server's own resources come back, the shared URI appears once per
+#        server rather than collapsing, and core_mcpserver_list carries the
+#        per-server resource count that previously only existed for tools.
+
+pre_configuration:
+  mcp_servers:
+    - name: "alpha"
+      config:
+        tools:
+          - name: "ping"
+            description: "Keeps alpha in the tool catalogue."
+            responses: [{ response: { ok: true } }]
+        resources:
+          - uri: "board://schema"
+            name: "Board schema (alpha)"
+            description: "Schema served by alpha."
+            text: "alpha-schema"
+          - uri: "board://overview"
+            name: "Board overview (alpha)"
+            description: "Overview served by alpha."
+            text: "alpha-overview"
+          - uri: "notes://alpha"
+            name: "Notes (alpha)"
+            description: "Notes served by alpha."
+            text: "alpha-notes"
+    - name: "beta"
+      config:
+        tools:
+          - name: "ping"
+            description: "Keeps beta in the tool catalogue."
+            responses: [{ response: { ok: true } }]
+        resources:
+          - uri: "board://schema"
+            name: "Board schema (beta)"
+            description: "Schema served by beta."
+            text: "beta-schema"
+
+steps:
+  - id: "wait-for-mock-servers"
+    description: "Both servers must be connected before filtering"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["alpha", "beta"]
+
+  # Four resources across two servers; the shared URI counts once per server.
+  - id: "unfiltered-sees-every-resource"
+    description: "Without filters every aggregated resource is reported"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_resources"
+      arguments:
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total_resources: 4
+        total: 4
+        truncated: false
+
+  # A URI pattern cannot separate the two servers here -- both expose
+  # board://schema -- which is exactly why the server filter exists.
+  - id: "server-filter-scopes-to-alpha"
+    description: "filter_resources scopes to one server's resources"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_resources"
+      arguments:
+        server: "alpha"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 3
+      contains: ["Board schema (alpha)", "notes://alpha"]
+      not_contains: ["Board schema (beta)"]
+
+  - id: "server-filter-scopes-to-beta"
+    description: "The colliding server is reported independently, not collapsed"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_resources"
+      arguments:
+        server: "beta"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 1
+      contains: ["Board schema (beta)"]
+      not_contains: ["Board schema (alpha)"]
+
+  - id: "pattern-filter-globs-the-uri"
+    description: "A URI glob narrows across servers"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_resources"
+      arguments:
+        pattern: "board://*"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 3
+      not_contains: ["notes://alpha"]
+
+  - id: "server-and-pattern-combine"
+    description: "Server and pattern filters intersect"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_resources"
+      arguments:
+        server: "alpha"
+        pattern: "board://*"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 2
+      not_contains: ["notes://alpha"]
+
+  - id: "paging-reports-more-matches"
+    description: "limit/offset page the matches and flag remaining ones"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_resources"
+      arguments:
+        server: "alpha"
+        limit: 2
+        offset: 0
+    expected:
+      success: true
+      json_path:
+        total: 3
+        filtered_count: 2
+        truncated: true
+
+  - id: "counts-are-reported-per-server"
+    description: "core_mcpserver_list carries resource counts, not just toolsCount"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      contains: ["resourcesCount"]


### PR DESCRIPTION
Completes #1096, on top of #1098. This is the discovery half: per-server scoping for resources and prompts, and the counts that make them visible in a server listing.

## Why

`filter_tools` lets a client scope tools to one server by pattern. Resources and prompts had no equivalent, so they could only be listed in aggregate — which is also why they are invisible in the dev portal today (giantswarm/backstage#2124).

For prompts, a pattern is enough: names carry the `x_<server>_` prefix, exactly like tool names. For **resources it is not** — a URI carrying a scheme is exposed unprefixed, so `board://schema` says nothing about which server produced it, and two servers may expose the same one. Scoping resources needs the source server as a first-class filter, which #1098 made available on the listing.

## What changed

- **`filter_resources`** — filters by `server` and/or a URI glob `pattern`, with `limit`/`offset` paging and the same `total` / `filtered_count` / `truncated` reporting shape as `filter_tools`. Every entry carries its `server`.
- **`filter_prompts`** — mirrors `filter_tools` over prompt names, and accepts `server` for symmetry (matching the same name prefix).
- **`resourcesCount` and `promptsCount` on `core_mcpserver_list`**, beside the existing `toolsCount`.

One thing found while wiring the counts: they were read **only** from the session capability store. That store is populated for OAuth servers, which show a different catalogue per user — so any server exposing one catalogue to everyone reported **no counts at all**, not merely no resource counts. Added a registry fallback, so all three counts now populate for those servers too.

`"server"` became a named constant (`metatools.ArgServer`) now that it appears as both an argument and a response field across the package.

## Verification

- New scenario `filter-resources-by-server` — two servers, one shared URI: server scoping returns each server's own resources without collapsing the collision, pattern and server filters intersect, paging reports remaining matches, and `core_mcpserver_list` carries `resourcesCount`. 8/8 steps pass.
- Full scenario suite: **197/197** on this branch rebased onto current main.
- Unit suite green; `golangci-lint run -E=gosec -E=goconst -E=govet` reports 0 issues.

## Follow-on

giantswarm/backstage#2124 consumes this — `ServerResources` / `ServerPrompts` panels beside `ServerTools`, and the counts in `RuntimeState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
