### PR TITLE
fix(helm): place the Grafana dashboard via the GS folder annotation

### DIFF
--- a/helm/muster/templates/grafana-dashboard.yaml
+++ b/helm/muster/templates/grafana-dashboard.yaml
@@ -15,8 +15,14 @@ metadata:
     {{- end }}
   annotations:
     grafana_folder: {{ $dash.folder | quote }}
-    {{- if and $dash.giantswarm.enabled $dash.giantswarm.organization }}
+    {{- if $dash.giantswarm.enabled }}
+    # The GS observability-operator reads its own folder key, not the
+    # upstream sidecar's grafana_folder; without it the dashboard lands in
+    # the organization's General folder.
+    observability.giantswarm.io/folder: {{ $dash.folder | quote }}
+    {{- if $dash.giantswarm.organization }}
     observability.giantswarm.io/organization: {{ $dash.giantswarm.organization | quote }}
+    {{- end }}
     {{- end }}
     {{- with $dash.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/helm/muster/tests/grafana-dashboard_test.yaml
+++ b/helm/muster/tests/grafana-dashboard_test.yaml
@@ -29,6 +29,8 @@ tests:
           path: metadata.labels["app.giantswarm.io/kind"]
       - notExists:
           path: metadata.annotations["observability.giantswarm.io/organization"]
+      - notExists:
+          path: metadata.annotations["observability.giantswarm.io/folder"]
 
   - it: renders into the release namespace by default and honors the namespace override
     set:
@@ -39,7 +41,7 @@ tests:
           path: metadata.namespace
           value: monitoring
 
-  - it: adds Giant Swarm discovery label and organization annotation when giantswarm.enabled
+  - it: adds Giant Swarm discovery label, organization and folder annotations when giantswarm.enabled
     set:
       muster.observability.grafanaDashboard.enabled: true
       muster.observability.grafanaDashboard.giantswarm.enabled: true
@@ -50,6 +52,9 @@ tests:
       - equal:
           path: metadata.annotations["observability.giantswarm.io/organization"]
           value: Giant Swarm
+      - equal:
+          path: metadata.annotations["observability.giantswarm.io/folder"]
+          value: muster
 
   - it: propagates extra labels and annotations
     set:

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -743,8 +743,11 @@ muster:
       # Namespace for the ConfigMap. Empty renders into the release
       # namespace.
       namespace: ""
-      # Value of the grafana_folder annotation (upstream sidecar
-      # convention for folder placement).
+      # Grafana folder the dashboard is placed in. Rendered as the
+      # upstream sidecar's grafana_folder annotation, and — when
+      # giantswarm.enabled — additionally as the
+      # observability.giantswarm.io/folder annotation the GS
+      # observability platform actually reads.
       folder: "muster"
       # Giant Swarm observability platform discovery: adds the
       # app.giantswarm.io/kind: dashboard label and the


### PR DESCRIPTION
Follow-up to #1116: the Giant Swarm observability-operator reads `observability.giantswarm.io/folder` (label or annotation), not the upstream Grafana sidecar's `grafana_folder` — verified in [observability-operator's dashboard mapper](https://github.com/giantswarm/observability-operator/blob/main/internal/mapper/dashboard_mapper.go) and its `docs/dashboards.md`. Without it the operator logs `folder: ""` and the dashboard lands in the organization's **General** folder, where nobody looks for it.

Now, when `grafanaDashboard.giantswarm.enabled` is set, the ConfigMap carries the GS folder annotation (same `folder` value, default `muster`) alongside the sidecar-compatible `grafana_folder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)