### PR TITLE
fix(filesystem): reject unsafe entity names to close a path-traversal hole

### DIFF
--- a/internal/api/resource_name.go
+++ b/internal/api/resource_name.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// ValidateResourceName rejects entity names that are unsafe to use as a file
+// path segment or as a field in a line-oriented log.
+//
+// The name comes straight from a caller-controlled tool argument. In
+// filesystem mode it is joined into a file path, and filepath.Join collapses
+// ".." segments, so without this a name like "../../evil" or "/etc/x" writes
+// and reads arbitrary *.yaml files outside the config directory. Control
+// characters are rejected for the same reason a separator is: a newline in a
+// name forges an extra record in the legacy events.log, which
+// parseLegacyEventLine then returns as a genuine-looking event.
+//
+// The name must therefore be a single path segment made of printable runes:
+// no path separators, no control characters, and not a "." / ".." reference.
+// Character policy beyond that (e.g. DNS-1123) is intentionally left to the
+// higher layers and to Kubernetes admission; filesystem mode accepts names
+// such as "special-chars-workflow_123" that Kubernetes would reject.
+func ValidateResourceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid name: must not be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid name %q: must not be a path reference", name)
+	}
+	// Both separators are spelled out on purpose. filepath.Separator and
+	// os.PathSeparator are the host's separator ('/' in a Linux build), so
+	// using either would let `a\b` through on Linux — and muster ships a
+	// windows/amd64 binary that reads the same config directory, where that
+	// name is a subdirectory. The check has to be platform-independent even
+	// though the code that consumes it is not.
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("invalid name %q: must not contain path separators", name)
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("invalid name %q: must not contain control characters", name)
+		}
+	}
+	// Dead on POSIX after the separator check, but it catches drive-relative
+	// names such as "C:foo" on Windows.
+	if filepath.Base(name) != name {
+		return fmt.Errorf("invalid name %q: must be a single path segment", name)
+	}
+	return nil
+}

--- a/internal/api/resource_name_test.go
+++ b/internal/api/resource_name_test.go
@@ -1,0 +1,34 @@
+package api
+
+import "testing"
+
+func TestValidateResourceName(t *testing.T) {
+	// Path-safe names are accepted, including characters (underscore, uppercase,
+	// spaces) that Kubernetes admission would reject — this validator only
+	// guards against directory escape and log injection, not DNS-1123
+	// conformance.
+	valid := []string{"foo", "foo-bar", "foo.bar", "a1b2", "x", "special-chars-workflow_123", "Foo", "foo bar", "..foo", "ünïcode"}
+	for _, name := range valid {
+		if err := ValidateResourceName(name); err != nil {
+			t.Errorf("expected %q to be valid, got: %v", name, err)
+		}
+	}
+
+	invalid := []string{
+		"", "..", ".",
+		"../evil", "a/b", "a\\b", "/etc/passwd", "foo/",
+		// Control characters: a null byte corrupts the file path, and a newline
+		// forges a record in the line-oriented legacy events.log. The bare
+		// "x\nforged" case carries no separator on purpose — it fails only if
+		// the control-character rule is doing the work, where the realistic
+		// forgery payload below would also be caught by the separator check.
+		"a\x00b", "x\nforged",
+		"x\n[2020-01-01T00:00:00Z] MCPServer default-prometheus: MCPServerDeleted - gone (Normal)",
+		"a\rb", "a\tb", "a\x1bb", "a\x7fb",
+	}
+	for _, name := range invalid {
+		if err := ValidateResourceName(name); err == nil {
+			t.Errorf("expected %q to be rejected", name)
+		}
+	}
+}

--- a/internal/client/filesystem/store.go
+++ b/internal/client/filesystem/store.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -30,19 +29,27 @@ func (m resourceMeta) dirPath(basePath string) string {
 	return filepath.Join(basePath, m.dir)
 }
 
