### PR TITLE
fix(aggregator): retire session OAuth connections on auth loss instead of retrying forever

### DIFF
--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -25,6 +25,11 @@ import (
 // requireSessionContextResult so the wording stays in sync.
 const errMissingSession = "Error: authentication context missing — no active session"
 
+// mcpServerKind is the MCPServer CRD kind. It is also the service type the
+// orchestrator reports for MCPServer-backed services, so state-change events
+// carry the same string.
+const mcpServerKind = "MCPServer"
+
 // requireSessionContext extracts sessionID and subject from ctx,
 // returning an error that names serverName when either is missing.
 func requireSessionContext(ctx context.Context, serverName string) (sessionID, sub string, err error) {
@@ -124,7 +129,9 @@ func establishConnection(
 	if oauthHandler != nil && oauthHandler.IsEnabled() && issuer != "" {
 		tokenStore := internalmcp.NewMusterTokenStore(sessionID, sub, issuer, oauthHandler)
 		clientID, clientSecret := oauthHandler.GetClientCredentialsForIssuer(ctx, issuer)
-		client = internalmcp.NewDynamicAuthClient(serverURL, tokenStore, scope, clientID, clientSecret).WithMeta(meta)
+		client = internalmcp.NewDynamicAuthClient(serverURL, tokenStore, scope, clientID, clientSecret).
+			WithMeta(meta).
+			WithAuthLossHandler(a.makeSessionAuthLossHandler(sessionID, serverName))
 		logging.Debug("Connection", "Using DynamicAuthClient for session %s, server %s (issuer=%s)",
 			logging.TruncateIdentifier(sessionID), serverName, issuer)
 	} else {
@@ -451,7 +458,7 @@ func emitTokenForwardingEvent(serverName, namespace string, success bool, errorM
 	}
 
 	objRef := api.ObjectReference{
-		Kind:      "MCPServer",
+		Kind:      mcpServerKind,
 		Name:      serverName,
 		Namespace: namespace,
 	}
@@ -753,7 +760,7 @@ func emitTokenExchangeEvent(serverName, namespace string, success bool, errorMsg
 	}
 
 	objRef := api.ObjectReference{
-		Kind:      "MCPServer",
+		Kind:      mcpServerKind,
 		Name:      serverName,
 		Namespace: namespace,
 	}
@@ -1164,6 +1171,78 @@ func notifyMCPServerConnected(serverName, authMethod string) {
 		logging.Warn("Connection", "Failed to update MCPServer %s state after %s: %v",
 			serverName, authMethod, err)
 	}
+}
+
+// makeSessionAuthLossHandler builds the WithAuthLossHandler callback for one
+// session-scoped OAuth (DynamicAuthClient) connection. When the connection's
+// authentication is observed lost — the stored token vanished (e.g. the token
+// store's backing service lost its data) or the server keeps rejecting it —
+// the handler retires the connection instead of letting mcp-go's continuous
+// listener retry once per second forever: a lost grant is terminal until a
+// human re-authenticates via core_auth_login.
+//
+// It logs the transition once at WARN, evicts the pooled client (closing it
+// stops the listener), revokes the session's authenticated mark (without this
+// core_auth_login answers "already authenticated" and the user cannot
+// re-authenticate), and — when this was the server's last live session
+// connection — syncs the service state back to Auth Required so the CRD
+// status and the connection-state metric stay accurate. notifyMCPServerConnected
+// is the exact counterpart on the way up.
+func (a *AggregatorServer) makeSessionAuthLossHandler(sessionID, serverName string) func(reason string) {
+	return func(reason string) {
+		logging.Warn("Connection", "Session %s lost authentication to MCP server %s (%s); closing the connection — re-authenticate via core_auth_login",
+			logging.TruncateIdentifier(sessionID), serverName, reason)
+
+		if a.authStore != nil {
+			if err := a.authStore.Revoke(context.Background(), sessionID, serverName); err != nil {
+				logging.Warn("Connection", "Failed to revoke session auth mark for %s/%s: %v",
+					logging.TruncateIdentifier(sessionID), serverName, err)
+			}
+		}
+
+		if a.connPool != nil {
+			a.connPool.Evict(sessionID, serverName)
+			if a.connPool.HasServer(serverName) {
+				// Another session still holds a live connection, so the
+				// server-level state remains whatever that connection proves.
+				return
+			}
+		}
+		a.notifyMCPServerAuthRequired(serverName, reason)
+	}
+}
+
+// notifyMCPServerAuthRequired syncs the service state to Auth Required after
+// the server's last authenticated session connection was lost, and emits the
+// CRD event operators find in `kubectl describe`. Best-effort, like
+// notifyMCPServerConnected.
+func (a *AggregatorServer) notifyMCPServerAuthRequired(serverName, reason string) {
+	if err := api.UpdateMCPServerState(serverName, api.StateAuthRequired, api.HealthUnknown, nil); err != nil {
+		logging.Warn("Connection", "Failed to update MCPServer %s state after authentication loss: %v",
+			serverName, err)
+	}
+
+	eventManager := api.GetEventManager()
+	if eventManager == nil {
+		return
+	}
+	namespace := ""
+	if serverInfo, exists := a.registry.GetServerInfo(serverName); exists {
+		namespace = serverInfo.GetNamespace()
+	}
+	if namespace == "" {
+		namespace = eventManager.DefaultNamespace()
+	}
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	_ = eventManager.CreateEventWithData(context.Background(), api.ObjectReference{
+		Kind:      mcpServerKind,
+		Name:      serverName,
+		Namespace: namespace,
+	}, string(events.ReasonMCPServerAuthRequired), api.EventData{
+		Error: reason,
+	})
 }
 
 // loadTokenExchangeCredentials loads OAuth client credentials from a Kubernetes secret

--- a/internal/aggregator/event_handler.go
+++ b/internal/aggregator/event_handler.go
@@ -319,7 +319,7 @@ func (eh *EventHandler) generateEvent(serviceName string, reason events.EventRea
 		namespace = metav1.NamespaceDefault
 	}
 	objectRef := api.ObjectReference{
-		Kind:      "MCPServer",
+		Kind:      mcpServerKind,
 		Name:      serviceName,
 		Namespace: namespace,
 	}
@@ -343,5 +343,5 @@ func (eh *EventHandler) generateEvent(serviceName string, reason events.EventRea
 //
 // Returns true if the event is related to an MCP service, false otherwise.
 func (eh *EventHandler) isMCPServiceEvent(event api.ServiceStateChangedEvent) bool {
-	return event.ServiceType == "MCPServer"
+	return event.ServiceType == mcpServerKind
 }

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -2983,7 +2983,8 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 		scope := serverInfo.AuthInfo.Scope
 		tokenStore := internalmcp.NewMusterTokenStore(sessionID, sub, issuer, oauthHandler)
 		clientID, clientSecret := oauthHandler.GetClientCredentialsForIssuer(ctx, issuer)
-		client = internalmcp.NewDynamicAuthClient(serverInfo.URL, tokenStore, scope, clientID, clientSecret)
+		client = internalmcp.NewDynamicAuthClient(serverInfo.URL, tokenStore, scope, clientID, clientSecret).
+			WithAuthLossHandler(a.makeSessionAuthLossHandler(sessionID, serverName))
 
 	} else {
 		return nil, nil, fmt.Errorf("unable to determine auth method for server %s", serverName)

--- a/internal/aggregator/session_connection_pool.go
+++ b/internal/aggregator/session_connection_pool.go
@@ -278,6 +278,20 @@ func (p *SessionConnectionPool) EvictSession(sessionID string) {
 	}
 }
 
+// HasServer reports whether any session currently holds a pooled connection
+// to the given server. Used to decide whether an authentication loss on one
+// session was the server's last live connection.
+func (p *SessionConnectionPool) HasServer(serverName string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for key := range p.pool {
+		if key.ServerName == serverName {
+			return true
+		}
+	}
+	return false
+}
+
 // EvictServer removes and closes all pooled entries for the given server
 // across every session.
 func (p *SessionConnectionPool) EvictServer(serverName string) {

--- a/internal/mcpserver/auth_loss.go
+++ b/internal/mcpserver/auth_loss.go
@@ -1,0 +1,130 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/giantswarm/muster/pkg/logging"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+)
+
+// authLossThreshold is the number of consecutive authentication failures
+// (token-store misses or HTTP 401 responses) after which a session-scoped
+// OAuth client reports that its authentication is lost. It mirrors
+// maxConsecutiveTokenFailures on the token-forwarding path: mcp-go's
+// continuous listener retries once per second, so detection settles within a
+// few seconds while a single transient 401 never tears down a connection.
+const authLossThreshold = 3
+
+// authLossDetector aggregates authentication-failure signals from the two
+// places a lost OAuth grant becomes visible, and fires onAuthLost once when
+// authLossThreshold consecutive failures accumulate:
+//
+//   - the token store: the token is gone (e.g. the backing store lost it), so
+//     mcp-go fails the request before it reaches the wire
+//   - the HTTP transport: a token is still held but the server rejects it
+//     with 401 (e.g. it was revoked or the grant it came from is unknown)
+//
+// One counter serves both signals on purpose: each request produces exactly
+// one of them (a store miss aborts the request, otherwise the wire result
+// decides), so a mixed sequence still means consecutive failed attempts.
+//
+// Without this detector nothing ever stops a broken session connection:
+// mcp-go's continuous-listening GET retries every second forever, logging an
+// error each time, while the connection can never recover on its own — only
+// a human re-authenticating mints a new grant.
+type authLossDetector struct {
+	// onAuthLost is invoked asynchronously, exactly once per detector, from
+	// its own goroutine so it may close the very client whose request path
+	// triggered it. Immutable after construction.
+	onAuthLost func(reason string)
+
+	mu          sync.Mutex
+	consecutive int
+	fired       bool
+}
+
+// noteFailure records one authentication failure and fires onAuthLost when
+// the threshold is reached. Safe to call on a nil detector.
+func (d *authLossDetector) noteFailure(reason string) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	d.consecutive++
+	fire := !d.fired && d.consecutive >= authLossThreshold && d.onAuthLost != nil
+	if fire {
+		d.fired = true
+	}
+	d.mu.Unlock()
+
+	if fire {
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					logging.Error("AuthLossDetector", fmt.Errorf("panic in onAuthLost: %v", r),
+						"onAuthLost callback panicked")
+				}
+			}()
+			d.onAuthLost(reason)
+		}()
+	}
+}
+
+// noteSuccess resets the consecutive-failure count. Called on any HTTP
+// response that is not a 401 — only the server accepting or rejecting the
+// credential says anything about authentication, so a successful token-store
+// read does not reset the count. Safe to call on a nil detector.
+func (d *authLossDetector) noteSuccess() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	d.consecutive = 0
+	d.mu.Unlock()
+}
+
+// authObservingTokenStore wraps a transport.TokenStore and reports token-store
+// misses (transport.ErrNoToken) to the detector. mcp-go consults the store via
+// GetAuthorizationHeader before every request — including the continuous
+// listener's GETs — so a store that lost its token is noticed within a few
+// listener iterations even when no tool call is in flight.
+type authObservingTokenStore struct {
+	transport.TokenStore
+	detector *authLossDetector
+}
+
+func (s *authObservingTokenStore) GetToken(ctx context.Context) (*transport.Token, error) {
+	token, err := s.TokenStore.GetToken(ctx)
+	if err != nil && errors.Is(err, transport.ErrNoToken) {
+		s.detector.noteFailure("token no longer present in the token store")
+	}
+	return token, err
+}
+
+// authObservingTransport reports the server's verdict on the credential to the
+// detector: a 401 response counts as an authentication failure, any other
+// response resets the count. Transport errors say nothing about
+// authentication and do neither. It covers the requests the token store
+// cannot see failing — a token that is still held but no longer accepted.
+type authObservingTransport struct {
+	next     http.RoundTripper
+	detector *authLossDetector
+}
+
+func (t *authObservingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.next.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.detector.noteFailure("server rejected the token with 401")
+	} else {
+		t.detector.noteSuccess()
+	}
+	return resp, err
+}

