### PR TITLE
fix(metatools): attribute prompts by source server, not by exposed name

### DIFF
--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -736,21 +736,19 @@ func (c *Client) listPrompts(ctx context.Context, initial bool) error {
 	return nil
 }
 
-// metaToolNames is the list of meta-tools that should NOT be wrapped through call_tool.
-// These are the discovery and execution tools exposed directly by the aggregator.
-var metaToolNames = map[string]bool{
-	"call_tool":         true,
-	"list_tools":        true,
-	"describe_tool":     true,
-	"filter_tools":      true,
-	"list_core_tools":   true,
-	"list_resources":    true,
-	"describe_resource": true,
-	"get_resource":      true,
-	"list_prompts":      true,
-	"describe_prompt":   true,
-	"get_prompt":        true,
-}
+// metaToolNames is the set of meta-tools that must NOT be wrapped through
+// call_tool -- the aggregator exposes them directly.
+//
+// Derived from metatools.MetaToolNames rather than restated here: the previous
+// hand-maintained copy silently went stale when filter_resources and
+// filter_prompts were added, so the CLI refused tools the server advertised.
+var metaToolNames = func() map[string]bool {
+	names := make(map[string]bool, len(metatools.MetaToolNames))
+	for _, name := range metatools.MetaToolNames {
+		names[name] = true
+	}
+	return names
+}()
 
 // callToolFunc is a function type for direct tool execution.
 // Used by wrapAndCallTool to abstract over callToolDirect and callToolDirectWithTimeout.

--- a/internal/agent/server_upgrade.go
+++ b/internal/agent/server_upgrade.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"github.com/giantswarm/muster/internal/metatools"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -137,4 +139,47 @@ func registerAgentTools(m *MCPServer) {
 		),
 	)
 	m.mcpServer.AddTool(filterToolsTool, m.forwardToServerMetaTool("filter_tools"))
+
+	// Resources are scoped by source server, not by URI pattern: a resource URI
+	// carrying a scheme is exposed unprefixed, so there is no per-server prefix
+	// to match against.
+	filterResourcesTool := mcp.NewTool(metatools.ToolFilterResources,
+		mcp.WithDescription("Filter aggregated resources by source server and/or URI pattern"),
+		mcp.WithString("server",
+			mcp.Description("Only return resources exposed by this server"),
+		),
+		mcp.WithString("pattern",
+			mcp.Description("Glob pattern to match against the resource URI"),
+		),
+		mcp.WithBoolean("case_sensitive",
+			mcp.Description("Match case-sensitively (default: false)"),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of results to return per page"),
+		),
+		mcp.WithNumber("offset",
+			mcp.Description("Number of matches to skip before the returned page"),
+		),
+	)
+	m.mcpServer.AddTool(filterResourcesTool, m.forwardToServerMetaTool(metatools.ToolFilterResources))
+
+	filterPromptsTool := mcp.NewTool(metatools.ToolFilterPrompts,
+		mcp.WithDescription("Filter aggregated prompts by source server and/or name pattern"),
+		mcp.WithString("server",
+			mcp.Description("Only return prompts exposed by this server"),
+		),
+		mcp.WithString("pattern",
+			mcp.Description("Glob pattern to match against the prompt name"),
+		),
+		mcp.WithBoolean("case_sensitive",
+			mcp.Description("Match case-sensitively (default: false)"),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of results to return per page"),
+		),
+		mcp.WithNumber("offset",
+			mcp.Description("Number of matches to skip before the returned page"),
+		),
+	)
+	m.mcpServer.AddTool(filterPromptsTool, m.forwardToServerMetaTool(metatools.ToolFilterPrompts))
 }

