### PR TITLE
fix(aggregator): stop a wedged downstream from hanging list_tools during registration

### DIFF
--- a/internal/aggregator/constants.go
+++ b/internal/aggregator/constants.go
@@ -5,3 +5,18 @@ import "time"
 // httpReadHeaderTimeout caps how long the HTTP servers wait for request
 // headers. Bounds Slowloris-style request-header attacks.
 const httpReadHeaderTimeout = 30 * time.Second
+
+// registerCapabilityAttemptTimeout bounds a single round of initial capability
+// queries (tools/resources/prompts) against a freshly registered downstream
+// server. Some transports can wedge on an individual request — an SSE server
+// may accept tools/list but never deliver the response event — and without a
+// bound the registration goroutine would hang forever (#1113).
+//
+// Variables rather than constants so tests can shrink them.
+var registerCapabilityAttemptTimeout = 5 * time.Second
+
+// registerCapabilityAttempts is how many bounded rounds of initial capability
+// queries are made before the server is registered with whatever was fetched.
+// A retry issues a fresh request, which recovers from per-request wedges that
+// a longer wait on the first request would not.
+var registerCapabilityAttempts = 3

--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -256,10 +256,14 @@ func (r *ServerRegistry) familyExposedName(family, toolName string) string {
 // Returns an error if the server name is already registered, client initialization
 // fails, or the server cannot be reached.
 func (r *ServerRegistry) Register(ctx context.Context, registration ServerRegistration, client MCPClient) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if _, exists := r.servers[registration.Name]; exists {
+	// Fail fast on duplicate names before touching the client, so a
+	// duplicate registration attempt does not re-initialize an
+	// already-connected client. The authoritative check happens under the
+	// write lock below.
+	r.mu.RLock()
+	_, exists := r.servers[registration.Name]
+	r.mu.RUnlock()
+	if exists {
 		return fmt.Errorf("server %s already registered", registration.Name)
 	}
 
@@ -282,10 +286,30 @@ func (r *ServerRegistry) Register(ctx context.Context, registration ServerRegist
 		RegisteredAt: time.Now(),
 	}
 
+	// Reserve the registry entry BEFORE fetching capabilities. The capability
+	// queries are network calls to the downstream server, and one wedged
+	// downstream (e.g. an SSE server that accepts tools/list but never
+	// delivers the response event) must not stall every registry reader:
+	// the list_tools meta-tool serves from this registry, so holding the
+	// write lock across the fetch hangs the whole aggregator (#1113). The
+	// reserved entry is visible with an empty capability set until the fetch
+	// lands; subscribers are notified once it does. Reserving — rather than
+	// inserting after the fetch — keeps the entry deregisterable while the
+	// fetch is in flight, so a server that goes unhealthy mid-registration
+	// is not left behind as a stale entry blocking re-registration.
+	r.mu.Lock()
+	if _, exists := r.servers[registration.Name]; exists {
+		r.mu.Unlock()
+		return fmt.Errorf("server %s already registered", registration.Name)
+	}
 	r.applyServerRegistrationLocked(registration.Name, registration.ToolPrefix, registration.Family)
+	r.servers[registration.Name] = info
+	r.mu.Unlock()
 
-	// Fetch initial capabilities from the server
-	if err := r.refreshServerCapabilities(ctx, info); err != nil {
+	// Fetch initial capabilities from the server, without holding the
+	// registry lock and bounded so a wedged downstream cannot pin this
+	// goroutine forever either.
+	if err := r.fetchInitialCapabilities(ctx, info); err != nil {
 		logging.Warn("Aggregator", "Failed to get initial capabilities for %s: %v", registration.Name, err)
 		// Log diagnostic information about partial success
 		info.mu.RLock()
@@ -299,11 +323,50 @@ func (r *ServerRegistry) Register(ctx context.Context, registration ServerRegist
 		info.mu.RUnlock()
 	}
 
-	r.servers[registration.Name] = info
+	// The entry may have been deregistered (server went unhealthy) or
+	// replaced (pending-auth upsert) while the fetch ran; its client is then
+	// already closed or orphaned. Report that instead of pretending the
+	// registration held.
+	r.mu.Lock()
+	if current, exists := r.servers[registration.Name]; !exists || current != info {
+		r.mu.Unlock()
+		return fmt.Errorf("server %s was deregistered or replaced during registration", registration.Name)
+	}
 	r.notifyUpdate()
+	r.mu.Unlock()
 
 	logging.Info("Aggregator", "Registered MCP server: %s", registration.Name)
 	return nil
+}
+
+// fetchInitialCapabilities runs the initial capability fetch for a freshly
+// reserved registry entry. Each round is bounded by
+// registerCapabilityAttemptTimeout and retried up to
+// registerCapabilityAttempts times: a retry issues fresh requests, which
+// recovers from transports that wedge on an individual request (the SSE
+// stream losing a single response event, for instance). Returns the last
+// error when every round failed; the caller registers the server with
+// whatever was fetched either way.
+func (r *ServerRegistry) fetchInitialCapabilities(ctx context.Context, info *ServerInfo) error {
+	var lastErr error
+	for attempt := 0; attempt < registerCapabilityAttempts; attempt++ {
+		if ctx.Err() != nil {
+			if lastErr == nil {
+				lastErr = ctx.Err()
+			}
+			return lastErr
+		}
+		attemptCtx, cancel := context.WithTimeout(ctx, registerCapabilityAttemptTimeout)
+		err := r.refreshServerCapabilities(attemptCtx, info)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		logging.Debug("Aggregator", "Capability fetch attempt %d/%d for %s failed: %v",
+			attempt+1, registerCapabilityAttempts, info.Name, err)
+	}
+	return lastErr
 }
 
 // Deregister removes an MCP server from the registry and cleans up its resources.
@@ -332,22 +395,17 @@ func (r *ServerRegistry) Deregister(name string) error {
 // process restarts.
 func (r *ServerRegistry) DeregisterRequestedAt(name string, requestedAt time.Time) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 
 	info, exists := r.servers[name]
 	if !exists {
+		r.mu.Unlock()
 		return fmt.Errorf("server %s not found", name)
 	}
 
 	if info.RegisteredAt.After(requestedAt) {
+		r.mu.Unlock()
 		logging.Info("Aggregator", "Skipping deregistration of %s: entry was re-registered after the deregistration was requested", name)
 		return nil
-	}
-
-	if info.Client != nil {
-		if err := info.Client.Close(); err != nil {
-			logging.Warn("Aggregator", "Error closing client for %s: %v", name, err)
-		}
 	}
 
 	delete(r.servers, name)
@@ -378,6 +436,19 @@ func (r *ServerRegistry) DeregisterRequestedAt(name string, requestedAt time.Tim
 	r.nameMu.Unlock()
 
 	r.notifyUpdate()
+	r.mu.Unlock()
+
+	// Close the client outside the registry lock: closing a wedged transport
+	// can block, and no registry reader should stall behind it (#1113). The
+	// entry is already gone from the map, so nothing new can reach the client
+	// through the registry. Closing also aborts an in-flight initial
+	// capability fetch for this entry, which then notices the eviction and
+	// reports the registration as failed.
+	if info.Client != nil {
+		if err := info.Client.Close(); err != nil {
+			logging.Warn("Aggregator", "Error closing client for %s: %v", name, err)
+		}
+	}
 
 	logging.Info("Aggregator", "Deregistered MCP server: %s", name)
 	return nil

--- a/internal/aggregator/registry_test.go
+++ b/internal/aggregator/registry_test.go
@@ -2,8 +2,10 @@ package aggregator
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -801,4 +803,159 @@ func TestServerRegistry_ResolveResourceName(t *testing.T) {
 		assert.Equal(t, []string{"boardsA", "boardsB"}, registry.GetResourceServerNames("board://schema"))
 		assert.Nil(t, registry.GetResourceServerNames("board://missing"))
 	})
+}
+
+// wedgedMCPClient simulates a downstream transport that accepts capability
+// requests but never answers them — the SSE failure mode behind #1113, where
+// a tools/list request is accepted but its response event is never delivered.
+// A ListTools call blocks until the request context is cancelled or the
+// client is closed.
+type wedgedMCPClient struct {
+	mockMCPClient
+	listToolsCalled chan struct{} // closed when ListTools is first entered
+	calledOnce      sync.Once
+	closed          chan struct{} // closed by Close, aborting in-flight calls
+	closeOnce       sync.Once
+}
+
+func newWedgedMCPClient() *wedgedMCPClient {
+	return &wedgedMCPClient{
+		listToolsCalled: make(chan struct{}),
+		closed:          make(chan struct{}),
+	}
+}
+
+func (w *wedgedMCPClient) ListTools(ctx context.Context) ([]mcp.Tool, error) {
+	w.calledOnce.Do(func() { close(w.listToolsCalled) })
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-w.closed:
+		return nil, errors.New("client closed")
+	}
+}
+
+func (w *wedgedMCPClient) Close() error {
+	w.closeOnce.Do(func() { close(w.closed) })
+	return nil
+}
+
+// TestServerRegistry_ReadersNotBlockedByWedgedRegistration is the regression
+// test for #1113: Register used to hold the registry write lock across the
+// downstream capability queries, so one wedged downstream blocked every
+// registry reader — including the list_tools meta-tool, which hung the whole
+// aggregator for as long as the downstream stayed silent.
+func TestServerRegistry_ReadersNotBlockedByWedgedRegistration(t *testing.T) {
+	registry := NewServerRegistry("x")
+
+	healthy := &mockMCPClient{tools: []mcp.Tool{{Name: "ping"}}}
+	require.NoError(t, registry.Register(context.Background(),
+		ServerRegistration{Name: "healthy", ToolPrefix: "healthy"}, healthy))
+
+	wedged := newWedgedMCPClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registerDone := make(chan error, 1)
+	go func() {
+		registerDone <- registry.Register(ctx,
+			ServerRegistration{Name: "wedged", ToolPrefix: "wedged"}, wedged)
+	}()
+
+	select {
+	case <-wedged.listToolsCalled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("registration never reached the capability fetch")
+	}
+
+	// list_tools serves from this read path; it must answer while the fetch
+	// against the wedged downstream is still in flight.
+	got := make(chan []mcp.Tool, 1)
+	go func() { got <- registry.GetAllTools() }()
+
+	select {
+	case tools := <-got:
+		names := make([]string, 0, len(tools))
+		for _, tool := range tools {
+			names = append(names, tool.Name)
+		}
+		require.Contains(t, names, "x_healthy_ping")
+	case <-time.After(10 * time.Second):
+		t.Fatal("GetAllTools blocked behind a wedged capability fetch (#1113 regression)")
+	}
+
+	// Unblock the fetch and make sure the registration completes: the server
+	// stays registered with an empty capability set rather than failing.
+	cancel()
+	select {
+	case err := <-registerDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("registration did not finish after the fetch was cancelled")
+	}
+
+	info, exists := registry.GetServerInfo("wedged")
+	require.True(t, exists)
+	info.mu.RLock()
+	defer info.mu.RUnlock()
+	require.Empty(t, info.Tools)
+}
+
+// TestServerRegistry_RegisterBoundedOnWedgedDownstream verifies that the
+// initial capability fetch is bounded: a downstream that never answers must
+// not pin the registration goroutine forever. The server is registered with
+// an empty capability set once the bounded attempts are exhausted.
+func TestServerRegistry_RegisterBoundedOnWedgedDownstream(t *testing.T) {
+	oldTimeout, oldAttempts := registerCapabilityAttemptTimeout, registerCapabilityAttempts
+	registerCapabilityAttemptTimeout = 25 * time.Millisecond
+	registerCapabilityAttempts = 2
+	t.Cleanup(func() {
+		registerCapabilityAttemptTimeout, registerCapabilityAttempts = oldTimeout, oldAttempts
+	})
+
+	registry := NewServerRegistry("x")
+	wedged := newWedgedMCPClient()
+
+	require.NoError(t, registry.Register(context.Background(),
+		ServerRegistration{Name: "wedged", ToolPrefix: "wedged"}, wedged))
+
+	info, exists := registry.GetServerInfo("wedged")
+	require.True(t, exists)
+	info.mu.RLock()
+	defer info.mu.RUnlock()
+	require.Empty(t, info.Tools)
+}
+
+// TestServerRegistry_DeregisterDuringCapabilityFetch verifies that a server
+// going unhealthy while its registration is still fetching capabilities is
+// deregistered cleanly: the eviction closes the client (aborting the fetch),
+// the in-flight registration reports failure, and the entry is not
+// resurrected — so a later re-registration is not blocked by a stale entry.
+func TestServerRegistry_DeregisterDuringCapabilityFetch(t *testing.T) {
+	registry := NewServerRegistry("x")
+	wedged := newWedgedMCPClient()
+
+	registerDone := make(chan error, 1)
+	go func() {
+		registerDone <- registry.Register(context.Background(),
+			ServerRegistration{Name: "flapper", ToolPrefix: "flapper"}, wedged)
+	}()
+
+	select {
+	case <-wedged.listToolsCalled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("registration never reached the capability fetch")
+	}
+
+	require.NoError(t, registry.Deregister("flapper"))
+
+	select {
+	case err := <-registerDone:
+		require.ErrorContains(t, err, "deregistered")
+	case <-time.After(10 * time.Second):
+		t.Fatal("registration did not finish after the client was closed")
+	}
+
+	_, exists := registry.GetServerInfo("flapper")
+	require.False(t, exists, "a deregistered server must not be resurrected by an in-flight registration")
 }


### PR DESCRIPTION
## Problem

`mcpserver-detect-transport` fails instance readiness intermittently in CI (#1113): the instance is healthy and receives the readiness check's `list_tools` call, logs "Executing tool list_tools", and then never answers until the 15s readiness budget is gone.

## Mechanism

`ServerRegistry.Register` held the registry **write lock** across the downstream capability queries (`tools/list`, `resources/list`, `prompts/list`). The SSE transport can wedge on an individual request — the request is accepted but the response event is never delivered — so the registration goroutine kept the write lock held indefinitely. Every registry reader then blocked on `RLock`, including `GetAllToolsForSession` behind the `list_tools` meta-tool. The rest of the process (reconciler, HTTP serving) kept working, which matches the CI evidence exactly: zero WARN/ERROR, normal reconciler logs, and a `list_tools` call that is accepted but never answered.

## Fix

- `Register` now **reserves** the registry entry first, fetches initial capabilities **without holding the lock**, and finalizes under the lock only if the entry was not deregistered or replaced meanwhile. Reserving (rather than inserting after the fetch) keeps the entry deregisterable mid-fetch, so a server that flaps during registration is not left behind as a stale entry blocking re-registration.
- The initial capability fetch is **bounded** (5s per attempt, 3 attempts). A retry issues fresh requests, which recovers from per-request SSE wedges within the harness's 15s readiness budget; a permanently silent downstream registers with an empty capability set instead of pinning the goroutine forever.
- `DeregisterRequestedAt` now closes the client **after** releasing the registry lock — closing a wedged transport must not stall readers either. Closing also aborts an in-flight capability fetch for the evicted entry.

## Testing

- `TestServerRegistry_ReadersNotBlockedByWedgedRegistration` proves the mechanism: it fails in 10s against the old code ("GetAllTools blocked behind a wedged capability fetch") and passes with the fix.
- `TestServerRegistry_RegisterBoundedOnWedgedDownstream` and `TestServerRegistry_DeregisterDuringCapabilityFetch` cover the bounded fetch and the deregister-mid-fetch race.
- `go test -race ./...` green; `mcpserver-detect-transport` passed 30/30 under CPU contention (`systemd-run --user --scope -p CPUQuota=200% env GOMAXPROCS=32`); full BDD suite 199/199; `golangci-lint` 0 issues.

Fixes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)