--- a/internal/mcpserver/auth_loss_test.go
+++ b/internal/mcpserver/auth_loss_test.go
@@ -1,0 +1,227 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingHandler collects onAuthLost invocations for assertions.
+type recordingHandler struct {
+	mu      sync.Mutex
+	reasons []string
+	fired   chan string
+}
+
+func newRecordingHandler() *recordingHandler {
+	return &recordingHandler{fired: make(chan string, 8)}
+}
+
+func (r *recordingHandler) handle(reason string) {
+	r.mu.Lock()
+	r.reasons = append(r.reasons, reason)
+	r.mu.Unlock()
+	r.fired <- reason
+}
+
+func (r *recordingHandler) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.reasons)
+}
+
+func (r *recordingHandler) waitFired(t *testing.T, timeout time.Duration) string {
+	t.Helper()
+	select {
+	case reason := <-r.fired:
+		return reason
+	case <-time.After(timeout):
+		t.Fatalf("onAuthLost did not fire within %v", timeout)
+		return ""
+	}
+}
+
+func TestAuthLossDetector_FiresOnceAtThreshold(t *testing.T) {
+	handler := newRecordingHandler()
+	detector := &authLossDetector{onAuthLost: handler.handle}
+
+	for i := 0; i < authLossThreshold-1; i++ {
+		detector.noteFailure("almost")
+	}
+	select {
+	case <-handler.fired:
+		t.Fatal("fired below threshold")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	detector.noteFailure("over the line")
+	assert.Equal(t, "over the line", handler.waitFired(t, time.Second))
+
+	// Further failures never re-fire: the connection is expected to be retired.
+	for i := 0; i < 2*authLossThreshold; i++ {
+		detector.noteFailure("extra")
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 1, handler.count())
+}
+
+func TestAuthLossDetector_SuccessResetsCount(t *testing.T) {
+	handler := newRecordingHandler()
+	detector := &authLossDetector{onAuthLost: handler.handle}
+
+	// Interleaved successes keep the consecutive count below the threshold.
+	for i := 0; i < 3*authLossThreshold; i++ {
+		detector.noteFailure("blip")
+		if (i+1)%(authLossThreshold-1) == 0 {
+			detector.noteSuccess()
+		}
+	}
+	select {
+	case <-handler.fired:
+		t.Fatal("fired despite interleaved successes")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestAuthLossDetector_NilSafe(t *testing.T) {
+	var detector *authLossDetector
+	detector.noteFailure("nil")
+	detector.noteSuccess()
+}
+
+// staticTokenStore serves a fixed token until dropToken is set, then reports
+// transport.ErrNoToken — the shape of a backing store that lost its data.
+type staticTokenStore struct {
+	dropToken atomic.Bool
+	token     transport.Token
+}
+
+func (s *staticTokenStore) GetToken(_ context.Context) (*transport.Token, error) {
+	if s.dropToken.Load() {
+		return nil, transport.ErrNoToken
+	}
+	token := s.token
+	return &token, nil
+}
+
+func (s *staticTokenStore) SaveToken(_ context.Context, _ *transport.Token) error { return nil }
+
+func TestAuthObservingTokenStore_ReportsMisses(t *testing.T) {
+	handler := newRecordingHandler()
+	store := &staticTokenStore{token: transport.Token{AccessToken: "tok", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)}}
+	observing := &authObservingTokenStore{
+		TokenStore: store,
+		detector:   &authLossDetector{onAuthLost: handler.handle},
+	}
+
+	// Successful reads do not fire and do not reset anything relevant here.
+	_, err := observing.GetToken(context.Background())
+	require.NoError(t, err)
+
+	store.dropToken.Store(true)
+	for i := 0; i < authLossThreshold; i++ {
+		_, err := observing.GetToken(context.Background())
+		require.ErrorIs(t, err, transport.ErrNoToken)
+	}
+	handler.waitFired(t, time.Second)
+}
+
+func TestAuthObservingTransport_CountsOnly401(t *testing.T) {
+	handler := newRecordingHandler()
+	detector := &authLossDetector{onAuthLost: handler.handle}
+
+	status := &atomic.Int64{}
+	status.Store(http.StatusOK)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(int(status.Load()))
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Transport: &authObservingTransport{next: http.DefaultTransport, detector: detector}}
+	get := func() {
+		resp, err := client.Get(ts.URL)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+	}
+
+	// 401s below the threshold, then a success: the count resets.
+	status.Store(http.StatusUnauthorized)
+	for i := 0; i < authLossThreshold-1; i++ {
+		get()
+	}
+	status.Store(http.StatusOK)
+	get()
+	status.Store(http.StatusUnauthorized)
+	for i := 0; i < authLossThreshold-1; i++ {
+		get()
+	}
+	select {
+	case <-handler.fired:
+		t.Fatal("fired despite reset")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	get()
+	handler.waitFired(t, time.Second)
+}
+
+// TestDynamicAuthClient_AuthLossStopsListener reproduces the incident shape
+// end to end: a session-scoped OAuth connection is established, then the
+// server starts rejecting the (still held) token with 401. mcp-go's
+// continuous listener hits the 401s; the auth-loss handler must fire so the
+// connection can be retired, and closing the client must stop the retry loop.
+func TestDynamicAuthClient_AuthLossStopsListener(t *testing.T) {
+	if testing.Short() {
+		t.Skip("multi-second listener retry timing")
+	}
+
+	revoked := &atomic.Bool{}
+	requests := &atomic.Int64{}
+
+	mcpHandler := server.NewStreamableHTTPServer(newTestMCPServer(), server.WithStateful(true))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if revoked.Load() {
+			w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="Token validation failed"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_token","error_description":"Token validation failed"}`))
+			return
+		}
+		mcpHandler.ServeHTTP(w, r)
+	}))
+	defer ts.Close()
+
+	store := &staticTokenStore{token: transport.Token{AccessToken: "tok", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)}}
+	handler := newRecordingHandler()
+	client := NewDynamicAuthClient(ts.URL, store, "scope", "client-id", "").
+		WithAuthLossHandler(handler.handle)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, client.Initialize(ctx))
+
+	// The grant disappears server-side. The continuous listener retries once
+	// per second, so the threshold is crossed within a few seconds even with
+	// no tool call in flight.
+	revoked.Store(true)
+	handler.waitFired(t, 15*time.Second)
+
+	// The production handler evicts the pooled client, which closes it.
+	require.NoError(t, client.Close())
+
+	// Give any in-flight request time to land, then verify the retry loop is
+	// gone: no further requests reach the server.
+	time.Sleep(time.Second)
+	before := requests.Load()
+	time.Sleep(2500 * time.Millisecond)
+	assert.Equal(t, before, requests.Load(), "listener kept retrying after close")
+}

