### PR TITLE
feat(observability): per-server tool dispatch metrics and a shipped Grafana dashboard

### DIFF
--- a/docs/explanation/observability.md
+++ b/docs/explanation/observability.md
@@ -107,8 +107,38 @@ The aggregator emits two instruments:
 
 Both instruments are recorded by the meta-tool layer middleware — they
 attribute to the meta-tool name (`call_tool`, `list_tools`, …), not
-the underlying workload tool. Per-real-tool metrics would require a
-second recording site at `CallToolInternal`; not wired today.
+the underlying workload tool.
+
+### Downstream dispatch metrics
+
+The dispatch layer (`CallToolInternal` → `dispatchResolvedTool` and the
+session-capability path) records a second pair of instruments once the
+`(server, tool)` pair is resolved — this is where meta-tool wrapping is
+unwrapped, so a `call_tool` invocation is attributed to the real tool
+and the backend server it went to:
+
+| OTel name                              | Type                  | Attributes                          | Prometheus export name                          |
+|----------------------------------------|-----------------------|-------------------------------------|--------------------------------------------------|
+| `muster.downstream_tool_calls`         | `Int64Counter`        | `mcpserver.name`, `tool`, `outcome` | `muster_downstream_tool_calls_total`             |
+| `muster.downstream_tool_call.duration` | `Float64Histogram`/s  | `mcpserver.name`, `tool`, `outcome` | `muster_downstream_tool_call_duration_seconds`   |
+
+`tool` carries the aggregator-exposed name (`x_<server>_<tool>` or the
+family name) so the label matches what `list_tools` shows. The server
+attribute is `mcpserver.name` — the same key the reconciler's
+`muster_mcpserver_state` uses, so fleet state and usage join on
+`mcpserver_name`. Core tools (`core_*`, `workflow_*`) are handled
+internally, never dispatched, and therefore only appear in the
+boundary metrics above.
+
+### Grafana dashboard
+
+The chart ships a ready-made dashboard built on these metrics
+(`helm/muster/dashboards/muster.json`, uid `muster`): MCP server fleet
+state, per-server/per-tool usage and latency, aggregator boundary
+traffic, and workflow executions. Enable it with
+`muster.observability.grafanaDashboard.enabled: true`; on Giant Swarm
+clusters additionally set `grafanaDashboard.giantswarm.enabled: true`
+to have the observability platform pick it up.
 
 ### Workflow execution metrics
 
@@ -157,6 +187,13 @@ The line carries the final post-handler outcome the client sees.
 
 ```
 sum by (tool, outcome) (rate(muster_tool_calls_total[5m]))
+```
+
+### Mimir — usage per backend server and real tool
+
+```
+sum by (mcpserver_name) (rate(muster_downstream_tool_calls_total[5m]))
+topk(10, sum by (tool) (increase(muster_downstream_tool_calls_total[24h])))
 ```
 
 ### Mimir — p95 tool latency

--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -152,6 +152,13 @@ A Helm chart for muster - Universal Control Plane for AI Agents built on MCP
 | muster.observability.metrics.prometheus.serviceMonitor.labels | object | `{}` |  |
 | muster.observability.metrics.prometheus.prometheusRule.enabled | bool | `false` |  |
 | muster.observability.metrics.prometheus.prometheusRule.labels | object | `{}` |  |
+| muster.observability.grafanaDashboard.enabled | bool | `false` |  |
+| muster.observability.grafanaDashboard.namespace | string | `""` |  |
+| muster.observability.grafanaDashboard.folder | string | `"muster"` |  |
+| muster.observability.grafanaDashboard.giantswarm.enabled | bool | `false` |  |
+| muster.observability.grafanaDashboard.giantswarm.organization | string | `"Giant Swarm"` |  |
+| muster.observability.grafanaDashboard.labels | object | `{}` |  |
+| muster.observability.grafanaDashboard.annotations | object | `{}` |  |
 | crds.install | bool | `false` |  |
 | crds.annotations."helm.sh/resource-policy" | string | `"keep"` |  |
 | networkPolicy.enabled | bool | `false` |  |