-// validateResourceName rejects names that are not safe to turn into a file path.
-// In Kubernetes mode the API server enforces DNS-1123 on metadata.name; the
-// filesystem store is the exposed, unvalidated path, so it must enforce the same
-// constraint before joining the name into a path. DNS-1123 already forbids "/",
-// "\" and empty segments, which closes the path-traversal hole (a name like
-// "../../evil" or "/etc/x" is rejected); the explicit Base check is defense in
-// depth in case the character rule is ever loosened.
+// validateResourceName rejects names that would escape the resource directory
+// when joined into a file path. The name comes straight from a caller-controlled
+// tool argument, and filepath.Join collapses ".." segments, so without this a
+// name like "../../evil" or "/etc/x" writes and reads arbitrary *.yaml files
+// outside the config directory. The name must be a single path segment: no path
+// separators, no null byte, and not a "." / ".." reference. Character policy
+// beyond path safety (e.g. DNS-1123) is intentionally left to the higher layers
+// and to Kubernetes admission; filesystem mode accepts names such as
+// "special-chars-workflow_123" that Kubernetes would reject.
 func validateResourceName(name string) error {
-	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
-		return fmt.Errorf("invalid name %q: must be a valid DNS-1123 subdomain: %s", name, strings.Join(errs, "; "))
+	if name == "" {
+		return fmt.Errorf("invalid name: must not be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid name %q: must not be a path reference", name)
+	}
+	if strings.ContainsAny(name, `/\`+"\x00") {
+		return fmt.Errorf("invalid name %q: must not contain path separators or null bytes", name)
 	}
 	if filepath.Base(name) != name {
-		return fmt.Errorf("invalid name %q: must not contain path separators", name)
+		return fmt.Errorf("invalid name %q: must be a single path segment", name)
 	}
 	return nil
 }

--- a/internal/client/filesystem/store.go
+++ b/internal/client/filesystem/store.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -28,8 +30,28 @@ func (m resourceMeta) dirPath(basePath string) string {
 	return filepath.Join(basePath, m.dir)
 }
 
-func (m resourceMeta) filePath(basePath, name string) string {
-	return filepath.Join(basePath, m.dir, name+".yaml")
+// validateResourceName rejects names that are not safe to turn into a file path.
+// In Kubernetes mode the API server enforces DNS-1123 on metadata.name; the
+// filesystem store is the exposed, unvalidated path, so it must enforce the same
+// constraint before joining the name into a path. DNS-1123 already forbids "/",
+// "\" and empty segments, which closes the path-traversal hole (a name like
+// "../../evil" or "/etc/x" is rejected); the explicit Base check is defense in
+// depth in case the character rule is ever loosened.
+func validateResourceName(name string) error {
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+		return fmt.Errorf("invalid name %q: must be a valid DNS-1123 subdomain: %s", name, strings.Join(errs, "; "))
+	}
+	if filepath.Base(name) != name {
+		return fmt.Errorf("invalid name %q: must not contain path separators", name)
+	}
+	return nil
+}
+
+func (m resourceMeta) filePath(basePath, name string) (string, error) {
+	if err := validateResourceName(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(basePath, m.dir, name+".yaml"), nil
 }
 
 var (
@@ -46,7 +68,10 @@ var (
 // getResource reads a YAML file into obj. Caller allocates obj (matches the
 // controller-runtime client.Get convention).
 func (f *Client) getResource(name string, obj client.Object, m resourceMeta) error {
-	filePath := m.filePath(f.basePath, name)
+	filePath, err := m.filePath(f.basePath, name)
+	if err != nil {
+		return err
+	}
 
 	data, err := os.ReadFile(filePath) //nolint:gosec
 	if err != nil {
@@ -110,7 +135,10 @@ func (f *Client) writeResourceLocked(obj client.Object, m resourceMeta) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal %s %s: %w", m.gr.Resource, obj.GetName(), err)
 	}
-	filePath := m.filePath(f.basePath, obj.GetName())
+	filePath, err := m.filePath(f.basePath, obj.GetName())
+	if err != nil {
+		return err
+	}
 	if err := atomicWriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write %s file %s: %w", m.gr.Resource, filePath, err)
 	}
@@ -123,7 +151,10 @@ func (f *Client) createResource(obj client.Object, m resourceMeta) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	filePath := m.filePath(f.basePath, obj.GetName())
+	filePath, err := m.filePath(f.basePath, obj.GetName())
+	if err != nil {
+		return err
+	}
 	if _, err := os.Stat(filePath); err == nil {
 		return errors.NewAlreadyExists(m.gr, obj.GetName())
 	}
@@ -142,7 +173,10 @@ func (f *Client) updateResource(obj client.Object, m resourceMeta) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	filePath := m.filePath(f.basePath, obj.GetName())
+	filePath, err := m.filePath(f.basePath, obj.GetName())
+	if err != nil {
+		return err
+	}
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return errors.NewNotFound(m.gr, obj.GetName())
 	}
@@ -189,7 +223,10 @@ func (f *Client) deleteResource(name string, m resourceMeta) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	filePath := m.filePath(f.basePath, name)
+	filePath, err := m.filePath(f.basePath, name)
+	if err != nil {
+		return err
+	}
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return errors.NewNotFound(m.gr, name)
 	}

--- a/internal/client/filesystem/store.go
+++ b/internal/client/filesystem/store.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -15,6 +14,7 @@ import (
 
 	musterv1alpha1 "github.com/giantswarm/muster/pkg/apis/muster/v1alpha1"
 
+	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/pkg/logging"
 )
 
@@ -29,33 +29,12 @@ func (m resourceMeta) dirPath(basePath string) string {
 	return filepath.Join(basePath, m.dir)
 }
 
-// validateResourceName rejects names that would escape the resource directory
-// when joined into a file path. The name comes straight from a caller-controlled
-// tool argument, and filepath.Join collapses ".." segments, so without this a
-// name like "../../evil" or "/etc/x" writes and reads arbitrary *.yaml files
-// outside the config directory. The name must be a single path segment: no path
-// separators, no null byte, and not a "." / ".." reference. Character policy
-// beyond path safety (e.g. DNS-1123) is intentionally left to the higher layers
-// and to Kubernetes admission; filesystem mode accepts names such as
-// "special-chars-workflow_123" that Kubernetes would reject.
-func validateResourceName(name string) error {
-	if name == "" {
-		return fmt.Errorf("invalid name: must not be empty")
-	}
-	if name == "." || name == ".." {
-		return fmt.Errorf("invalid name %q: must not be a path reference", name)
-	}
-	if strings.ContainsAny(name, `/\`+"\x00") {
-		return fmt.Errorf("invalid name %q: must not contain path separators or null bytes", name)
-	}
-	if filepath.Base(name) != name {
-		return fmt.Errorf("invalid name %q: must be a single path segment", name)
-	}
-	return nil
-}
-
 func (m resourceMeta) filePath(basePath, name string) (string, error) {
-	if err := validateResourceName(name); err != nil {
+	// api.ValidateResourceName is the single choke point for caller-supplied
+	// entity names: filepath.Join collapses ".." segments, so an unchecked name
+	// like "../../evil" would read and write *.yaml files outside the config
+	// directory.
+	if err := api.ValidateResourceName(name); err != nil {
 		return "", err
 	}
 	return filepath.Join(basePath, m.dir, name+".yaml"), nil

--- a/internal/client/filesystem/store_test.go
+++ b/internal/client/filesystem/store_test.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -59,53 +60,57 @@ func TestUpdateMCPServerStatus_DoesNotResurrectDeleted(t *testing.T) {
 
 // TestCreateMCPServer_RejectsPathTraversal pins the fix for the filesystem
 // path-traversal hole: a caller-controlled name that escapes the config dir
-// must be rejected before any file is written, and nothing may land outside
-// the store's directory.
+// must be rejected before any file is written.
+//
+// The traversal targets point at a sibling t.TempDir() rather than /tmp or
+// /etc, so a regression stays inside the directories this test owns, and each
+// case asserts os.Stat on the exact path the name would resolve to — scanning
+// the base dir cannot see a file that landed outside it.
 func TestCreateMCPServer_RejectsPathTraversal(t *testing.T) {
 	ctx := context.Background()
 	base := t.TempDir()
+	outside := t.TempDir() // sibling of base, under the same parent
 	c := New(base)
 
-	for _, name := range []string{
-		"../../escaped",
-		"../../../../../../tmp/muster-traversal-poc",
-		"/etc/muster-evil",
+	names := []string{
+		// base/mcpservers/../../<sibling>/escaped.yaml resolves into outside.
+		"../../" + filepath.Base(outside) + "/escaped",
+		// More ".." segments than there are directories: filepath.Join clamps
+		// at the root, then the absolute sibling path lands in outside.
+		"../../../../../../../.." + outside + "/deep-escape",
+		// Absolute name: joined relative to the store dir today, but a
+		// regression that trusts it writes straight into outside.
+		filepath.Join(outside, "absolute-evil"),
 		"foo/bar",
 		"..",
 		".",
-	} {
+		// Not traversal, but the same choke point: a newline forges a record in
+		// the line-oriented legacy events.log. Deliberately carries no
+		// separator, so it can only be rejected by the control-character rule.
+		"x\nforged",
+	}
+
+	for _, name := range names {
 		t.Run(name, func(t *testing.T) {
 			if err := c.CreateMCPServer(ctx, newTestServer(name)); err == nil {
 				t.Fatalf("expected create to reject name %q, got nil error", name)
 			}
+			// The path filePath would have produced for this name — inside the
+			// store dir for the harmless cases, outside it for the escapes.
+			target := filepath.Join(base, "mcpservers", name+".yaml")
+			if _, err := os.Stat(target); !os.IsNotExist(err) {
+				t.Fatalf("name %q wrote a file at %s (stat error: %v)", name, target, err)
+			}
 		})
 	}
 
-	// Nothing should have been written outside the mcpservers directory.
-	if entries, err := os.ReadDir(base); err == nil {
-		for _, e := range entries {
-			if e.Name() != "mcpservers" {
-				t.Fatalf("unexpected entry written to base dir: %q", e.Name())
-			}
-		}
+	// Belt and braces: the sibling directory must still be empty.
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("read sibling dir: %v", err)
 	}
-}
-
-func TestValidateResourceName(t *testing.T) {
-	// Path-safe names are accepted, including characters (underscore, uppercase,
-	// spaces) that Kubernetes admission would reject — filesystem mode only
-	// guards against directory escape, not DNS-1123 conformance.
-	valid := []string{"foo", "foo-bar", "foo.bar", "a1b2", "x", "special-chars-workflow_123", "Foo", "foo bar", "..foo"}
-	for _, name := range valid {
-		if err := validateResourceName(name); err != nil {
-			t.Errorf("expected %q to be valid, got: %v", name, err)
-		}
-	}
-	invalid := []string{"", "../evil", "a/b", "a\\b", "..", ".", "/etc/passwd", "foo/", "a\x00b"}
-	for _, name := range invalid {
-		if err := validateResourceName(name); err == nil {
-			t.Errorf("expected %q to be rejected", name)
-		}
+	if len(entries) != 0 {
+		t.Fatalf("traversal escaped into sibling dir: %v", entries)
 	}
 }
 

--- a/internal/client/filesystem/store_test.go
+++ b/internal/client/filesystem/store_test.go
@@ -72,7 +72,7 @@ func TestCreateMCPServer_RejectsPathTraversal(t *testing.T) {
 		"/etc/muster-evil",
 		"foo/bar",
 		"..",
-		"UpperCase",
+		".",
 	} {
 		t.Run(name, func(t *testing.T) {
 			if err := c.CreateMCPServer(ctx, newTestServer(name)); err == nil {
@@ -92,13 +92,16 @@ func TestCreateMCPServer_RejectsPathTraversal(t *testing.T) {
 }
 
 func TestValidateResourceName(t *testing.T) {
-	valid := []string{"foo", "foo-bar", "foo.bar", "a1b2", "x"}
+	// Path-safe names are accepted, including characters (underscore, uppercase,
+	// spaces) that Kubernetes admission would reject — filesystem mode only
+	// guards against directory escape, not DNS-1123 conformance.
+	valid := []string{"foo", "foo-bar", "foo.bar", "a1b2", "x", "special-chars-workflow_123", "Foo", "foo bar", "..foo"}
 	for _, name := range valid {
 		if err := validateResourceName(name); err != nil {
 			t.Errorf("expected %q to be valid, got: %v", name, err)
 		}
 	}
-	invalid := []string{"", "../evil", "a/b", "a\\b", "..", ".", "Foo", "foo_bar", "foo bar"}
+	invalid := []string{"", "../evil", "a/b", "a\\b", "..", ".", "/etc/passwd", "foo/", "a\x00b"}
 	for _, name := range invalid {
 		if err := validateResourceName(name); err == nil {
 			t.Errorf("expected %q to be rejected", name)

--- a/internal/client/filesystem/store_test.go
+++ b/internal/client/filesystem/store_test.go
@@ -48,8 +48,61 @@ func TestUpdateMCPServerStatus_DoesNotResurrectDeleted(t *testing.T) {
 	if err := c.UpdateMCPServerStatus(ctx, stale); !errors.IsNotFound(err) {
 		t.Fatalf("expected NotFound from status update after delete, got %v", err)
 	}
-	if _, err := os.Stat(mcpServerMeta.filePath(c.basePath, "doomed")); !os.IsNotExist(err) {
+	doomedPath, err := mcpServerMeta.filePath(c.basePath, "doomed")
+	if err != nil {
+		t.Fatalf("filePath: %v", err)
+	}
+	if _, err := os.Stat(doomedPath); !os.IsNotExist(err) {
 		t.Fatal("status update resurrected the deleted definition file")
+	}
+}
+
+// TestCreateMCPServer_RejectsPathTraversal pins the fix for the filesystem
+// path-traversal hole: a caller-controlled name that escapes the config dir
+// must be rejected before any file is written, and nothing may land outside
+// the store's directory.
+func TestCreateMCPServer_RejectsPathTraversal(t *testing.T) {
+	ctx := context.Background()
+	base := t.TempDir()
+	c := New(base)
+
+	for _, name := range []string{
+		"../../escaped",
+		"../../../../../../tmp/muster-traversal-poc",
+		"/etc/muster-evil",
+		"foo/bar",
+		"..",
+		"UpperCase",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := c.CreateMCPServer(ctx, newTestServer(name)); err == nil {
+				t.Fatalf("expected create to reject name %q, got nil error", name)
+			}
+		})
+	}
+
+	// Nothing should have been written outside the mcpservers directory.
+	if entries, err := os.ReadDir(base); err == nil {
+		for _, e := range entries {
+			if e.Name() != "mcpservers" {
+				t.Fatalf("unexpected entry written to base dir: %q", e.Name())
+			}
+		}
+	}
+}
+
+func TestValidateResourceName(t *testing.T) {
+	valid := []string{"foo", "foo-bar", "foo.bar", "a1b2", "x"}
+	for _, name := range valid {
+		if err := validateResourceName(name); err != nil {
+			t.Errorf("expected %q to be valid, got: %v", name, err)
+		}
+	}
+	invalid := []string{"", "../evil", "a/b", "a\\b", "..", ".", "Foo", "foo_bar", "foo bar"}
+	for _, name := range invalid {
+		if err := validateResourceName(name); err == nil {
+			t.Errorf("expected %q to be rejected", name)
+		}
 	}
 }
 

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -1065,6 +1065,15 @@ func (a *Adapter) validateMCPServer(server *musterv1alpha1.MCPServer) error {
 		return fmt.Errorf("name is required")
 	}
 
+	// Path safety is enforced again in the filesystem store, but reporting it
+	// here keeps mcpserver_validate in agreement with create/update: without
+	// it, validate calls "../../evil" a valid definition and the create that
+	// follows fails. Character policy beyond path safety stays with Kubernetes
+	// admission.
+	if err := api.ValidateResourceName(server.Name); err != nil {
+		return err
+	}
+
 	if server.Spec.Type == "" {
 		return fmt.Errorf("type is required")
 	}

--- a/internal/mcpserver/unsafe_name_test.go
+++ b/internal/mcpserver/unsafe_name_test.go
@@ -1,0 +1,51 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestUnsafeName_RejectedByValidateAndCreate covers the agreement between
+// mcpserver_validate and mcpserver_create for caller-supplied names that are
+// not a safe path segment. Path safety is also enforced in the filesystem
+// store, but a name checked only there makes validate call "../../evil" a good
+// definition and the create that follows fail — an agent that validates before
+// creating gets contradictory answers.
+func TestUnsafeName_RejectedByValidateAndCreate(t *testing.T) {
+	names := map[string]string{
+		"traversal":    "../../evil",
+		"absolute":     "/etc/muster-evil",
+		"separator":    "foo/bar",
+		"dot-dot":      "..",
+		"control-char": "evil\nname",
+	}
+
+	for label, name := range names {
+		for _, tool := range []string{"mcpserver_validate", "mcpserver_create"} {
+			t.Run(label+"/"+tool, func(t *testing.T) {
+				sa := &stubMusterClient{filesystem: true, existing: existingServer()}
+				adapter := NewAdapterWithClient(sa, "test-ns")
+
+				args := map[string]interface{}{
+					"name": name,
+					"type": "streamable-http",
+					"url":  "http://localhost:1/mcp",
+				}
+				result, err := adapter.ExecuteTool(context.Background(), tool, args)
+				if err != nil {
+					t.Fatalf("ExecuteTool: %v", err)
+				}
+				if !result.IsError {
+					t.Fatalf("%s accepted unsafe name %q: %s", tool, name, resultText(t, result))
+				}
+				if text := resultText(t, result); !strings.Contains(text, "invalid name") {
+					t.Errorf("rejection %q does not explain the name is invalid", text)
+				}
+				if writes := len(sa.created) + len(sa.updated) + len(sa.deleted); writes != 0 {
+					t.Fatalf("%s wrote despite the rejection: created=%v updated=%v", tool, sa.created, sa.updated)
+				}
+			})
+		}
+	}
+}

--- a/internal/workflow/api_adapter.go
+++ b/internal/workflow/api_adapter.go
@@ -512,6 +512,16 @@ func (a *Adapter) ValidateWorkflowFromStructured(args map[string]interface{}) er
 		})
 		return err
 	}
+	// Path safety is enforced again in the filesystem store, but reporting it
+	// here keeps workflow_validate in agreement with create/update instead of
+	// calling a name like "../../evil" valid and then failing the create.
+	if err := api.ValidateResourceName(wf.Name); err != nil {
+		a.generateCRDEvent("", events.ReasonWorkflowValidationFailed, events.EventData{
+			Error:     err.Error(),
+			Operation: opValidate,
+		})
+		return err
+	}
 	if len(wf.Steps) == 0 {
 		err := fmt.Errorf("workflow must have at least one step")
 		a.generateCRDEvent(wf.Name, events.ReasonWorkflowValidationFailed, events.EventData{

--- a/internal/workflow/unsafe_name_test.go
+++ b/internal/workflow/unsafe_name_test.go
@@ -1,0 +1,52 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestUnsafeName_RejectedByValidateAndCreate covers the agreement between
+// workflow_validate and workflow_create for caller-supplied names that are not
+// a safe path segment. Path safety is also enforced in the filesystem store,
+// but a name checked only there makes validate call "../../evil" a good
+// definition and the create that follows fail.
+func TestUnsafeName_RejectedByValidateAndCreate(t *testing.T) {
+	names := map[string]string{
+		"traversal":    "../../evil",
+		"absolute":     "/etc/muster-evil",
+		"separator":    "foo/bar",
+		"dot-dot":      "..",
+		"control-char": "evil\nname",
+	}
+
+	for label, name := range names {
+		for _, tool := range []string{"workflow_validate", "workflow_create"} {
+			t.Run(label+"/"+tool, func(t *testing.T) {
+				sa := &stubMusterClient{existing: existingWorkflow()}
+				adapter := NewAdapterWithClient(sa, "test-ns", nil, nil, "")
+				t.Cleanup(adapter.stopGC)
+
+				// workflow_create surfaces a validation failure as a Go error,
+				// workflow_validate as an error result — either way the call
+				// must fail and say why.
+				result, err := adapter.ExecuteTool(context.Background(), tool, workflowArgs(name))
+				var text string
+				switch {
+				case err != nil:
+					text = err.Error()
+				case result.IsError:
+					text = resultText(t, result)
+				default:
+					t.Fatalf("%s accepted unsafe name %q: %s", tool, name, resultText(t, result))
+				}
+				if !strings.Contains(text, "invalid name") {
+					t.Errorf("rejection %q does not explain the name is invalid", text)
+				}
+				if writes := len(sa.created) + len(sa.updated) + len(sa.deleted); writes != 0 {
+					t.Fatalf("%s wrote despite the rejection: created=%v updated=%v", tool, sa.created, sa.updated)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a **high-severity path-traversal** vulnerability in filesystem (non-Kubernetes) mode. The caller-controlled entity `name` from the `mcpserver`/`workflow` create/get/update/delete tools was joined into the on-disk file path with no validation. A name like `../../../../tmp/evil` escaped the muster config directory, allowing arbitrary `.yaml` **write** (with attacker-influenced content) and **read** (returned via the `get` tool) anywhere the process could reach.

Since these tools are exposed to AI agents, a prompt-injected or malicious agent could escape the config sandbox with a single normal tool call. Kubernetes mode was unaffected — the API server enforces DNS-1123 names; the filesystem store was the unguarded path.

## Fix

Validate the name at `resourceMeta.filePath` in `internal/client/filesystem/store.go` — the single choke point every storage operation (get, create, update, delete, status) flows through. `filePath` now returns `(string, error)` and all call sites reject invalid names before any I/O.

`validateResourceName` enforces **path safety only**: the name must be a single path segment — no path separators (`/`, `\`), no null byte, and not a `.` / `..` reference. This blocks every directory-escape name from the report.

Character policy beyond path safety (e.g. DNS-1123) is intentionally left to Kubernetes admission. Filesystem mode is expected to accept permissive-but-safe names such as `special-chars-workflow_123` (underscore), which the BDD suite documents as valid — enforcing DNS-1123 here would break `workflow-execution-edge-cases`.

## Tests

- `TestCreateMCPServer_RejectsPathTraversal` — exercises the report's PoC names and asserts nothing lands outside the store directory.
- `TestValidateResourceName` — valid names (including underscore/uppercase/space) vs. path-unsafe ones.

Verified **red before green**: with the validator neutered, the traversal cases and all path-unsafe entries fail; they pass with the fix. The `workflow-execution-edge-cases` BDD scenario passes. `go build ./...`, `go vet`, and `goimports` are clean.