--- a/internal/mcpserver/client_dynamic_auth.go
+++ b/internal/mcpserver/client_dynamic_auth.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/pkg/logging"
@@ -37,6 +38,11 @@ type DynamicAuthClient struct {
 	// meta holds the spec.meta entries merged into params._meta of every
 	// outbound request.
 	meta map[string]string
+
+	// onAuthLost, when set, is invoked once when the connection's
+	// authentication is observed lost (see authLossDetector). Immutable after
+	// construction; set via WithAuthLossHandler.
+	onAuthLost func(reason string)
 }
 
 // WithMeta sets the entries merged into the params._meta object of every
@@ -44,6 +50,20 @@ type DynamicAuthClient struct {
 // construction site reads as one expression.
 func (c *DynamicAuthClient) WithMeta(meta map[string]string) *DynamicAuthClient {
 	c.meta = meta
+	return c
+}
+
+// WithAuthLossHandler registers a function invoked once when the client's
+// authentication is observed lost: the token store no longer holds a token,
+// or the server keeps rejecting the held token with 401 (authLossThreshold
+// consecutive failures either way). The handler runs on its own goroutine and
+// is expected to retire this client — a lost grant never heals on its own, it
+// needs a human to re-authenticate, so leaving the client running means
+// mcp-go's continuous listener retries (and logs) every second forever.
+//
+// Returns the client so a construction site reads as one expression.
+func (c *DynamicAuthClient) WithAuthLossHandler(fn func(reason string)) *DynamicAuthClient {
+	c.onAuthLost = fn
 	return c
 }
 
@@ -83,12 +103,24 @@ func (c *DynamicAuthClient) Initialize(ctx context.Context) error {
 
 	logging.Debug("DynamicAuthClient", "Creating StreamableHTTP client for URL: %s with OAuth handler", c.url)
 
+	// The detector watches both places a lost grant shows up: the token store
+	// (token gone) and the wire (token rejected with 401). Nil when no handler
+	// is registered — every observer method tolerates a nil detector.
+	var detector *authLossDetector
+	if c.onAuthLost != nil {
+		detector = &authLossDetector{onAuthLost: c.onAuthLost}
+	}
+
 	var opts []transport.StreamableHTTPCOption
 	if c.tokenStore != nil {
+		tokenStore := c.tokenStore
+		if detector != nil {
+			tokenStore = &authObservingTokenStore{TokenStore: tokenStore, detector: detector}
+		}
 		opts = append(opts, transport.WithHTTPOAuth(transport.OAuthConfig{
 			ClientID:     c.clientID,
 			ClientSecret: c.clientSecret,
-			TokenStore:   c.tokenStore,
+			TokenStore:   tokenStore,
 			Scopes:       []string{c.scope},
 		}))
 	}
@@ -96,12 +128,25 @@ func (c *DynamicAuthClient) Initialize(ctx context.Context) error {
 	// The OAuth handler is separate from the transport's HTTP client, so a
 	// metadata-injecting client composes with bearer injection instead of
 	// replacing it.
-	if httpClient := metaHTTPClient(c.meta); httpClient != nil {
-		opts = append(opts, transport.WithHTTPBasicClient(httpClient))
+	httpClient := metaHTTPClient(c.meta)
+	if httpClient != nil {
 		logging.Debug("DynamicAuthClient", "Configured %d meta entries", len(c.meta))
+	}
+	if detector != nil {
+		base := http.RoundTripper(http.DefaultTransport)
+		if httpClient != nil {
+			base = httpClient.Transport
+		}
+		// No timeout on the client, matching mcp-go's default: a timeout would
+		// also cut the long-lived GET that WithContinuousListening opens.
+		httpClient = &http.Client{Transport: &authObservingTransport{next: base, detector: detector}}
+	}
+	if httpClient != nil {
+		opts = append(opts, transport.WithHTTPBasicClient(httpClient))
 	}
 
 	opts = append(opts, transport.WithContinuousListening())
+	opts = append(opts, transport.WithHTTPLogger(mcpTransportLogger(c.url)))
 
 	mcpClient, err := client.NewStreamableHttpClient(c.url, opts...)
 	if err != nil {

--- a/internal/mcpserver/client_streamable_http.go
+++ b/internal/mcpserver/client_streamable_http.go
@@ -102,6 +102,7 @@ func (c *StreamableHTTPClient) Initialize(ctx context.Context) error {
 	// Enable receiving server-pushed notifications outside active requests.
 	// This opens a long-lived GET connection to the server per the MCP spec.
 	opts = append(opts, transport.WithContinuousListening())
+	opts = append(opts, transport.WithHTTPLogger(mcpTransportLogger(c.url)))
 
 	mcpClient, err := client.NewStreamableHttpClient(c.url, opts...)
 	if err != nil {

--- a/internal/mcpserver/transport_logger.go
+++ b/internal/mcpserver/transport_logger.go
@@ -1,0 +1,56 @@
+package mcpserver
+
+import (
+	"context"
+	"log/slog"
+)
+
+// mcpTransportLogger returns the logger handed to mcp-go's streamable-http
+// transport for one client. Without it the transport logs through the bare
+// process default: its once-per-second listener retry errors then appear as
+// context-free ERROR lines that cannot be attributed to a server.
+//
+// The returned logger tags every record with the server URL and caps the
+// level at WARN: the transport's errors are retry noise from a loop that
+// either recovers by itself or is torn down by muster (see authLossDetector)
+// — the conditions worth alerting on are logged by muster at the state
+// transition, not once per retry.
+func mcpTransportLogger(serverURL string) *slog.Logger {
+	return slog.New(warnCapHandler{slog.Default().Handler()}).With(
+		slog.String("subsystem", "mcp-transport"),
+		slog.String("server_url", serverURL),
+	)
+}
+
+// warnCapHandler demotes records above WARN to WARN and delegates everything
+// else unchanged.
+type warnCapHandler struct {
+	slog.Handler
+}
+
+func (h warnCapHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	if level > slog.LevelWarn {
+		level = slog.LevelWarn
+	}
+	return h.Handler.Enabled(ctx, level)
+}
+
+func (h warnCapHandler) Handle(ctx context.Context, record slog.Record) error {
+	if record.Level > slog.LevelWarn {
+		capped := slog.NewRecord(record.Time, slog.LevelWarn, record.Message, record.PC)
+		record.Attrs(func(attr slog.Attr) bool {
+			capped.AddAttrs(attr)
+			return true
+		})
+		record = capped
+	}
+	return h.Handler.Handle(ctx, record)
+}
+
+func (h warnCapHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return warnCapHandler{h.Handler.WithAttrs(attrs)}
+}
+
+func (h warnCapHandler) WithGroup(name string) slog.Handler {
+	return warnCapHandler{h.Handler.WithGroup(name)}
+}

--- a/internal/mcpserver/types.go
+++ b/internal/mcpserver/types.go
@@ -136,13 +136,18 @@ func CheckForAuthRequiredError(ctx context.Context, err error, url string) *Auth
 		return nil
 	}
 
+	// The wrapped Err keeps transport.ErrUnauthorized in the chain so callers
+	// that test with pkgoauth.IsOAuthUnauthorizedError / errors.Is still
+	// recognize an AuthRequiredError as a 401 — core_auth_login relies on this
+	// to clear a stored-but-rejected token and issue a fresh auth challenge
+	// instead of dead-ending with "try again".
 	var oauthErr *transport.OAuthAuthorizationRequiredError
 	if errors.As(err, &oauthErr) {
 		authInfo := extractAuthInfoFromHandler(ctx, oauthErr.Handler)
 		return &AuthRequiredError{
 			URL:      url,
 			AuthInfo: authInfo,
-			Err:      fmt.Errorf("server returned 401 Unauthorized"),
+			Err:      fmt.Errorf("server returned 401 Unauthorized: %w", transport.ErrUnauthorized),
 		}
 	}
 
@@ -152,7 +157,7 @@ func CheckForAuthRequiredError(ctx context.Context, err error, url string) *Auth
 		return &AuthRequiredError{
 			URL:      url,
 			AuthInfo: AuthInfo{},
-			Err:      fmt.Errorf("server returned 401 Unauthorized"),
+			Err:      fmt.Errorf("server returned 401 Unauthorized: %w", transport.ErrUnauthorized),
 		}
 	}
 

--- a/internal/testing/scenarios/oauth-token-loss-terminal-auth-required.yaml
+++ b/internal/testing/scenarios/oauth-token-loss-terminal-auth-required.yaml
@@ -1,0 +1,196 @@
+name: "oauth-token-loss-terminal-auth-required"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  Test that losing an OAuth grant retires the session connection instead of
+  retrying forever (gazelle 2026-08-26 incident shape).
+
+  When a session-scoped OAuth connection's grant disappears — the backing
+  token store lost it, or the server starts rejecting the held token with 401
+  (revoked / unknown grant) — nothing used to stop the broken pooled client:
+  every tool call kept re-using it, and mcp-go's continuous listener retried
+  its SSE GET once per second forever, logging an ERROR each time, while the
+  connection could never recover on its own.
+
+  The auth-loss detector observes both signals (token-store misses and wire
+  401s) and, after three consecutive failures, evicts the pooled connection —
+  closing it stops the listener — logs the transition once at WARN, and syncs
+  the service state to auth_required so the connection-state alerts still
+  fire. The listener-driven signal is covered by the Go test
+  TestDynamicAuthClient_AuthLossStopsListener (the harness's SSE stream never
+  breaks, so listener re-GETs cannot be provoked here); this scenario drives
+  the same detector through failing tool calls and validates the state
+  machine end to end:
+  1. An authenticated session connection works (tool call succeeds).
+  2. After the OAuth server revokes all tokens, tool calls fail with 401;
+     after the third consecutive failure the pooled connection is evicted
+     and the service state flips to auth_required.
+  3. Auth Required is terminal until a human acts: further tool calls fail
+     with authentication guidance instead of hanging on a broken client.
+  4. Re-authenticating (the human act) restores the connection and the
+     Connected state.
+tags: ["oauth", "auth-required", "token-loss", "eviction", "regression"]
+timeout: "3m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "token-loss-idp"
+      scopes: ["openid", "profile", "api:access"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "token-loss-client"
+
+  mcp_servers:
+    - name: "token-loss-server"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "token-loss-idp"
+          scope: "api:access"
+        tools:
+          - name: "get_protected_data"
+            description: "Returns protected data that requires valid authentication"
+            responses:
+              - response:
+                  status: "success"
+                  message: "You have access to protected data"
+
+steps:
+  # Phase 1: Establish an authenticated session connection.
+  - id: authenticate
+    description: "Complete OAuth flow to store a token for the protected server"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "token-loss-server"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: establish-connection
+    description: "Establish the session connection (pools a DynamicAuthClient)"
+    tool: "core_auth_login"
+    args:
+      server: "token-loss-server"
+    expected:
+      success: true
+
+  - id: call-tool-while-authenticated
+    description: "Protected tool call succeeds while the grant is valid"
+    tool: "x_token-loss-server_get_protected_data"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "You have access to protected data"
+
+  - id: verify-connected-state
+    description: "Service state reflects the authenticated connection"
+    tool: "core_service_status"
+    args:
+      name: "token-loss-server"
+    expected:
+      success: true
+      wait_for_state: "15s"
+      json_path:
+        name: "token-loss-server"
+        state: "connected"
+
+  # Phase 2: The grant disappears server-side (the incident shape: muster
+  # still holds the token, the server no longer accepts it).
+  - id: revoke-tokens
+    description: "Revoke all tokens on the OAuth server while muster still holds one"
+    tool: "test_revoke_token"
+    args:
+      server: "token-loss-idp"
+    expected:
+      success: true
+      contains:
+        - "Revoked"
+
+  # Three consecutive wire 401s trip the auth-loss detector. Each call fails
+  # (the pooled client's token is rejected); the third one fires the handler,
+  # which evicts the pooled connection and syncs the state.
+  - id: failing-call-1
+    description: "First tool call after revocation fails with 401"
+    tool: "x_token-loss-server_get_protected_data"
+    args: {}
+    expected:
+      success: false
+
+  - id: failing-call-2
+    description: "Second consecutive failure"
+    tool: "x_token-loss-server_get_protected_data"
+    args: {}
+    expected:
+      success: false
+
+  - id: failing-call-3
+    description: "Third consecutive failure crosses the auth-loss threshold"
+    tool: "x_token-loss-server_get_protected_data"
+    args: {}
+    expected:
+      success: false
+
+  - id: state-flips-to-auth-required
+    description: "The pooled connection is evicted and the state syncs to auth_required (terminal until a human re-authenticates)"
+    tool: "core_service_status"
+    args:
+      name: "token-loss-server"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        name: "token-loss-server"
+        state: "auth_required"
+
+  - id: tool-call-fails-with-auth-guidance
+    description: "A tool call in the terminal state fails with authentication guidance"
+    tool: "x_token-loss-server_get_protected_data"
+    args: {}
+    expected:
+      success: false
+      error_contains:
+        - "auth"
+
+  # Phase 3: The human acts — re-authentication restores the connection.
+  - id: re-authenticate
+    description: "Complete a fresh OAuth flow (the human act that ends the terminal state)"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "token-loss-server"
+    expected:
+      success: true
+      contains:
+        - "success"
+
+  - id: reconnect
+    description: "Re-establish the session connection with the new grant"
+    tool: "core_auth_login"
+    args:
+      server: "token-loss-server"
+    expected:
+      success: true
+
+  - id: call-tool-after-reauth
+    description: "Protected tool call succeeds again after re-authentication"
+    tool: "x_token-loss-server_get_protected_data"
+    args: {}
+    expected:
+      success: true
+      contains:
+        - "You have access to protected data"
+
+  - id: state-back-to-connected
+    description: "Service state reflects the restored connection"
+    tool: "core_service_status"
+    args:
+      name: "token-loss-server"
+    expected:
+      success: true
+      wait_for_state: "15s"
+      json_path:
+        name: "token-loss-server"
+        state: "connected"


### PR DESCRIPTION
## What

Makes **Auth Required terminal until a human acts** for session-scoped OAuth (`DynamicAuthClient`) connections. When a connection's grant disappears — the valkey-backed token store lost the token, or the server starts rejecting the held token with 401 — muster now retires the connection instead of letting mcp-go's continuous listener retry its SSE GET once per second forever.

## Why

Observed on gazelle 2026-08-26 with `gazelle-mcp-pro`: the valkey store restarted with an RDB snapshot predating the grant, and muster sustained 7–18 context-free ERROR lines/min (`failed to listen to server. retry in 1 second`, err variants `401 invalid_token "Token validation failed"` and `failed to handle SSE response: unexpected nil response`) while the server sat in Auth Required — a state only a human re-authorizing can end.

The token-forwarding and token-exchange paths already solve exactly this with `onStaleToken` eviction. The plain-OAuth (`DynamicAuthClient` + `MusterTokenStore`) path was the gap: a broken pooled client stayed in the `SessionConnectionPool` with its listener hot-looping, and every tool call kept reusing it.

## How

- **`authLossDetector`** (`internal/mcpserver/auth_loss.go`) watches both places a lost grant becomes visible — the token store (`transport.ErrNoToken`) and the HTTP transport (wire 401s) — and fires once after 3 consecutive failures. mcp-go consults the token store before every request (listener GETs included), and the transport observer sees every response, so both loss shapes are caught with no tool call in flight.
- **`makeSessionAuthLossHandler`** (aggregator) is wired into both `DynamicAuthClient` creation sites. On auth loss it logs **once at WARN**, evicts the pooled client (closing it stops the listener), revokes the session's authenticated mark, and — when that was the server's last live session connection — syncs the service state to **Auth Required** and emits the `MCPServerAuthRequired` CRD event, so `kubectl get mcpserver`, the state metric, and the connection-state alerts (giantswarm/agent-platform#231) stay accurate. `notifyMCPServerConnected` is the exact counterpart on the way up.

Two adjacent bugs surfaced by the behavioral scenario, both fixed:

- **`core_auth_login` dead-ended after auth loss.** The session's authenticated mark was never cleared, so it answered *"Server X is already authenticated"* — the human could not re-authenticate. Eviction now revokes the mark.
- **A stored-but-revoked token dead-ended with "Please try again".** `CheckForAuthRequiredError` dropped the typed transport error, so `is401Error` could not see a 401 through an `AuthRequiredError` and `core_auth_login` never cleared the stale token to issue a fresh challenge. `AuthRequiredError` now keeps `transport.ErrUnauthorized` in its wrap chain. *(This is the dead end a human re-authorizing gazelle-mcp-pro would have hit.)*

Logging noise fix: mcp-go streamable transports now log through muster's logger with the server URL attached and levels capped at WARN (`transport.WithHTTPLogger`). The transport's retry noise was ERROR with no way to tell which server produced it; conditions worth alerting on are logged by muster at the state transition.

## Testing

- New behavioral scenario `oauth-token-loss-terminal-auth-required`: connected → tokens revoked server-side → three 401s trip the detector → state `auth_required` (terminal, with auth guidance on tool calls) → human re-auth → connected again. Run locally with a fresh build: ✅
- `TestDynamicAuthClient_AuthLossStopsListener`: end-to-end against a real streamable server that starts 401ing — handler fires from the listener's 401s alone, and closing the client provably stops the retry loop (request count stays flat).
- Unit tests for the detector (threshold, reset-on-success, fire-once, nil-safety) and both observers.
- Full local suite: 197/197 scenarios ✅, `go test ./...` ✅ (pre-existing `internal/agent/oauth` port-3000 collision on my machine excepted), pre-commit ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)