--- a/helm/muster/dashboards/muster.json
+++ b/helm/muster/dashboards/muster.json
@@ -1,0 +1,1638 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Muster MCP gateway: MCP server fleet state, aggregator tool-call usage and latency, and workflow executions.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "MCP server fleet",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(max by (mcpserver_name, mcpserver_namespace) (muster_mcpserver_state{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}))",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "MCP servers",
+      "type": "stat",
+      "description": "MCP server definitions muster currently reconciles."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(max by (mcpserver_name, mcpserver_namespace) (muster_mcpserver_state{state=\"Connected\", cluster_id=~\"$cluster\", namespace=~\"$namespace\"})) or vector(0)",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Connected",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(max by (mcpserver_name, mcpserver_namespace) (muster_mcpserver_state{state=\"Auth Required\", cluster_id=~\"$cluster\", namespace=~\"$namespace\"})) or vector(0)",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Auth required",
+      "type": "stat",
+      "description": "Servers waiting for a user to complete an OAuth login."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(max by (mcpserver_name, mcpserver_namespace) (muster_mcpserver_state{state=\"Failed\", cluster_id=~\"$cluster\", namespace=~\"$namespace\"})) or vector(0)",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Failed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Running"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Auth Required"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disconnected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Starting"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (state) (muster_mcpserver_state{cluster_id=~\"$cluster\", namespace=~\"$namespace\"})",
+          "refId": "A",
+          "legendFormat": "{{state}}"
+        }
+      ],
+      "title": "Servers by state",
+      "type": "timeseries",
+      "description": "Number of MCP servers in each connection state over time."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Running"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Auth Required"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Disconnected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Starting"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (state) (increase(muster_mcpserver_state_transitions_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "→ {{state}}"
+        }
+      ],
+      "title": "State transitions",
+      "type": "timeseries",
+      "description": "State transitions per interval, labeled by the state entered. Frequent transitions into Failed indicate a flapping server (see the MusterMCPServerFlapping alert)."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 8,
+      "panels": [],
+      "title": "MCP usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(muster_downstream_tool_calls_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range])) or vector(0)",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Dispatched tool calls",
+      "type": "stat",
+      "description": "Tool calls dispatched to downstream MCP servers in the selected time range. Meta-tool wrapping (call_tool) is unwrapped: each call is attributed to the resolved tool and server."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(increase(muster_downstream_tool_calls_total{outcome!=\"ok\", cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range])) or vector(0)) / sum(increase(muster_downstream_tool_calls_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range]))",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Error ratio",
+      "type": "stat",
+      "description": "Share of dispatched calls that ended in a protocol error or an error result over the selected time range."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(muster_downstream_tool_call_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range])))",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "p95 dispatch latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(sum by (tool) (increase(muster_downstream_tool_calls_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range])) > 0) or vector(0)",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Distinct tools used",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (mcpserver_name) (rate(muster_downstream_tool_calls_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{mcpserver_name}}"
+        }
+      ],
+      "title": "Call rate by MCP server",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (mcpserver_name, le) (rate(muster_downstream_tool_call_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "{{mcpserver_name}}"
+        }
+      ],
+      "title": "p95 latency by MCP server",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 15,
+      "options": {
+        "displayMode": "basic",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "top",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (tool) (increase(muster_downstream_tool_calls_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range])))",
+          "refId": "A",
+          "legendFormat": "{{tool}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Top 10 tools",
+      "type": "bargauge",
+      "description": "Most-called tools in the selected time range."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 16,
+      "options": {
+        "displayMode": "basic",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "top",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (tool) (increase(muster_downstream_tool_calls_total{outcome!=\"ok\", cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range])))",
+          "refId": "A",
+          "legendFormat": "{{tool}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Top 10 tools by errors",
+      "type": "bargauge",
+      "description": "Tools with the most failed calls in the selected time range."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 17,
+      "panels": [],
+      "title": "Aggregator boundary",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "cps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ok"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error_result"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (outcome) (rate(muster_tool_calls_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "title": "Tool call rate by outcome",
+      "type": "timeseries",
+      "description": "Everything clients invoke at the aggregator boundary, including the call_tool/filter_tools meta-tools and core_* management tools. ok: handler succeeded. error: MCP protocol error. error_result: handler returned a result with isError=true."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(muster_tool_call_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(muster_tool_call_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(muster_tool_call_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "refId": "C",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Tool call latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Workflows",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "completed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (status) (increase(muster_workflow_executions_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "title": "Workflow executions by status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (workflow, le) (rate(muster_workflow_execution_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "{{workflow}}"
+        }
+      ],
+      "title": "Workflow duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (workflow) (increase(muster_workflow_execution_store_errors_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{workflow}}"
+        }
+      ],
+      "title": "Execution store errors",
+      "type": "timeseries",
+      "description": "Failures persisting workflow execution records. Executions still run; their history is lost."
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "owner:team-bumblebee",
+    "topic:muster",
+    "component:muster",
+    "mcp"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(muster_mcpserver_state, cluster_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(muster_mcpserver_state, cluster_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(muster_mcpserver_state{cluster_id=~\"$cluster\"}, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(muster_mcpserver_state{cluster_id=~\"$cluster\"}, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Muster / MCP Gateway",
+  "uid": "muster",
+  "version": 1,
+  "weekStart": ""
+}

--- a/helm/muster/templates/grafana-dashboard.yaml
+++ b/helm/muster/templates/grafana-dashboard.yaml
@@ -1,0 +1,27 @@
+{{- $dash := .Values.muster.observability.grafanaDashboard }}
+{{- if $dash.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "muster.fullname" . }}-grafana-dashboard
+  namespace: {{ $dash.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+    {{- if $dash.giantswarm.enabled }}
+    app.giantswarm.io/kind: dashboard
+    {{- end }}
+    {{- with $dash.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    grafana_folder: {{ $dash.folder | quote }}
+    {{- if and $dash.giantswarm.enabled $dash.giantswarm.organization }}
+    observability.giantswarm.io/organization: {{ $dash.giantswarm.organization | quote }}
+    {{- end }}
+    {{- with $dash.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  muster.json: |-
+{{ .Files.Get "dashboards/muster.json" | indent 4 }}
+{{- end }}

--- a/helm/muster/tests/grafana-dashboard_test.yaml
+++ b/helm/muster/tests/grafana-dashboard_test.yaml
@@ -1,0 +1,67 @@
+suite: Grafana dashboard template tests
+templates:
+  - templates/grafana-dashboard.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a ConfigMap with the dashboard JSON when enabled
+    set:
+      muster.observability.grafanaDashboard.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ConfigMap
+      - equal:
+          path: metadata.annotations.grafana_folder
+          value: muster
+      - matchRegex:
+          path: data["muster.json"]
+          pattern: '"uid": "muster"'
+      - matchRegex:
+          path: data["muster.json"]
+          pattern: 'muster_downstream_tool_calls_total'
+      - notExists:
+          path: metadata.labels["app.giantswarm.io/kind"]
+      - notExists:
+          path: metadata.annotations["observability.giantswarm.io/organization"]
+
+  - it: renders into the release namespace by default and honors the namespace override
+    set:
+      muster.observability.grafanaDashboard.enabled: true
+      muster.observability.grafanaDashboard.namespace: "monitoring"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+
+  - it: adds Giant Swarm discovery label and organization annotation when giantswarm.enabled
+    set:
+      muster.observability.grafanaDashboard.enabled: true
+      muster.observability.grafanaDashboard.giantswarm.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.giantswarm.io/kind"]
+          value: dashboard
+      - equal:
+          path: metadata.annotations["observability.giantswarm.io/organization"]
+          value: Giant Swarm
+
+  - it: propagates extra labels and annotations
+    set:
+      muster.observability.grafanaDashboard.enabled: true
+      muster.observability.grafanaDashboard.labels:
+        grafana_dashboard: "1"
+      muster.observability.grafanaDashboard.annotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.grafana_dashboard
+          value: "1"
+      - equal:
+          path: metadata.annotations["example.com/team"]
+          value: platform

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -430,6 +430,41 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "grafanaDashboard": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "folder": {
+                                    "type": "string"
+                                },
+                                "giantswarm": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "organization": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                },
+                                "namespace": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "metrics": {
                             "type": "object",
                             "additionalProperties": false,

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -728,6 +728,38 @@ muster:
           # to the right Prometheus instance (ruleSelector).
           labels: {}  # @schema additionalProperties: true
 
+    # Grafana dashboard ("Muster / MCP Gateway": MCP server fleet state,
+    # per-server/per-tool usage and latency, workflow executions) shipped
+    # as a ConfigMap rendered from dashboards/muster.json. Discovery is
+    # deployment-specific: the upstream Grafana sidecar needs its marker
+    # label added via labels below (e.g. grafana_dashboard: "1"); Giant
+    # Swarm's observability stack picks the ConfigMap up via
+    # giantswarm.enabled. Like prometheusRule, this is gated separately
+    # from the prometheus exporter: the dashboard only needs the metrics
+    # to reach the Grafana datasource, whether by local scrape or OTLP
+    # remote-write.
+    grafanaDashboard:
+      enabled: false
+      # Namespace for the ConfigMap. Empty renders into the release
+      # namespace.
+      namespace: ""
+      # Value of the grafana_folder annotation (upstream sidecar
+      # convention for folder placement).
+      folder: "muster"
+      # Giant Swarm observability platform discovery: adds the
+      # app.giantswarm.io/kind: dashboard label and the
+      # observability.giantswarm.io/organization annotation.
+      giantswarm:
+        enabled: false
+        # Grafana organization display name the dashboard is loaded
+        # into. Must match an existing organization's display name.
+        organization: "Giant Swarm"
+      # Extra labels applied to the ConfigMap, e.g. grafana_dashboard: "1"
+      # for the upstream Grafana sidecar.
+      labels: {}  # @schema additionalProperties: true
+      # Extra annotations applied to the ConfigMap.
+      annotations: {}  # @schema additionalProperties: true
+
 # CRD ownership. The muster application chart ships the MCPServer and Workflow
 # CustomResourceDefinitions in the Helm 3 `crds/` directory (helm/muster/crds/),
 # with `helm.sh/resource-policy: keep` baked in. Helm installs them automatically

--- a/internal/aggregator/metrics.go
+++ b/internal/aggregator/metrics.go
@@ -72,6 +72,71 @@ func passthroughMiddleware() server.ToolHandlerMiddleware {
 	return func(next server.ToolHandlerFunc) server.ToolHandlerFunc { return next }
 }
 
+// attrDownstreamServer is the attribute key for the backend server a tool
+// call was dispatched to. Exported as mcpserver_name, matching the
+// reconciler's muster_mcpserver_state metrics so the two join on the same
+// label (and sidestepping the Prometheus-Operator target-label rename a
+// bare "namespace"-style key would suffer, see mcpserver_state_metrics.go).
+const attrDownstreamServer = "mcpserver.name"
+
+// downstreamMetrics records the downstream leg of a tool call: the dispatch
+// to a backend MCP server once (server, tool) resolution has happened.
+//
+// The Metrics middleware above sits at the aggregator boundary and sees what
+// clients invoke — which for agent sessions is almost exclusively the
+// call_tool/filter_tools meta-tools, hiding the real tool behind
+// tool="call_tool". This instrument attributes each dispatched call to the
+// resolved backend server and the aggregator-exposed tool name, which is the
+// dimension per-server / per-tool usage views need.
+//
+// Exported via the Prometheus OTEL exporter these become
+// muster_downstream_tool_calls_total and
+// muster_downstream_tool_call_duration_seconds.
+type downstreamMetrics struct {
+	calls    metric.Int64Counter
+	duration metric.Float64Histogram
+}
+
+// newDownstreamMetrics creates the downstream instruments. It returns nil
+// when instrument creation fails; record is nil-safe, so the failure mode is
+// a silent no-op rather than a guard at every call site.
+func newDownstreamMetrics() *downstreamMetrics {
+	m := otel.Meter(observability.TracerName)
+	calls, err := m.Int64Counter("muster.downstream_tool_calls",
+		metric.WithDescription("Number of tool calls the muster aggregator dispatched to downstream MCP servers."),
+		metric.WithUnit("{call}"),
+	)
+	if err != nil {
+		logging.Warn("Aggregator", "create muster.downstream_tool_calls counter: %v", err)
+		return nil
+	}
+	duration, err := m.Float64Histogram("muster.downstream_tool_call.duration",
+		metric.WithDescription("Duration of tool calls the muster aggregator dispatched to downstream MCP servers."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		logging.Warn("Aggregator", "create muster.downstream_tool_call.duration histogram: %v", err)
+		return nil
+	}
+	return &downstreamMetrics{calls: calls, duration: duration}
+}
+
+// record counts one dispatched call. toolName is the aggregator-exposed name
+// (x_<server>_<tool> or the family name), not the backend-native one, so the
+// label matches what list_tools shows users.
+func (d *downstreamMetrics) record(ctx context.Context, serverName, toolName string, start time.Time, res *mcp.CallToolResult, err error) {
+	if d == nil {
+		return
+	}
+	attrs := metric.WithAttributes(
+		attribute.String(attrDownstreamServer, serverName),
+		attribute.String("tool", toolName),
+		attribute.String("outcome", classify(res, err)),
+	)
+	d.calls.Add(ctx, 1, attrs)
+	d.duration.Record(ctx, time.Since(start).Seconds(), attrs)
+}
+
 // classify maps a (result, error) pair to the outcome label used as a
 // metric attribute and a log field.
 func classify(res *mcp.CallToolResult, err error) string {

--- a/internal/aggregator/metrics_test.go
+++ b/internal/aggregator/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -95,6 +96,56 @@ func TestMetrics(t *testing.T) {
 			require.True(t, sawHistogram, "expected muster.tool_call.duration histogram")
 		})
 	}
+}
+
+func TestDownstreamMetrics(t *testing.T) {
+	reader := setupMeter(t)
+	d := newDownstreamMetrics()
+	require.NotNil(t, d)
+
+	start := time.Now()
+	d.record(context.Background(), "prometheus-backend", "x_prometheus_execute_query", start, &mcp.CallToolResult{}, nil)
+	d.record(context.Background(), "prometheus-backend", "x_prometheus_execute_query", start, nil, errors.New("boom"))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var sawCounter, sawHistogram bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "muster.downstream_tool_calls":
+				sawCounter = true
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok, "downstream_tool_calls should be a Sum")
+				require.Len(t, sum.DataPoints, 2, "one series per outcome")
+				outcomes := map[string]int64{}
+				for _, dp := range sum.DataPoints {
+					server, _ := dp.Attributes.Value(attrDownstreamServer)
+					tool, _ := dp.Attributes.Value("tool")
+					require.Equal(t, "prometheus-backend", server.AsString())
+					require.Equal(t, "x_prometheus_execute_query", tool.AsString())
+					outcome, _ := dp.Attributes.Value("outcome")
+					outcomes[outcome.AsString()] = dp.Value
+				}
+				require.Equal(t, map[string]int64{outcomeOK: 1, outcomeError: 1}, outcomes)
+			case "muster.downstream_tool_call.duration":
+				sawHistogram = true
+				hist, ok := m.Data.(metricdata.Histogram[float64])
+				require.True(t, ok, "downstream_tool_call.duration should be a Histogram[float64]")
+				require.Len(t, hist.DataPoints, 2)
+			}
+		}
+	}
+	require.True(t, sawCounter, "expected muster.downstream_tool_calls counter")
+	require.True(t, sawHistogram, "expected muster.downstream_tool_call.duration histogram")
+}
+
+func TestDownstreamMetricsNilSafe(t *testing.T) {
+	var d *downstreamMetrics
+	require.NotPanics(t, func() {
+		d.record(context.Background(), "s", "t", time.Now(), nil, nil)
+	})
 }
 
 func TestClassify(t *testing.T) {

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -538,23 +538,22 @@ func NewAggregatorServer(aggConfig AggregatorConfig, errorCallback func(error)) 
 	stores := createStores(aggConfig)
 
 	return &AggregatorServer{
-		config:          aggConfig,
-		registry:        NewServerRegistry(aggConfig.MusterPrefix),
-		toolManager:     newActiveItemManager(),
-		errorCallback:   errorCallback,
-		authRateLimiter: rateLimiter,
-		authMetrics:     NewAuthMetrics(),
-
+		config:            aggConfig,
+		registry:          NewServerRegistry(aggConfig.MusterPrefix),
+		toolManager:       newActiveItemManager(),
+		errorCallback:     errorCallback,
+		authRateLimiter:   rateLimiter,
+		authMetrics:       NewAuthMetrics(),
 		downstreamMetrics: newDownstreamMetrics(),
-		authStore:       stores.authStore,
-		capabilityStore: stores.capabilityStore,
-		connPool:        NewSessionConnectionPool(DefaultConnectionPoolMaxAge),
-		ssoTracker:      newSSOTracker(),
-		subjectSessions: newSubjectSessionTracker(),
-		eventFollows:    make(map[string]*eventFollow),
-		valkeyClient:    stores.valkeyClient,
-		valkeyKeyPrefix: stores.keyPrefix,
-		valkeyEncryptor: stores.encryptor,
+		authStore:         stores.authStore,
+		capabilityStore:   stores.capabilityStore,
+		connPool:          NewSessionConnectionPool(DefaultConnectionPoolMaxAge),
+		ssoTracker:        newSSOTracker(),
+		subjectSessions:   newSubjectSessionTracker(),
+		eventFollows:      make(map[string]*eventFollow),
+		valkeyClient:      stores.valkeyClient,
+		valkeyKeyPrefix:   stores.keyPrefix,
+		valkeyEncryptor:   stores.encryptor,
 	}
 }
 

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -114,6 +114,10 @@ type AggregatorServer struct {
 	authRateLimiter *AuthRateLimiter // Per-user rate limiting for auth operations
 	authMetrics     *AuthMetrics     // Authentication metrics for monitoring
 
+	// Per-backend tool dispatch metrics. May be nil when instrument
+	// creation failed; record() is nil-safe.
+	downstreamMetrics *downstreamMetrics
+
 	// Per-session auth store tracks which sessions have authenticated to which servers.
 	// Separated from capabilityStore so that clearing stale capabilities does not
 	// accidentally revoke authentication (see capability freshness plan).
@@ -540,6 +544,8 @@ func NewAggregatorServer(aggConfig AggregatorConfig, errorCallback func(error)) 
 		errorCallback:   errorCallback,
 		authRateLimiter: rateLimiter,
 		authMetrics:     NewAuthMetrics(),
+
+		downstreamMetrics: newDownstreamMetrics(),
 		authStore:       stores.authStore,
 		capabilityStore: stores.capabilityStore,
 		connPool:        NewSessionConnectionPool(DefaultConnectionPoolMaxAge),
@@ -1846,7 +1852,10 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 		if sessionErr == nil {
 			logging.DebugWithAttrs("Aggregator", "Tool found in capability cache",
 				slog.String("tool", toolName), slog.String("server", sessionServerName))
-			return a.callToolWithTokenExchangeRetry(ctx, sessionServerName, originalName, args, sessionID, sub)
+			start := time.Now()
+			res, err := a.callToolWithTokenExchangeRetry(ctx, sessionServerName, originalName, args, sessionID, sub)
+			a.downstreamMetrics.record(ctx, sessionServerName, toolName, start, res, err)
+			return res, err
 		}
 	}
 
@@ -1872,7 +1881,9 @@ func (a *AggregatorServer) CallToolInternal(ctx context.Context, toolName string
 // for solo tools or via ResolveToolNameForServer for family-grouped tools).
 // It encapsulates the global-client vs. session-scoped vs. token-exchange
 // branching that previously lived inline in CallToolInternal.
-func (a *AggregatorServer) dispatchResolvedTool(ctx context.Context, toolName, serverName, originalName string, args map[string]any, sessionID, sub string) (*mcp.CallToolResult, error) {
+func (a *AggregatorServer) dispatchResolvedTool(ctx context.Context, toolName, serverName, originalName string, args map[string]any, sessionID, sub string) (res *mcp.CallToolResult, err error) {
+	start := time.Now()
+	defer func() { a.downstreamMetrics.record(ctx, serverName, toolName, start, res, err) }()
 	serverInfo, exists := a.registry.GetServerInfo(serverName)
 	if !exists || serverInfo == nil {
 		return nil, fmt.Errorf("server not found: %s", serverName)

--- a/internal/testing/scenarios/downstream-tool-call-metrics.yaml
+++ b/internal/testing/scenarios/downstream-tool-call-metrics.yaml
@@ -1,0 +1,134 @@
+name: "downstream-tool-call-metrics"
+description: "Dispatched tool calls are exported per backend server and resolved tool name as Prometheus metrics"
+category: "behavioral"
+concept: "aggregator"
+tags: ["aggregator", "observability", "metrics", "tools"]
+timeout: "3m"
+
+# Test Story: MCP usage has to be attributable to real tools and servers
+#
+# Given: a backend MCP server with one healthy and one erroring tool
+# When:  the tools are called through the aggregator (the test client wraps
+#        every call in the call_tool meta-tool, exactly like agent sessions do)
+# Then:  muster_downstream_tool_calls_total exports one series per
+#        (server, tool, outcome) carrying the RESOLVED tool name — not
+#        tool="call_tool" — plus a duration histogram with the same labels
+#
+# The aggregator-boundary metric (muster_tool_calls_total) only ever sees the
+# meta-tool an agent invoked, so before this metric existed per-tool and
+# per-server usage was invisible: dashboards showed 90% "call_tool". The
+# assertions run against the process's real Prometheus endpoint
+# (test_scrape_metrics) because the exported names and labels are the
+# contract the Grafana dashboard in helm/muster/dashboards/muster.json and
+# the Backstage MCP-usage tab select on — the OTel Prometheus exporter
+# rewrites muster.downstream_tool_calls to muster_downstream_tool_calls_total
+# and mcpserver.name to mcpserver_name, and only a scrape proves it.
+
+pre_configuration:
+  mcp_servers:
+    - name: "usage-metrics-server"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "usage_probe_tool"
+            input_schema:
+              type: "object"
+              properties:
+                message: { type: "string" }
+            responses:
+              - response:
+                  message: "alive: {{ .message }}"
+          - name: "usage_boom_tool"
+            input_schema:
+              type: "object"
+              properties: {}
+            responses:
+              - error: "intentional failure for outcome labeling"
+
+steps:
+  - id: "verify-server-connected"
+    description: "Baseline: the pre-configured server reaches Connected"
+    tool: "core_service_status"
+    args:
+      name: "usage-metrics-server"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        name: "usage-metrics-server"
+        state: "connected"
+
+  - id: "call-probe-tool"
+    description: "Call the healthy tool through the aggregator (meta-wrapped via call_tool)"
+    tool: "x_usage-metrics-server_usage_probe_tool"
+    args:
+      message: "usage-attribution"
+    expected:
+      success: true
+      contains: ["alive", "usage-attribution"]
+
+  - id: "call-boom-tool"
+    description: "Call the erroring tool so a non-ok outcome series exists"
+    tool: "x_usage-metrics-server_usage_boom_tool"
+    args: {}
+    expected:
+      success: false
+
+  # The resolved-name guarantee. The test client invoked call_tool, yet the
+  # downstream series must carry the x_-prefixed resolved tool name and the
+  # backend server it was dispatched to. line_count pins the full series set:
+  # exactly one series per (tool, outcome) pair and — crucially — no
+  # tool="call_tool" series on this metric.
+  - id: "verify-ok-call-exported"
+    description: "The healthy call is exported with the resolved tool name and server label"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_downstream_tool_calls_total{"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      contains:
+        - 'muster_downstream_tool_calls_total{'
+        - 'mcpserver_name="usage-metrics-server"'
+        - 'tool="x_usage-metrics-server_usage_probe_tool"'
+        - 'outcome="ok"'
+      json_path:
+        line_count: 2
+
+  - id: "verify-error-call-exported"
+    description: "The failed call is exported with a non-ok outcome, same label scheme"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_downstream_tool_calls_total{"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      contains:
+        - 'tool="x_usage-metrics-server_usage_boom_tool"'
+        - 'outcome="error"'
+
+  - id: "verify-duration-histogram-exported"
+    description: "The dispatch duration histogram is exported with the same labels"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_downstream_tool_call_duration_seconds_bucket"
+    expected:
+      success: true
+      wait_for_state: "60s"
+      contains:
+        - 'muster_downstream_tool_call_duration_seconds_bucket{'
+        - 'mcpserver_name="usage-metrics-server"'
+        - 'tool="x_usage-metrics-server_usage_probe_tool"'
+
+  # The meta-tool layer keeps its own accounting: the aggregator-boundary
+  # metric records what the client actually invoked. Both layers together
+  # give traffic (boundary) and attribution (downstream).
+  - id: "verify-boundary-metric-still-meta"
+    description: "muster_tool_calls_total records the call_tool meta-tool invocation"
+    tool: "test_scrape_metrics"
+    args:
+      filter: "muster_tool_calls_total{"
+    expected:
+      success: true
+      contains:
+        - 'tool="call_tool"'


### PR DESCRIPTION
## What

- **New downstream dispatch metrics.** Agent sessions invoke everything through the `call_tool` meta-tool, so the existing aggregator-boundary metrics attribute most traffic to `tool="call_tool"` — per-tool and per-server usage was invisible. This records a second instrument pair at the dispatch layer (`dispatchResolvedTool` + the session-capability path), where meta-wrapping is already unwrapped:
  - `muster_downstream_tool_calls_total{mcpserver_name, tool, outcome}`
  - `muster_downstream_tool_call_duration_seconds{mcpserver_name, tool, outcome}`

  The server attribute reuses the reconciler's `mcpserver.name` key so fleet state (`muster_mcpserver_state`) and usage join on the same `mcpserver_name` label.

- **Shipped Grafana dashboard** (`helm/muster/dashboards/muster.json`, uid `muster`): MCP server fleet state, per-server/per-tool usage + latency, aggregator boundary traffic, workflow executions. Rendered as a ConfigMap behind `muster.observability.grafanaDashboard.enabled`, with optional Giant Swarm observability-platform discovery (`app.giantswarm.io/kind: dashboard` label + organization annotation). Gated independently from the local prometheus exporter, following the `prometheusRule` precedent.

## Testing

- Unit tests for the new instruments (`TestDownstreamMetrics`, nil-safety).
- Behavioral scenario `downstream-tool-call-metrics` scrapes the real `/metrics` endpoint and pins the exported names/labels — including that a meta-wrapped `call_tool` invocation is exported under the resolved tool name. Passing locally.
- helm unittest suite for the new template (5 tests); values schema regenerated via pre-commit.
- All dashboard PromQL validated against live gazelle Mimir data.

## Consumers

The Backstage "MCP usage" tab (giantswarm/backstage, in flight) and the shipped dashboard both select on these metric names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)