--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -1367,11 +1367,22 @@ func (r *ServerRegistry) GetAllResourcesForSession(ctx context.Context, store oa
 //
 // For OAuth servers, prompts are read from the CapabilityStore.
 // For non-OAuth servers, prompts are read from ServerInfo.Prompts.
-func (r *ServerRegistry) GetAllPromptsForSession(ctx context.Context, store oauthstore.CapabilityStore, sessionID string) []mcp.Prompt {
+func (r *ServerRegistry) GetAllPromptsForSession(ctx context.Context, store oauthstore.CapabilityStore, sessionID string) []api.PromptOrigin {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	var allPrompts []mcp.Prompt
+	var allPrompts []api.PromptOrigin
+
+	appendPrompts := func(serverName string, prompts []mcp.Prompt) {
+		for _, prompt := range prompts {
+			exposedPrompt := prompt
+			exposedPrompt.Name = r.ExposedPromptName(serverName, prompt.Name)
+			allPrompts = append(allPrompts, api.PromptOrigin{
+				Prompt: exposedPrompt,
+				Server: serverName,
+			})
+		}
+	}
 
 	for serverName, info := range r.servers {
 		if info.RequiresSessionAuth() {
@@ -1382,11 +1393,7 @@ func (r *ServerRegistry) GetAllPromptsForSession(ctx context.Context, store oaut
 			if err != nil || caps == nil {
 				continue
 			}
-			for _, prompt := range caps.Prompts {
-				exposedPrompt := prompt
-				exposedPrompt.Name = r.ExposedPromptName(serverName, prompt.Name)
-				allPrompts = append(allPrompts, exposedPrompt)
-			}
+			appendPrompts(serverName, caps.Prompts)
 			continue
 		}
 
@@ -1395,11 +1402,7 @@ func (r *ServerRegistry) GetAllPromptsForSession(ctx context.Context, store oaut
 		}
 
 		info.mu.RLock()
-		for _, prompt := range info.Prompts {
-			exposedPrompt := prompt
-			exposedPrompt.Name = r.ExposedPromptName(serverName, prompt.Name)
-			allPrompts = append(allPrompts, exposedPrompt)
-		}
+		appendPrompts(serverName, info.Prompts)
 		info.mu.RUnlock()
 	}
 

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1705,7 +1705,7 @@ func (a *AggregatorServer) GetResourcesForSession(ctx context.Context, sessionID
 
 // GetPromptsForSession returns a session-specific view of all available prompts.
 // For OAuth servers, prompts are read from the CapabilityStore keyed by session ID.
-func (a *AggregatorServer) GetPromptsForSession(ctx context.Context, sessionID string) []mcp.Prompt {
+func (a *AggregatorServer) GetPromptsForSession(ctx context.Context, sessionID string) []api.PromptOrigin {
 	return a.registry.GetAllPromptsForSession(ctx, a.capabilityStore, sessionID)
 }
 
@@ -3180,7 +3180,7 @@ func (a *AggregatorServer) ListResourcesForContext(ctx context.Context) []api.Re
 }
 
 // ListPromptsForContext returns all available prompts for the current session context.
-func (a *AggregatorServer) ListPromptsForContext(ctx context.Context) []mcp.Prompt {
+func (a *AggregatorServer) ListPromptsForContext(ctx context.Context) []api.PromptOrigin {
 	sessionID := getSessionIDFromContext(ctx)
 	if sessionID == "" {
 		logging.Warn("Aggregator", "ListPromptsForContext: no session ID in context — returning empty")

--- a/internal/api/metatools.go
+++ b/internal/api/metatools.go
@@ -65,8 +65,8 @@ type MetaToolsDataProvider interface {
 	//   - ctx: Context containing session information
 	//
 	// Returns:
-	//   - []mcp.Prompt: List of available prompts for the session
-	ListPromptsForContext(ctx context.Context) []mcp.Prompt
+	//   - []PromptOrigin: Available prompts for the session, each tagged with its source server
+	ListPromptsForContext(ctx context.Context) []PromptOrigin
 
 	// GetPrompt executes a prompt with the provided arguments.
 	//
@@ -213,7 +213,7 @@ type MetaToolsHandler interface {
 	// Returns:
 	//   - []mcp.Prompt: List of available prompts
 	//   - error: Error if listing fails
-	ListPrompts(ctx context.Context) ([]mcp.Prompt, error)
+	ListPrompts(ctx context.Context) ([]PromptOrigin, error)
 
 	// GetPrompt executes a prompt with the provided arguments.
 	//
@@ -253,4 +253,17 @@ type MetaToolsHandler interface {
 type ResourceOrigin struct {
 	Resource mcp.Resource
 	Server   string
+}
+
+// PromptOrigin pairs an aggregated prompt with the server exposing it.
+//
+// A prompt name is prefixed, but with the server's *configured* tool prefix
+// (spec.toolPrefix) rather than its name -- a server named "gazelle-mcp-pro"
+// with prefix "pro" exposes "x_pro_<name>". Deriving the source server by
+// matching the server name against the exposed name therefore fails for every
+// server whose prefix differs from its name, which is the common case. Carry
+// the attribution explicitly instead, as ResourceOrigin does.
+type PromptOrigin struct {
+	Prompt mcp.Prompt
+	Server string
 }

--- a/internal/metatools/api_adapter.go
+++ b/internal/metatools/api_adapter.go
@@ -178,11 +178,11 @@ func (a *Adapter) GetResource(ctx context.Context, uri, serverName string) (*mcp
 // ListPrompts returns all available prompts for the current session.
 // This delegates to the data provider (aggregator) which handles session-scoped
 // prompt visibility for OAuth-protected servers.
-func (a *Adapter) ListPrompts(ctx context.Context) ([]mcp.Prompt, error) {
+func (a *Adapter) ListPrompts(ctx context.Context) ([]api.PromptOrigin, error) {
 	provider, err := a.getDataProvider()
 	if err != nil {
 		logging.Warn("metatools", "ListPrompts: %v", err)
-		return []mcp.Prompt{}, nil
+		return []api.PromptOrigin{}, nil
 	}
 
 	prompts := provider.ListPromptsForContext(ctx)

--- a/internal/metatools/formatters.go
+++ b/internal/metatools/formatters.go
@@ -192,21 +192,23 @@ func (f *Formatters) FormatResourcesListJSON(resources []api.ResourceOrigin) (st
 //   - error: JSON marshaling errors (should be rare)
 //
 // If no prompts are available, returns a simple message string.
-func (f *Formatters) FormatPromptsListJSON(prompts []mcp.Prompt) (string, error) {
+func (f *Formatters) FormatPromptsListJSON(prompts []api.PromptOrigin) (string, error) {
 	if len(prompts) == 0 {
 		return "No prompts available", nil
 	}
 
-	type PromptInfo struct {
+	type promptListEntry struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
+		Server      string `json:"server"`
 	}
 
-	promptList := make([]PromptInfo, len(prompts))
-	for i, prompt := range prompts {
-		promptList[i] = PromptInfo{
-			Name:        prompt.Name,
-			Description: prompt.Description,
+	promptList := make([]promptListEntry, len(prompts))
+	for i, origin := range prompts {
+		promptList[i] = promptListEntry{
+			Name:        origin.Prompt.Name,
+			Description: origin.Prompt.Description,
+			Server:      origin.Server,
 		}
 	}
 
@@ -289,10 +291,12 @@ func (f *Formatters) FormatResourceDetailJSON(origin api.ResourceOrigin) (string
 // Returns:
 //   - JSON string containing complete prompt information including arguments
 //   - error: JSON marshaling errors (should be rare)
-func (f *Formatters) FormatPromptDetailJSON(prompt mcp.Prompt) (string, error) {
+func (f *Formatters) FormatPromptDetailJSON(origin api.PromptOrigin) (string, error) {
+	prompt := origin.Prompt
 	promptInfo := map[string]interface{}{
 		api.FieldName:            prompt.Name,
 		api.SchemaKeyDescription: prompt.Description,
+		ArgServer:                origin.Server,
 	}
 
 	if len(prompt.Arguments) > 0 {
@@ -367,10 +371,10 @@ func (f *Formatters) FindResource(resources []api.ResourceOrigin, uri string) []
 //   - Pointer to the found prompt, or nil if not found
 //
 // The search is case-sensitive and requires exact name matching.
-func (f *Formatters) FindPrompt(prompts []mcp.Prompt, name string) *mcp.Prompt {
-	for _, prompt := range prompts {
-		if prompt.Name == name {
-			return &prompt
+func (f *Formatters) FindPrompt(prompts []api.PromptOrigin, name string) *api.PromptOrigin {
+	for _, origin := range prompts {
+		if origin.Prompt.Name == name {
+			return &origin
 		}
 	}
 	return nil

--- a/internal/metatools/formatters_test.go
+++ b/internal/metatools/formatters_test.go
@@ -96,15 +96,15 @@ func TestFormatters_FormatPromptsListJSON(t *testing.T) {
 	formatters := NewFormatters()
 
 	t.Run("empty prompts list", func(t *testing.T) {
-		result, err := formatters.FormatPromptsListJSON([]mcp.Prompt{})
+		result, err := formatters.FormatPromptsListJSON([]api.PromptOrigin{})
 		require.NoError(t, err)
 		assert.Equal(t, "No prompts available", result)
 	})
 
 	t.Run("with prompts", func(t *testing.T) {
-		prompts := []mcp.Prompt{
-			{Name: "prompt1", Description: "First prompt"},
-			{Name: "prompt2", Description: "Second prompt"},
+		prompts := []api.PromptOrigin{
+			{Prompt: mcp.Prompt{Name: "prompt1", Description: "First prompt"}, Server: "alpha"},
+			{Prompt: mcp.Prompt{Name: "prompt2", Description: "Second prompt"}, Server: "beta"},
 		}
 
 		result, err := formatters.FormatPromptsListJSON(prompts)
@@ -117,6 +117,10 @@ func TestFormatters_FormatPromptsListJSON(t *testing.T) {
 		assert.Len(t, parsed, 2)
 		assert.Equal(t, "prompt1", parsed[0]["name"])
 		assert.Equal(t, "First prompt", parsed[0]["description"])
+		// The exposed name is prefixed with the server's configured tool
+		// prefix, not its name, so attribution has to be carried explicitly.
+		assert.Equal(t, "alpha", parsed[0]["server"])
+		assert.Equal(t, "beta", parsed[1]["server"])
 	})
 }
 
@@ -179,9 +183,12 @@ func TestFormatters_FormatPromptDetailJSON(t *testing.T) {
 	formatters := NewFormatters()
 
 	t.Run("without arguments", func(t *testing.T) {
-		prompt := mcp.Prompt{
-			Name:        "test_prompt",
-			Description: "A test prompt",
+		prompt := api.PromptOrigin{
+			Prompt: mcp.Prompt{
+				Name:        "test_prompt",
+				Description: "A test prompt",
+			},
+			Server: "alpha",
 		}
 
 		result, err := formatters.FormatPromptDetailJSON(prompt)
@@ -197,13 +204,16 @@ func TestFormatters_FormatPromptDetailJSON(t *testing.T) {
 	})
 
 	t.Run("with arguments", func(t *testing.T) {
-		prompt := mcp.Prompt{
-			Name:        "test_prompt",
-			Description: "A test prompt",
-			Arguments: []mcp.PromptArgument{
-				{Name: "arg1", Description: "First argument", Required: true},
-				{Name: "arg2", Description: "Second argument", Required: false},
+		prompt := api.PromptOrigin{
+			Prompt: mcp.Prompt{
+				Name:        "test_prompt",
+				Description: "A test prompt",
+				Arguments: []mcp.PromptArgument{
+					{Name: "arg1", Description: "First argument", Required: true},
+					{Name: "arg2", Description: "Second argument", Required: false},
+				},
 			},
+			Server: "alpha",
 		}
 
 		result, err := formatters.FormatPromptDetailJSON(prompt)
@@ -281,15 +291,16 @@ func TestFormatters_FindResource(t *testing.T) {
 func TestFormatters_FindPrompt(t *testing.T) {
 	formatters := NewFormatters()
 
-	prompts := []mcp.Prompt{
-		{Name: "prompt1", Description: "First prompt"},
-		{Name: "prompt2", Description: "Second prompt"},
+	prompts := []api.PromptOrigin{
+		{Prompt: mcp.Prompt{Name: "prompt1", Description: "First prompt"}, Server: "alpha"},
+		{Prompt: mcp.Prompt{Name: "prompt2", Description: "Second prompt"}, Server: "beta"},
 	}
 
 	t.Run("finds existing prompt", func(t *testing.T) {
 		prompt := formatters.FindPrompt(prompts, "prompt1")
 		require.NotNil(t, prompt)
-		assert.Equal(t, "prompt1", prompt.Name)
+		assert.Equal(t, "prompt1", prompt.Prompt.Name)
+		assert.Equal(t, "alpha", prompt.Server)
 	})
 
 	t.Run("returns nil for non-existent prompt", func(t *testing.T) {

--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -767,9 +767,12 @@ func (p *Provider) handleFilterResources(ctx context.Context, args map[string]an
 
 // handleFilterPrompts handles the filter_prompts meta-tool.
 //
-// Prompt names are prefixed "x_<server>_<name>", so a pattern selects one
-// server's prompts exactly as it does for tools. The "server" argument is
-// accepted for symmetry with filter_resources and matches the same prefix.
+// The "server" argument matches the source server recorded on each prompt, not
+// the exposed name. A prompt name is prefixed with the server's *configured*
+// tool prefix (spec.toolPrefix) rather than its name -- a server named
+// "gazelle-mcp-pro" with prefix "pro" exposes "x_pro_<name>" -- so matching the
+// server name against the exposed name would find nothing for any server whose
+// prefix differs from its name. "pattern" still globs the exposed name.
 func (p *Provider) handleFilterPrompts(ctx context.Context, args map[string]any) (*api.CallToolResult, error) {
 	opts, errResult := parseCapabilityFilterArgs(args)
 	if errResult != nil {
@@ -786,23 +789,27 @@ func (p *Provider) handleFilterPrompts(ctx context.Context, args map[string]any)
 		return errorResult(fmt.Sprintf("Failed to list prompts: %v", err)), nil
 	}
 
-	matched := make([]mcp.Prompt, 0, len(prompts))
-	for _, prompt := range prompts {
-		if opts.Server != "" && !matchesPattern(prompt.Name, serverPromptPattern(opts.Server), opts.CaseSensitive) {
+	matched := make([]api.PromptOrigin, 0, len(prompts))
+	for _, origin := range prompts {
+		if opts.Server != "" && origin.Server != opts.Server {
 			continue
 		}
-		if !matchesPattern(prompt.Name, opts.Pattern, opts.CaseSensitive) {
+		if !matchesPattern(origin.Prompt.Name, opts.Pattern, opts.CaseSensitive) {
 			continue
 		}
-		matched = append(matched, prompt)
+		matched = append(matched, origin)
 	}
 
 	start, end, truncated := paginate(len(matched), opts.Limit, opts.Offset)
 	page := matched[start:end]
 
 	infos := make([]PromptInfo, 0, len(page))
-	for _, prompt := range page {
-		infos = append(infos, PromptInfo{Name: prompt.Name, Description: prompt.Description})
+	for _, origin := range page {
+		infos = append(infos, PromptInfo{
+			Name:        origin.Prompt.Name,
+			Description: origin.Prompt.Description,
+			Server:      origin.Server,
+		})
 	}
 
 	resp := FilterPromptsResponse{
@@ -819,14 +826,6 @@ func (p *Provider) handleFilterPrompts(ctx context.Context, args map[string]any)
 		return errorResult(fmt.Sprintf("Failed to format filtered prompts: %v", err)), nil
 	}
 	return textResult(string(jsonData)), nil
-}
-
-// serverPromptPattern builds the glob matching every prompt exposed by one
-// server. It mirrors the "x_<server>_" prefix ExposedPromptName applies; the
-// muster prefix is fixed at the aggregator's configured value, so the leading
-// segment is globbed rather than assumed to be "x".
-func serverPromptPattern(serverName string) string {
-	return fmt.Sprintf("*_%s_*", serverName)
 }
 
 // handleListPrompts handles the list_prompts meta-tool.

--- a/internal/metatools/handlers_test.go
+++ b/internal/metatools/handlers_test.go
@@ -16,7 +16,7 @@ import (
 type mockMetaToolsHandler struct {
 	tools     []mcp.Tool
 	resources []api.ResourceOrigin
-	prompts   []mcp.Prompt
+	prompts   []api.PromptOrigin
 
 	callToolResult *mcp.CallToolResult
 	callToolError  error
@@ -50,7 +50,7 @@ func (m *mockMetaToolsHandler) GetResource(ctx context.Context, uri, serverName 
 	return m.getResourceResult, nil
 }
 
-func (m *mockMetaToolsHandler) ListPrompts(ctx context.Context) ([]mcp.Prompt, error) {
+func (m *mockMetaToolsHandler) ListPrompts(ctx context.Context) ([]api.PromptOrigin, error) {
 	return m.prompts, nil
 }
 
@@ -502,8 +502,8 @@ func TestProvider_HandleListPrompts(t *testing.T) {
 	ctx := context.Background()
 
 	mock := &mockMetaToolsHandler{
-		prompts: []mcp.Prompt{
-			{Name: "prompt1", Description: "First prompt"},
+		prompts: []api.PromptOrigin{
+			{Prompt: mcp.Prompt{Name: "prompt1", Description: "First prompt"}, Server: "alpha"},
 		},
 	}
 	cleanup := registerMockHandler(mock)
@@ -519,6 +519,7 @@ func TestProvider_HandleListPrompts(t *testing.T) {
 	err = json.Unmarshal([]byte(content), &parsed)
 	require.NoError(t, err)
 	assert.Len(t, parsed, 1)
+	assert.Equal(t, "alpha", parsed[0]["server"], "listing must attribute each prompt to its source server")
 }
 
 func TestProvider_HandleDescribePrompt(t *testing.T) {
@@ -526,8 +527,8 @@ func TestProvider_HandleDescribePrompt(t *testing.T) {
 	ctx := context.Background()
 
 	mock := &mockMetaToolsHandler{
-		prompts: []mcp.Prompt{
-			{Name: "test_prompt", Description: "Test prompt"},
+		prompts: []api.PromptOrigin{
+			{Prompt: mcp.Prompt{Name: "test_prompt", Description: "Test prompt"}, Server: "alpha"},
 		},
 	}
 	cleanup := registerMockHandler(mock)

--- a/internal/metatools/provider_test.go
+++ b/internal/metatools/provider_test.go
@@ -113,3 +113,34 @@ func TestProvider_GetFormatters(t *testing.T) {
 	formatters := provider.GetFormatters()
 	require.NotNil(t, formatters)
 }
+
+// TestMetaToolNamesMatchesProvider guards the list clients route on against
+// the provider that actually advertises the tools.
+//
+// filter_resources and filter_prompts were added to the provider while the
+// agent kept a hand-written copy of the names, so the CLI answered "tool not
+// found" for tools the aggregator was serving. Nothing caught it: the copy was
+// a map literal, so no type check could notice, and every scenario exercises
+// meta-tools through a path that does not consult that list.
+func TestMetaToolNamesMatchesProvider(t *testing.T) {
+	advertised := make(map[string]bool)
+	for _, tool := range NewProvider().GetTools() {
+		advertised[tool.Name] = true
+	}
+
+	canonical := make(map[string]bool, len(MetaToolNames))
+	for _, name := range MetaToolNames {
+		canonical[name] = true
+		assert.True(t, advertised[name],
+			"MetaToolNames lists %q but the provider does not advertise it", name)
+		assert.True(t, IsMetaTool(name), "IsMetaTool must accept %q", name)
+	}
+
+	for name := range advertised {
+		assert.True(t, canonical[name],
+			"the provider advertises %q but MetaToolNames omits it -- clients routing on that list will refuse the tool", name)
+	}
+
+	assert.False(t, IsMetaTool("core_mcpserver_list"),
+		"aggregated tools must not be treated as meta-tools")
+}

--- a/internal/metatools/types.go
+++ b/internal/metatools/types.go
@@ -146,11 +146,13 @@ type FilterResourcesResponse struct {
 
 // PromptInfo is one entry in a filter_prompts response.
 //
-// Prompt names are prefixed "x_<server>_<name>", so unlike resources they can
-// be scoped to a server by pattern alone, exactly as tool names are.
+// Server carries the source server explicitly. The exposed name is prefixed
+// with the server's *configured* tool prefix rather than its name, so the name
+// alone does not identify the server.
 type PromptInfo struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Server      string `json:"server"`
 }
 
 // FilterPromptsResponse is the response structure from the filter_prompts

--- a/internal/metatools/types.go
+++ b/internal/metatools/types.go
@@ -21,6 +21,9 @@ const (
 	// ToolListResources lists available MCP resources.
 	ToolListResources = "list_resources"
 
+	// ToolFilterResources filters resources by source server and URI pattern.
+	ToolFilterResources = "filter_resources"
+
 	// ToolDescribeResource gets resource metadata.
 	ToolDescribeResource = "describe_resource"
 
@@ -29,6 +32,9 @@ const (
 
 	// ToolListPrompts lists available prompts.
 	ToolListPrompts = "list_prompts"
+
+	// ToolFilterPrompts filters prompts by source server and name pattern.
+	ToolFilterPrompts = "filter_prompts"
 
 	// ToolDescribePrompt gets prompt details.
 	ToolDescribePrompt = "describe_prompt"
@@ -112,6 +118,40 @@ type FilterCriteria struct {
 	IncludeSchema     bool              `json:"include_schema"`
 	Limit             int               `json:"limit"`
 	Offset            int               `json:"offset"`
+}
+
+// MetaToolNames is the canonical set of meta-tools the aggregator exposes
+// directly over MCP, as opposed to aggregated tools reached through call_tool.
+//
+// Clients that route on this distinction must derive their list from here.
+// filter_resources and filter_prompts were added to the provider without
+// updating the agent's hand-maintained copy, so the CLI reported "tool not
+// found" for tools the server was advertising -- a mismatch nothing could
+// catch, because the copy was a map literal rather than a type.
+var MetaToolNames = []string{
+	ToolListTools,
+	ToolDescribeTool,
+	ToolFilterTools,
+	ToolListCoreTools,
+	ToolCallTool,
+	ToolListResources,
+	ToolFilterResources,
+	ToolDescribeResource,
+	ToolGetResource,
+	ToolListPrompts,
+	ToolFilterPrompts,
+	ToolDescribePrompt,
+	ToolGetPrompt,
+}
+
+// IsMetaTool reports whether name is one of the aggregator's meta-tools.
+func IsMetaTool(name string) bool {
+	for _, n := range MetaToolNames {
+		if n == name {
+			return true
+		}
+	}
+	return false
 }
 
 // ArgServer is the argument name selecting which MCP server a resource or

--- a/internal/testing/mock/server.go
+++ b/internal/testing/mock/server.go
@@ -48,6 +48,7 @@ func NewServerFromFile(configPath string, debug bool) (*Server, error) {
 	var configData struct {
 		Tools           []ToolConfig     `yaml:"tools"`
 		Resources       []ResourceConfig `yaml:"resources"`
+		Prompts         []PromptConfig   `yaml:"prompts"`
 		ProtocolVersion string           `yaml:"protocol_version"`
 	}
 	if err := yaml.Unmarshal(content, &configData); err != nil {
@@ -89,7 +90,7 @@ func NewServerFromFile(configPath string, debug bool) (*Server, error) {
 		"1.0.0",
 		server.WithToolCapabilities(true),
 		server.WithResourceCapabilities(false, len(configData.Resources) > 0),
-		server.WithPromptCapabilities(false),
+		server.WithPromptCapabilities(len(configData.Prompts) > 0),
 		server.WithHooks(hooks),
 	)
 	mockServer.mcpServer = mcpServer
@@ -126,6 +127,21 @@ func NewServerFromFile(configPath string, debug bool) (*Server, error) {
 				MIMEType: mimeType,
 				Text:     text,
 			}}, nil
+		})
+	}
+
+	// Register static prompts. As with resources these have no handler config --
+	// a fetch returns the configured text verbatim.
+	for _, promptConfig := range configData.Prompts {
+		prompt := mcp.NewPrompt(
+			promptConfig.Name,
+			mcp.WithPromptDescription(promptConfig.Description),
+		)
+		description, text := promptConfig.Description, promptConfig.Text
+		mcpServer.AddPrompt(prompt, func(_ context.Context, _ mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			return mcp.NewGetPromptResult(description, []mcp.PromptMessage{
+				mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(text)),
+			}), nil
 		})
 	}
 

--- a/internal/testing/mock/types.go
+++ b/internal/testing/mock/types.go
@@ -39,6 +39,21 @@ type ResourceConfig struct {
 	Text string `yaml:"text"`
 }
 
+// PromptConfig defines a static MCP prompt served by the mock server.
+//
+// Prompts exist in the mock so scenarios can exercise the aggregator's prompt
+// paths -- notably that an exposed prompt name carries the server's configured
+// tool prefix rather than its name, so attribution cannot be derived from the
+// name alone.
+type PromptConfig struct {
+	// Name is the prompt name as the backend server exposes it
+	Name string `yaml:"name"`
+	// Description describes what the prompt does
+	Description string `yaml:"description"`
+	// Text is the message body returned when the prompt is fetched
+	Text string `yaml:"text"`
+}
+
 // ToolResponse defines a conditional response for a mock tool
 type ToolResponse struct {
 	// Condition defines arg matching for this response (optional)

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -1804,7 +1804,14 @@ func (m *musterInstanceManager) extractExpectedToolsWithHTTPMocks(config *Muster
 		}
 
 		// Family-grouped servers expose tools as x_<family.name>_<tool>; non-
-		// family servers retain per-server prefixing as x_<server>_<tool>.
+		// family servers use x_<toolPrefix>_<tool>, falling back to the server
+		// name when spec.toolPrefix is unset. Mirroring the toolPrefix here
+		// matters: without it, readiness waits for a name the aggregator never
+		// exposes and the instance never comes up.
+		serverPrefix := mcpServer.Name
+		if toolPrefix, ok := mcpServer.Config["toolPrefix"].(string); ok && toolPrefix != "" {
+			serverPrefix = toolPrefix
+		}
 		familyName := ""
 		familyInstanceArg := ""
 		if family, ok := mcpServer.Config["family"].(map[string]interface{}); ok {
@@ -1842,7 +1849,7 @@ func (m *musterInstanceManager) extractExpectedToolsWithHTTPMocks(config *Muster
 							if grouped {
 								prefixedName = fmt.Sprintf("x_%s_%s", familyName, name)
 							} else {
-								prefixedName = fmt.Sprintf("x_%s_%s", mcpServer.Name, name)
+								prefixedName = fmt.Sprintf("x_%s_%s", serverPrefix, name)
 							}
 							expectedTools = append(expectedTools, prefixedName)
 						}

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -609,6 +609,12 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 	resourceTicker := time.NewTicker(100 * time.Millisecond)
 	defer resourceTicker.Stop()
 
+	// Retained across ticks so the timeout error can say what was still
+	// missing. Without it the failure reads only "timeout waiting for all
+	// expected resources", which names neither the server nor the tool and
+	// makes every occurrence a log dig.
+	var lastNotReadyReasons []string
+
 	for {
 		select {
 		case <-resourceCtx.Done():
@@ -628,7 +634,11 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 					}
 				}
 			}
-			return fmt.Errorf("timeout waiting for all expected resources to be available")
+			if len(lastNotReadyReasons) > 0 {
+				return fmt.Errorf("timeout waiting for all expected resources to be available after %s: %s",
+					resourceTimeout, strings.Join(lastNotReadyReasons, "; "))
+			}
+			return fmt.Errorf("timeout waiting for all expected resources to be available after %s", resourceTimeout)
 		case <-procExited:
 			// The process died while we were waiting for its resources to
 			// register — surface the crash immediately rather than polling a
@@ -703,6 +713,8 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 					}
 				}
 			}
+
+			lastNotReadyReasons = notReadyReasons
 
 			if allReady {
 				if m.debug {

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -658,7 +658,10 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 						logger.Debug("🔍 Failed to list tools: %v\n", err)
 					}
 					allReady = false
-					notReadyReasons = append(notReadyReasons, "tools check failed")
+					// Carry the error: "tools check failed" alone cannot
+					// distinguish an aggregator that is still starting from one
+					// that is answering but short a tool.
+					notReadyReasons = append(notReadyReasons, fmt.Sprintf("tools check failed: %v", err))
 				} else {
 					missingTools := m.findMissingTools(expectedTools, availableTools)
 					if len(missingTools) > 0 {
@@ -676,7 +679,7 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 						logger.Debug("🔍 Failed to list workflows: %v\n", err)
 					}
 					allReady = false
-					notReadyReasons = append(notReadyReasons, "workflows check failed")
+					notReadyReasons = append(notReadyReasons, fmt.Sprintf("workflows check failed: %v", err))
 				} else {
 					for _, workflowName := range expectedWorkflows {
 						found := false
@@ -704,7 +707,7 @@ func (m *musterInstanceManager) WaitForReady(ctx context.Context, instance *Must
 						logger.Debug("🔍 Failed to list MCP servers: %v\n", err)
 					}
 					allReady = false
-					notReadyReasons = append(notReadyReasons, "MCP servers check failed")
+					notReadyReasons = append(notReadyReasons, fmt.Sprintf("MCP servers check failed: %v", err))
 				} else {
 					missingServers := m.findMissingMCPServers(expectedMCPServers, serverStates)
 					if len(missingServers) > 0 {

--- a/internal/testing/scenarios/filter-prompts-by-server.yaml
+++ b/internal/testing/scenarios/filter-prompts-by-server.yaml
@@ -1,0 +1,120 @@
+name: "filter-prompts-by-server"
+description: "filter_prompts scopes prompts by their source server, which the exposed name does not encode: a prompt name carries the server's configured toolPrefix, not its name, so matching the server name against the name finds nothing whenever the two differ (#1096)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["metatools", "filter_prompts", "list_prompts", "prompts", "attribution", "toolPrefix"]
+timeout: "5m"
+
+# Regression guard for the prompt half of #1096:
+#
+# Given: A server named "promptserver" configured with toolPrefix "pp", so its
+#        prompts are exposed as "x_pp_<name>" -- the server name appears nowhere
+#        in the exposed name.
+# When:  filter_prompts is scoped to server "promptserver".
+# Then:  Its prompts come back, and list_prompts names the source server.
+#
+# An earlier implementation derived the server from the exposed name by
+# matching "*_<serverName>_*", which silently returned nothing for exactly this
+# (normal) configuration.
+
+pre_configuration:
+  mcp_servers:
+    - name: "promptserver"
+      config:
+        toolPrefix: "pp"
+        tools:
+          - name: "ping"
+            description: "Keeps promptserver in the tool catalogue."
+            responses: [{ response: { ok: true } }]
+        prompts:
+          - name: "triage"
+            description: "Triage an incoming issue."
+            text: "Triage this issue."
+          - name: "summarize"
+            description: "Summarize a thread."
+            text: "Summarize this thread."
+    - name: "otherserver"
+      config:
+        tools:
+          - name: "ping"
+            description: "Keeps otherserver in the tool catalogue."
+            responses: [{ response: { ok: true } }]
+        prompts:
+          - name: "unrelated"
+            description: "A prompt from a different server."
+            text: "Unrelated."
+
+steps:
+  - id: "wait-for-mock-servers"
+    description: "Both prompt-exposing servers must be connected"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["promptserver", "otherserver"]
+
+  # The configured prefix, not the server name, is what lands in the name.
+  - id: "prompt-names-carry-the-configured-prefix"
+    description: "list_prompts exposes the toolPrefix-based name and the true source server"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "list_prompts"
+      arguments: {}
+    expected:
+      success: true
+      contains: ["x_pp_triage", "promptserver"]
+      not_contains: ["x_promptserver_triage"]
+
+  # The regression: scoping by server must not go via the exposed name.
+  - id: "server-filter-finds-prefix-divergent-prompts"
+    description: "filter_prompts scopes to a server whose prefix differs from its name"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_prompts"
+      arguments:
+        server: "promptserver"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 2
+      contains: ["x_pp_triage", "x_pp_summarize"]
+      not_contains: ["unrelated"]
+
+  - id: "server-filter-excludes-other-servers"
+    description: "The other server's prompts are reported under their own server"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_prompts"
+      arguments:
+        server: "otherserver"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 1
+      contains: ["otherserver"]
+      not_contains: ["x_pp_triage"]
+
+  - id: "pattern-still-globs-the-exposed-name"
+    description: "A name glob narrows independently of the server filter"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_prompts"
+      arguments:
+        pattern: "*_triage"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 1
+      contains: ["x_pp_triage"]
+
+  - id: "counts-are-reported-per-server"
+    description: "core_mcpserver_list carries prompt counts"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      contains: ["promptsCount"]


### PR DESCRIPTION
Follow-up to #1099, which I got wrong. Found while wiring the Backstage panels that consume it (giantswarm/backstage#2127) — the prompts panel would have rendered nothing, silently.

## The bug

`filter_prompts` derived a prompt's server by matching `*_<serverName>_*` against the exposed name. That assumed the exposed name embeds the *server name*. It does not: `ExposedPromptName` prefixes with the server's **configured tool prefix** (`spec.toolPrefix`). A server named `gazelle-mcp-pro` with `toolPrefix: pro` exposes `x_pro_<name>` — the server name appears nowhere.

So `filter_prompts(server: "gazelle-mcp-pro")` matched nothing for any server whose prefix differs from its name, which is the normal configuration. And it failed by returning an **empty list**, not an error — the worst shape for a UI panel, which would simply render as "no prompts".

Resources never had this problem: #1098 gave them explicit attribution precisely because their URIs carry no usable prefix. Prompts looked like they had a usable prefix, so I filtered on the name. That was wrong.

## The fix

Carry the source server explicitly, exactly as resources do:

- `GetAllPromptsForSession` returns `[]api.PromptOrigin` instead of `[]mcp.Prompt`.
- `list_prompts` and `describe_prompt` report `server` for every entry.
- `filter_prompts` compares `origin.Server` against the `server` argument. `pattern` still globs the exposed name.

## Two test-infrastructure gaps closed first

Neither the bug nor its fix was observable without these, which is why it shipped in the first place:

- **The mock MCP server served no prompts** (`WithPromptCapabilities(false)`), so no scenario could exercise a prompt path at all. It now serves static prompts, as it now does resources.
- **Readiness ignored `spec.toolPrefix`.** Expected tool names were built as `x_<serverName>_<tool>`, mirroring family grouping but not the prefix. Any scenario configuring a `toolPrefix` waited for a name the aggregator never exposes and timed out during startup — so the divergent case was untestable, not merely untested.

## Verification

- New scenario `filter-prompts-by-server` — a server named `promptserver` with `toolPrefix: pp`, so its prompts are exposed `x_pp_*` and the server name appears nowhere in them. It asserts the listing reports `promptserver` as the source, that scoping by server finds both its prompts, that another server's prompt is excluded, and that a name glob still works. 6/6 steps pass; it fails on the previous implementation.
- Full scenario suite **198/198**, unit suite green, `golangci-lint -E=gosec -E=goconst -E=govet` reports 0 issues.

Unrelated but worth recording: `muster test` warns when `--base-port` lands inside the OS ephemeral range (32768–60999), and ports there really do get stolen — several runs of mine failed spuriously until I moved below it. CI's `--base-port 30000` is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
