### PR TITLE
fix(app): close a channel instead of racing on a bool when the aggregator fails at startup

### DIFF
--- a/internal/app/modes.go
+++ b/internal/app/modes.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/giantswarm/muster/internal/orchestrator"
 	serv "github.com/giantswarm/muster/internal/services"
 
 	"github.com/giantswarm/muster/pkg/logging"
@@ -36,19 +37,8 @@ import (
 func runOrchestrator(ctx context.Context, services *Services) error {
 	logging.Info("CLI", "--- Setting up orchestrator for service management ---")
 
-	aggregatorFailed := false
 	sigChan := make(chan os.Signal, 1)
-	changeChan := services.Orchestrator.SubscribeToStateChanges()
-	go func() {
-		for change := range changeChan {
-			if change.Name == "mcp-aggregator" && serv.ServiceState(change.NewState) == serv.StateFailed {
-				logging.Info("CLI", "MCP Aggregator failed: %v", change)
-				aggregatorFailed = true
-				sigChan <- nil
-				break
-			}
-		}
-	}()
+	aggregatorFailed := watchAggregatorFailure(services.Orchestrator.SubscribeToStateChanges())
 
 	// IMPORTANT: Startup order matters for capturing all state change events.
 	//
@@ -94,9 +84,11 @@ func runOrchestrator(ctx context.Context, services *Services) error {
 	logging.Info("CLI", "Services started. Press Ctrl+C to stop all services and exit.")
 
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	if !aggregatorFailed {
-		// Wait for interrupt signal or later service startup failure to gracefully shutdown
-		<-sigChan
+	// Wait for an interrupt signal or an aggregator failure (which may already
+	// have happened during startup) to gracefully shutdown.
+	select {
+	case <-sigChan:
+	case <-aggregatorFailed:
 	}
 
 	// Graceful shutdown sequence
@@ -119,4 +111,27 @@ func runOrchestrator(ctx context.Context, services *Services) error {
 	_ = services.Orchestrator.Stop()
 
 	return nil
+}
+
+// watchAggregatorFailure returns a channel that is closed when changeChan
+// reports the mcp-aggregator service entering the failed state.
+//
+// The failure is signalled through a closed channel rather than a shared
+// flag: the watcher runs on its own goroutine while runOrchestrator waits on
+// the main one, and a plain bool written here and read there is a data race
+// (caught by the race detector as a startup crash whenever the aggregator
+// failed to bind its port). A closed channel also wakes the waiter regardless
+// of whether the failure lands before or after the wait starts.
+func watchAggregatorFailure(changeChan <-chan orchestrator.ServiceStateChangedEvent) <-chan struct{} {
+	failed := make(chan struct{})
+	go func() {
+		for change := range changeChan {
+			if change.Name == "mcp-aggregator" && serv.ServiceState(change.NewState) == serv.StateFailed {
+				logging.Info("CLI", "MCP Aggregator failed: %v", change)
+				close(failed)
+				return
+			}
+		}
+	}()
+	return failed
 }

--- a/internal/app/modes_test.go
+++ b/internal/app/modes_test.go
@@ -2,8 +2,11 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	"github.com/giantswarm/muster/internal/config"
+	"github.com/giantswarm/muster/internal/orchestrator"
+	serv "github.com/giantswarm/muster/internal/services"
 )
 
 func TestConfigValidation(t *testing.T) {
@@ -71,5 +74,48 @@ func TestConfigDefaults(t *testing.T) {
 	// Verify the config structure is valid
 	if cfg.MusterConfig == nil {
 		t.Error("MusterConfig should not be nil")
+	}
+}
+
+// TestWatchAggregatorFailure_SignalsOnAggregatorFailed verifies that the
+// returned channel closes when the aggregator enters the failed state —
+// including when the failure event lands before anyone waits on the channel,
+// which is the startup-crash ordering (aggregator port already bound) that
+// used to race on a shared bool.
+func TestWatchAggregatorFailure_SignalsOnAggregatorFailed(t *testing.T) {
+	changeChan := make(chan orchestrator.ServiceStateChangedEvent, 4)
+	failed := watchAggregatorFailure(changeChan)
+
+	// Unrelated events must not signal.
+	changeChan <- orchestrator.ServiceStateChangedEvent{Name: "some-service", NewState: string(serv.StateFailed)}
+	changeChan <- orchestrator.ServiceStateChangedEvent{Name: "mcp-aggregator", NewState: string(serv.StateRunning)}
+	select {
+	case <-failed:
+		t.Fatal("failure channel closed without an aggregator failure event")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// The aggregator failing must signal, even though the event is sent
+	// before this goroutine starts waiting.
+	changeChan <- orchestrator.ServiceStateChangedEvent{Name: "mcp-aggregator", NewState: string(serv.StateFailed)}
+	select {
+	case <-failed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("failure channel not closed after aggregator failure event")
+	}
+}
+
+// TestWatchAggregatorFailure_NoSignalOnChannelClose verifies that the watcher
+// goroutine exits quietly when the subscription channel closes without an
+// aggregator failure.
+func TestWatchAggregatorFailure_NoSignalOnChannelClose(t *testing.T) {
+	changeChan := make(chan orchestrator.ServiceStateChangedEvent)
+	failed := watchAggregatorFailure(changeChan)
+	close(changeChan)
+
+	select {
+	case <-failed:
+		t.Fatal("failure channel closed although no aggregator failure was reported")
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/internal/mcpserver/auth_loss_test.go
+++ b/internal/mcpserver/auth_loss_test.go
@@ -204,6 +204,10 @@ func TestDynamicAuthClient_AuthLossStopsListener(t *testing.T) {
 	handler := newRecordingHandler()
 	client := NewDynamicAuthClient(ts.URL, store, "scope", "client-id", "").
 		WithAuthLossHandler(handler.handle)
+	// Close is idempotent; this net runs before the deferred ts.Close above,
+	// so a failed assertion below cannot leave the listener's SSE stream open
+	// and wedge ts.Close until the package test timeout.
+	defer func() { _ = client.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -213,6 +217,14 @@ func TestDynamicAuthClient_AuthLossStopsListener(t *testing.T) {
 	// per second, so the threshold is crossed within a few seconds even with
 	// no tool call in flight.
 	revoked.Store(true)
+	// Drop connections established before the revocation. The wrapper above
+	// only 401s requests it sees, so an SSE stream that connected earlier
+	// stays healthy forever and the listener never retries — a schedule the
+	// race detector's timing hits reliably. Cutting it forces the reconnect
+	// loop into the 401 path regardless of when the first GET landed, which
+	// also mirrors the incident: a revoked session's connections do not
+	// outlive the grant.
+	ts.CloseClientConnections()
 	handler.waitFired(t, 15*time.Second)
 
 	// The production handler evicts the pooled client, which closes it.


### PR DESCRIPTION
## Problem

While running the integration suite with a `-race` build (`GORACE=halt_on_error=1`) during the #1110 investigation, `muster serve` instances crashed at startup with a data race. `runOrchestrator` shares a plain `bool` (`aggregatorFailed`) between two goroutines with no happens-before edge:

- the state-change subscription goroutine **writes** it when the aggregator enters `StateFailed` (modes.go:46), and
- the main goroutine **reads** it after `Orchestrator.Start` returns (modes.go:97).

Any aggregator startup failure — e.g. its port already bound under parallel test load — makes the race fire deterministically; with `halt_on_error=1` that kills the instance and fails the scenario.

### Not the OTel race it looked like

The race detector's "previous read" stack spliced stale frames from earlier main-goroutine execution (OTel instrument creation in `InitializeServices` → `newMCPServerStateMetrics` / `newWorkflowMetrics`, SDK metric-cache `Lookup`) *below* `cmd.runServe`, which misdirected the initial diagnosis toward concurrent OTel meter-cache access. A live stack can't have `runServe` called by `Int64ObservableGauge`; every one of the 6 captured reports raced only on the `aggregatorFailed` bool (modes.go:42/46/89/97). All OTel instrument creation is on the main goroutine and the SDK caches are mutex-guarded.

## Fixes

1. **`internal/app`**: replace the flag + `sigChan <- nil` sentinel with `watchAggregatorFailure`, which closes a channel when the aggregator fails; the shutdown wait `select`s on that channel and the signal channel. A closed channel wakes the waiter whether the failure lands before or after the wait starts, preserving the existing behavior (immediate shutdown on aggregator startup failure, graceful shutdown on SIGINT/SIGTERM).
2. **`internal/mcpserver` (surfaced by this PR's first CI run)**: `TestDynamicAuthClient_AuthLossStopsListener` hangs for the full 10-minute package timeout under `-race` — on `main` too (locally 3/3, and this PR's go-build job on go1.27.0). Under race-detector timing the listener's SSE GET connects before the test flips `revoked`, the established stream stays healthy forever, `onAuthLost` never fires, and the resulting `Fatal` skipped `client.Close`, wedging the deferred `ts.Close` on the live stream. The test now cuts pre-revocation connections (`ts.CloseClientConnections`) so the listener deterministically reconnects into the 401 path, and defers an idempotent `client.Close` so a failed assertion can't wedge teardown. Passes 3/3 under `-race` (~7.5s) after the fix.

## Verification

- **Deterministic repro (before → after):** `go build -race`, pre-bind the aggregator port, run `muster serve` with `GORACE=halt_on_error=1`. Before the fix the race fires 100% of the time (~1s into startup, 5/5 runs); after the fix, 0/5 — and the instance still shuts down promptly on the failed aggregator with exit 0.
- **Full suite:** 6 iterations of `muster test --parallel 30 --base-port 33000 --readiness-timeout 120s` against the `-race` build with `halt_on_error=1`: zero data races anywhere (instance logs + reports). 3/6 iterations 199/199; residual failures in the others are the known #1110 auth flake (fix in #1112, not in this branch) and harness timeout kills of race-slowed instances (#1101/#1105 theme).
- New regression tests: `TestWatchAggregatorFailure_SignalsOnAggregatorFailed` (covers the failure-before-wait ordering that used to race) and `TestWatchAggregatorFailure_NoSignalOnChannelClose`, both run under `-race`.
- `go test -race ./...` green.
- `golangci-lint`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)