### PR TITLE
fix(helm): render allowPublicClientRegistration into the aggregator oauth config

### DIFF
--- a/helm/muster/templates/configmap.yaml
+++ b/helm/muster/templates/configmap.yaml
@@ -81,6 +81,9 @@ data:
           {{- if .Values.muster.oauth.server.allowLocalhostRedirectURIs }}
           allowLocalhostRedirectURIs: true
           {{- end }}
+          {{- if .Values.muster.oauth.server.allowPublicClientRegistration }}
+          allowPublicClientRegistration: true
+          {{- end }}
           {{- with .Values.muster.oauth.server.trustedPublicRegistrationRedirectURIs }}
           trustedPublicRegistrationRedirectURIs:
             {{- toYaml . | nindent 12 }}

--- a/helm/muster/tests/configmap_test.yaml
+++ b/helm/muster/tests/configmap_test.yaml
@@ -68,6 +68,31 @@ tests:
           path: data["config.yaml"]
           pattern: "trustedPublicRegistrationSchemes:"
 
+  - it: renders allowPublicClientRegistration into config.yaml when enabled
+    set:
+      muster.oauth.server.enabled: true
+      muster.oauth.server.baseUrl: "https://muster.example.com"
+      muster.oauth.server.existingSecret: "muster-oauth"
+      muster.oauth.server.dex.issuerUrl: "https://dex.example.com"
+      muster.oauth.server.dex.clientId: "muster"
+      muster.oauth.server.allowPublicClientRegistration: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "allowPublicClientRegistration: true"
+
+  - it: omits allowPublicClientRegistration when left at the default (false)
+    set:
+      muster.oauth.server.enabled: true
+      muster.oauth.server.baseUrl: "https://muster.example.com"
+      muster.oauth.server.existingSecret: "muster-oauth"
+      muster.oauth.server.dex.issuerUrl: "https://dex.example.com"
+      muster.oauth.server.dex.clientId: "muster"
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "allowPublicClientRegistration"
+
   - it: renders tokenExchangeBroker into config.yaml
     set:
       muster.oauth.server.enabled: true


### PR DESCRIPTION
## What

The chart exposes `muster.oauth.server.allowPublicClientRegistration` in `values.yaml`, `values.schema.json`, and the README, but `templates/configmap.yaml` never rendered it into the `aggregator.oauth.server` block of `config.yaml`. Every neighbouring key (`allowLocalhostRedirectURIs`, `trustedPublicRegistrationRedirectURIs`, `trustedAudiences`, …) is rendered — this one was missing, so the value set by chart consumers was silently dropped and Dynamic Client Registration stayed gated.

## How

- Render the key in `configmap.yaml`, guarded like its boolean siblings (`{{- if … }}` → `allowPublicClientRegistration: true`).
- Extend the ConfigMap helm-unittest suite: renders when enabled, omitted at the default (`false`).

## Testing

- `helm unittest helm/muster/` — 125/125 pass (12 suites), including the two new cases.
- `make helm-lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)