### PR TITLE
fix(aggregator): redact caller tokens from SSO log lines

### DIFF
--- a/docs/contributing/testing/scenarios.md
+++ b/docs/contributing/testing/scenarios.md
@@ -76,6 +76,11 @@ cleanup:
     expected:
       success: true
     timeout: "30s"
+
+# Optional assertions on muster serve's own stdout/stderr, captured at debug
+# level for the whole scenario and evaluated once after steps and cleanup ran
+instance_logs:
+  not_contains: ["eyJ"]                # e.g. no JWT ever reached the logs
 ```
 
 ### Key Schema Changes
@@ -141,6 +146,7 @@ steps:
 - **timeout**: Global timeout in Go duration format (e.g., "5m", "30s", "1h")
 - **pre_configuration**: Setup for the isolated muster instance
 - **cleanup**: Teardown steps run after test completion
+- **instance_logs**: Assertions on the muster serve instance's captured output; see [Instance log assertions](#instance-log-assertions)
 
 #### Step Schema
 
@@ -355,6 +361,27 @@ expected:
 
 Set `wait_for_state` *or* a step `timeout:`, not both -- two deadlines on the
 same step race, and the poll should own the bound.
+
+#### Instance log assertions
+
+Step expectations only see what a tool call returns. `instance_logs` is the one
+expectation that sees the other side: the stdout and stderr of the `muster serve`
+instance the scenario ran against, captured at debug level for the whole run and
+checked once after the last step and cleanup step. It is scenario-level, not
+per-step, and takes `contains` and/or `not_contains` lists (at least one is
+required; an empty block is rejected at load time):
+
+```yaml
+instance_logs:
+  contains: ["SSO: initSSOForSession called"]
+  not_contains: ["eyJ"]   # the base64url prefix every JWT header shares
+```
+
+The typical use is proving a credential never reached the logs, so a
+`not_contains` hit is reported by line number and the text of that line *up to*
+the match -- never the match itself or what follows it. Use `contains` sparingly:
+log lines are not an API, and a scenario pinned to log wording breaks on
+harmless rewording.
 
 ### 5. Mock Server Configuration
 

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -362,7 +363,12 @@ func (a *AggregatorServer) bootstrapNewSessionSSO(sso ssoSession) {
 func (a *AggregatorServer) initSSOForSession(sso ssoSession) {
 	musterIssuer := a.getMusterIssuer()
 
-	logging.Info("Aggregator", "SSO: initSSOForSession called (session=%v, musterIssuer=%s)", sso, musterIssuer)
+	// sso is a LogValuer: the structured attr renders truncated identifiers and
+	// token lengths. Never hand it to a %v -- the raw struct holds the caller's
+	// ID token and bearer.
+	logging.InfoWithAttrs("Aggregator", "SSO: initSSOForSession called",
+		slog.Any("session", sso),
+		slog.String("musterIssuer", musterIssuer))
 
 	if musterIssuer == "" {
 		logging.Info("Aggregator", "SSO: initSSOForSession returning early: musterIssuer is empty")

--- a/internal/aggregator/sso_session.go
+++ b/internal/aggregator/sso_session.go
@@ -61,3 +61,18 @@ func (s ssoSession) LogValue() slog.Value {
 		slog.String("tokenSource", string(s.tokenSource)),
 	)
 }
+
+// String implements fmt.Stringer so that %v, %+v and %s of an ssoSession print
+// the same redacted view as LogValue. Without it, fmt falls back to the struct
+// layout and prints the caller's ID token and bearer verbatim -- one stray %v
+// is enough to land two live JWTs in the pod logs and every pipeline that
+// collects them. Rendering LogValue keeps the two views from ever disagreeing
+// about what is safe to print.
+func (s ssoSession) String() string {
+	return logging.FormatGroup("ssoSession", s.LogValue())
+}
+
+// GoString implements fmt.GoStringer so that %#v redacts as well.
+func (s ssoSession) GoString() string {
+	return s.String()
+}

--- a/internal/aggregator/sso_session_test.go
+++ b/internal/aggregator/sso_session_test.go
@@ -1,9 +1,14 @@
 package aggregator
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
 	"testing"
 
+	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/stretchr/testify/require"
 
 	"github.com/giantswarm/muster/internal/api"
@@ -41,5 +46,50 @@ func TestCanBootstrapSSO(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, ssoSession{tokens: tc.tokens}.canBootstrapSSO())
 		})
+	}
+}
+
+// TestSSOSession_FormattingRedactsTokens pins the property that no way of
+// printing an ssoSession reveals the tokens it carries. The struct holds the
+// caller's ID token and bearer; before String/GoString existed, a %v printed
+// both verbatim (muster 5.7.8 did exactly that from initSSOForSession, landing
+// full 30-minute JWTs in pod logs). Every fmt verb and both slog handlers are
+// exercised so a regression in any one rendering path fails here.
+func TestSSOSession_FormattingRedactsTokens(t *testing.T) {
+	const idToken = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.id-token-signature"
+	const bearer = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSIsImFjdCI6e319.bearer-signature"
+	sso := ssoSession{
+		userID:      "alice@giantswarm.io",
+		sessionID:   "session-1234567890",
+		tokens:      server.CallerTokens{IDToken: idToken, Bearer: bearer},
+		tokenSource: providers.TokenSourceOAuth,
+	}
+
+	rendered := map[string]string{
+		"%v":         fmt.Sprintf("%v", sso),
+		"%+v":        fmt.Sprintf("%+v", sso),
+		"%#v":        fmt.Sprintf("%#v", sso),
+		"%s":         fmt.Sprintf("%s", sso), //nolint:staticcheck // S1025: the %s verb path is what is under test
+		"%v pointer": fmt.Sprintf("%v", &sso),
+		"Sprint":     fmt.Sprint(sso),
+		"Sprintln":   fmt.Sprintln(sso),
+	}
+	var buf bytes.Buffer
+	slog.New(slog.NewTextHandler(&buf, nil)).Info("sso", slog.Any("session", sso))
+	rendered["slog text"] = buf.String()
+	buf.Reset()
+	slog.New(slog.NewJSONHandler(&buf, nil)).Info("sso", slog.Any("session", sso))
+	rendered["slog json"] = buf.String()
+
+	for name, out := range rendered {
+		require.NotContains(t, out, "eyJ", "%s leaks a JWT prefix: %s", name, out)
+		require.NotContains(t, out, idToken, "%s leaks the ID token", name)
+		require.NotContains(t, out, bearer, "%s leaks the bearer", name)
+		// The redacted view still carries what an operator needs to correlate.
+		require.Contains(t, out, "alice@gi...", "%s should keep the truncated userID", name)
+		require.Contains(t, out, "session-...", "%s should keep the truncated sessionID", name)
+		require.Contains(t, out, strconv.Itoa(len(idToken)), "%s should report the ID token length", name)
+		require.Contains(t, out, strconv.Itoa(len(bearer)), "%s should report the bearer length", name)
+		require.Contains(t, out, "oauth", "%s should keep the token source", name)
 	}
 }

--- a/internal/aggregator/tool_factory.go
+++ b/internal/aggregator/tool_factory.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/giantswarm/muster/internal/api"
@@ -94,7 +95,10 @@ func (a *AggregatorServer) createMetaToolHandler(provider api.ToolProvider, tool
 		// Execute the meta-tool through the provider
 		result, err := provider.ExecuteTool(ctx, toolName, args)
 		if err != nil {
-			logging.Error("AggregatorMetaToolHandler", err, "Meta-tool execution failed for %s with args %+v", toolName, args)
+			// Log the argument names only. Meta-tool arguments carry whatever the
+			// caller sent -- an MCPServer spec with an Authorization header, for
+			// one -- and this fires on every failed call.
+			logging.Error("AggregatorMetaToolHandler", err, "Meta-tool execution failed for %s (args: %s)", toolName, metaToolArgNames(args))
 			return mcp.NewToolResultError(fmt.Sprintf("Meta-tool execution failed: %v", err)), nil
 		}
 
@@ -337,4 +341,13 @@ func convertToMCPResult(result *api.CallToolResult) *mcp.CallToolResult {
 		IsError:           result.IsError,
 		StructuredContent: result.StructuredContent,
 	}
+}
+
+// metaToolArgNames renders the argument names of a meta-tool call, sorted, for
+// log lines. Values are deliberately left out: they can be credentials.
+func metaToolArgNames(args map[string]any) string {
+	if len(args) == 0 {
+		return "none"
+	}
+	return strings.Join(slices.Sorted(maps.Keys(args)), ", ")
 }

--- a/internal/aggregator/tool_factory_logging_test.go
+++ b/internal/aggregator/tool_factory_logging_test.go
@@ -1,0 +1,56 @@
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+type failingToolProvider struct{ err error }
+
+func (p failingToolProvider) GetTools() []api.ToolMetadata { return nil }
+
+func (p failingToolProvider) ExecuteTool(context.Context, string, map[string]any) (*api.CallToolResult, error) {
+	return nil, p.err
+}
+
+// TestMetaToolHandler_FailureLogNamesArgsWithoutValues pins that a failed
+// meta-tool call logs which arguments were sent, not what they held. Meta-tool
+// arguments are caller-supplied and can carry credentials -- an MCPServer spec
+// with an Authorization header is the obvious case -- and the failure log used
+// to print the whole map with %+v.
+func TestMetaToolHandler_FailureLogNamesArgsWithoutValues(t *testing.T) {
+	logBuf := captureLog(t)
+
+	handler := (&AggregatorServer{}).createMetaToolHandler(failingToolProvider{err: errors.New("spec rejected")}, "core_mcpserver_create")
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "core_mcpserver_create"
+	req.Params.Arguments = map[string]any{
+		"name": "backend",
+		"headers": map[string]any{
+			"Authorization": "Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJzZWNyZXQifQ.sig",
+		},
+	}
+
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+
+	logged := logBuf.String()
+	require.Contains(t, logged, "core_mcpserver_create")
+	require.Contains(t, logged, "headers, name", "argument names should be logged, sorted")
+	require.NotContains(t, logged, "eyJ", "argument values must not be logged: %s", logged)
+	require.NotContains(t, logged, "backend", "argument values must not be logged: %s", logged)
+}
+
+func TestMetaToolArgNames(t *testing.T) {
+	require.Equal(t, "none", metaToolArgNames(nil))
+	require.Equal(t, "none", metaToolArgNames(map[string]any{}))
+	require.Equal(t, "a, b, c", metaToolArgNames(map[string]any{"c": 1, "a": "x", "b": nil}))
+}

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -849,7 +849,9 @@ func (s *OAuthHTTPServer) getProviderToken(ctx context.Context, r *http.Request)
 	}
 	token, err := s.tokenStore.GetToken(ctx, bearerToken)
 	if err != nil {
-		logging.Warn("OAuth", "SSO: Failed to get provider token from store: %v", err)
+		// Store errors can embed the key that was looked up, which here is the
+		// caller's live bearer. Strip it before the message reaches the logs.
+		logging.Warn("OAuth", "SSO: Failed to get provider token from store: %s", logging.RedactSecret(err.Error(), bearerToken))
 		return nil
 	}
 	return token

--- a/internal/server/oauth_http_provider_token_test.go
+++ b/internal/server/oauth_http_provider_token_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// keyEchoingTokenStore fails every lookup with an error that embeds the key it
+// was asked for, the way mcp-oauth's in-memory store does
+// (fmt.Errorf("%w: %s", storage.ErrTokenNotFound, key)). For getProviderToken
+// that key is the caller's bearer.
+type keyEchoingTokenStore struct {
+	storage.TokenStore
+}
+
+func (keyEchoingTokenStore) GetToken(_ context.Context, key string) (*oauth2.Token, error) {
+	return nil, fmt.Errorf("%w: %s", storage.ErrTokenNotFound, key)
+}
+
+// TestGetProviderToken_StoreErrorDoesNotLogBearer pins that a token-store
+// failure is logged without the bearer the store echoed back. Before the
+// redaction, every request whose bearer had no stored provider token (an agent
+// arriving with a trusted-issuer JWT, for one) wrote that JWT to the logs at
+// WARN level.
+func TestGetProviderToken_StoreErrorDoesNotLogBearer(t *testing.T) {
+	const bearer = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.live-signature"
+
+	var logBuf bytes.Buffer
+	logging.InitForCLI(logging.LevelDebug, &logBuf)
+
+	s := &OAuthHTTPServer{tokenStore: keyEchoingTokenStore{}}
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+bearer)
+
+	require.Nil(t, s.getProviderToken(context.Background(), req))
+
+	logged := logBuf.String()
+	require.Contains(t, logged, "Failed to get provider token from store", "the failure must still be logged")
+	require.Contains(t, logged, "token not found", "the store's reason must survive redaction")
+	require.NotContains(t, logged, bearer, "the bearer must not reach the logs: %s", logged)
+	require.NotContains(t, logged, "eyJ", "no JWT prefix may reach the logs: %s", logged)
+}

--- a/internal/server/token_provider.go
+++ b/internal/server/token_provider.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/giantswarm/mcp-oauth/providers"
 	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/muster/pkg/logging"
 )
 
 // contextKey is a custom type for context keys to avoid collisions.
@@ -54,9 +57,31 @@ func GetBearerTokenFromContext(ctx context.Context) string {
 // CallerTokens is the set of per-request credential tokens (subject bearer and
 // ID token) carried as a unit so a context rebuilt off the request path cannot
 // silently drop one.
+//
+// Both fields are live credentials. The type implements slog.LogValuer,
+// fmt.Stringer and fmt.GoStringer so that structured attrs and every fmt verb
+// print token lengths, never token bytes.
 type CallerTokens struct {
 	IDToken string
 	Bearer  string
+}
+
+// LogValue implements slog.LogValuer.
+func (t CallerTokens) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("idTokenLen", len(t.IDToken)),
+		slog.Int("bearerLen", len(t.Bearer)),
+	)
+}
+
+// String implements fmt.Stringer; %v, %+v and %s render the LogValue view.
+func (t CallerTokens) String() string {
+	return logging.FormatGroup("CallerTokens", t.LogValue())
+}
+
+// GoString implements fmt.GoStringer so that %#v redacts as well.
+func (t CallerTokens) GoString() string {
+	return t.String()
 }
 
 // CallerTokensFromContext snapshots the credential tokens present on ctx.

--- a/internal/server/token_provider_test.go
+++ b/internal/server/token_provider_test.go
@@ -1,7 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,4 +21,35 @@ func TestCallerTokens_RoundTrip(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "id-tok", id)
 	require.Equal(t, "bearer-tok", GetBearerTokenFromContext(ctx))
+}
+
+// TestCallerTokens_FormattingRedactsTokens pins that no fmt verb and no slog
+// handler prints the credentials a CallerTokens carries -- only their lengths.
+func TestCallerTokens_FormattingRedactsTokens(t *testing.T) {
+	const idToken = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.id-token-signature"
+	const bearer = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.bearer-signature"
+	tokens := CallerTokens{IDToken: idToken, Bearer: bearer}
+
+	rendered := map[string]string{
+		"%v":         fmt.Sprintf("%v", tokens),
+		"%+v":        fmt.Sprintf("%+v", tokens),
+		"%#v":        fmt.Sprintf("%#v", tokens),
+		"%s":         fmt.Sprintf("%s", tokens), //nolint:staticcheck // S1025: the %s verb path is what is under test
+		"%v pointer": fmt.Sprintf("%v", &tokens),
+		"Sprint":     fmt.Sprint(tokens),
+	}
+	var buf bytes.Buffer
+	slog.New(slog.NewTextHandler(&buf, nil)).Info("tokens", slog.Any("tokens", tokens))
+	rendered["slog text"] = buf.String()
+	buf.Reset()
+	slog.New(slog.NewJSONHandler(&buf, nil)).Info("tokens", slog.Any("tokens", tokens))
+	rendered["slog json"] = buf.String()
+
+	for name, out := range rendered {
+		require.NotContains(t, out, "eyJ", "%s leaks a JWT prefix: %s", name, out)
+		require.NotContains(t, out, idToken, "%s leaks the ID token", name)
+		require.NotContains(t, out, bearer, "%s leaks the bearer", name)
+		require.Contains(t, out, strconv.Itoa(len(idToken)), "%s should report the ID token length", name)
+		require.Contains(t, out, strconv.Itoa(len(bearer)), "%s should report the bearer length", name)
+	}
 }

--- a/internal/testing/instance_logs_test.go
+++ b/internal/testing/instance_logs_test.go
@@ -1,0 +1,94 @@
+package testing
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestInstanceLogsRequiresAnAssertion covers the load-time rule for the
+// scenario-level instance_logs block: declaring it with nothing to check would
+// pass vacuously, the same failure mode status_code and retry had.
+func TestInstanceLogsRequiresAnAssertion(t *testing.T) {
+	loader := &scenarioLoader{}
+	scenario := TestScenario{
+		Name:     "logs-are-clean",
+		Category: CategoryBehavioral,
+		Concept:  ConceptMCPServer,
+		Steps: []TestStep{{
+			ID:       "list",
+			Tool:     "core_mcpserver_list",
+			Expected: TestExpectation{Success: true},
+		}},
+		InstanceLogs: &InstanceLogExpectation{},
+	}
+
+	err := loader.validateScenario(scenario, "logs-are-clean.yaml")
+	if err == nil {
+		t.Fatal("validateScenario accepted an empty instance_logs block")
+	}
+	if !strings.Contains(err.Error(), "instance_logs") {
+		t.Errorf("the rejection should name the block, got: %v", err)
+	}
+
+	scenario.InstanceLogs.NotContains = []string{"eyJ"}
+	if err := loader.validateScenario(scenario, "logs-are-clean.yaml"); err != nil {
+		t.Errorf("a scenario with a not_contains assertion should load, got: %v", err)
+	}
+}
+
+func TestValidateInstanceLogs(t *testing.T) {
+	logs := &InstanceLogs{
+		Stdout: "level=INFO msg=\"SSO: onAuthenticated callback\" session.userID=alice...\n" +
+			"level=INFO msg=\"SSO: initSSOForSession called\" session=eyJhbGciOiJSUzI1NiJ9.secret-payload.sig\n",
+		Stderr: "warning: something on stderr\n",
+	}
+
+	t.Run("nil expectation is a no-op", func(t *testing.T) {
+		if err := validateInstanceLogs(nil, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("no captured logs cannot satisfy an assertion", func(t *testing.T) {
+		err := validateInstanceLogs(&InstanceLogExpectation{NotContains: []string{"eyJ"}}, nil)
+		if err == nil {
+			t.Fatal("an assertion against missing logs must not pass vacuously")
+		}
+	})
+
+	t.Run("contains is checked across stdout and stderr", func(t *testing.T) {
+		exp := &InstanceLogExpectation{Contains: []string{"onAuthenticated callback", "something on stderr"}}
+		if err := validateInstanceLogs(exp, logs); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		exp.Contains = append(exp.Contains, "never logged")
+		err := validateInstanceLogs(exp, logs)
+		if err == nil || !strings.Contains(err.Error(), `do not contain "never logged"`) {
+			t.Fatalf("missing substring should be reported, got: %v", err)
+		}
+	})
+
+	t.Run("not_contains reports the line without echoing the match", func(t *testing.T) {
+		err := validateInstanceLogs(&InstanceLogExpectation{NotContains: []string{"eyJ"}}, logs)
+		if err == nil {
+			t.Fatal("forbidden substring present but no error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "on 1 line(s), first at line 2") {
+			t.Errorf("the report should locate the match by line, got: %v", msg)
+		}
+		if !strings.Contains(msg, "initSSOForSession called") {
+			t.Errorf("the report should quote the line up to the match, got: %v", msg)
+		}
+		if strings.Contains(msg, "secret-payload") {
+			t.Errorf("the report must not echo what follows the match, got: %v", msg)
+		}
+	})
+
+	t.Run("clean logs pass", func(t *testing.T) {
+		clean := &InstanceLogs{Stdout: "level=INFO msg=ready\n"}
+		if err := validateInstanceLogs(&InstanceLogExpectation{NotContains: []string{"eyJ"}}, clean); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/testing/scenario_loader.go
+++ b/internal/testing/scenario_loader.go
@@ -171,6 +171,12 @@ func (l *scenarioLoader) validateScenario(scenario TestScenario, filePath string
 		}
 	}
 
+	// An instance_logs block with nothing to check would pass vacuously -- the
+	// same failure mode status_code and retry had.
+	if scenario.InstanceLogs != nil && len(scenario.InstanceLogs.Contains) == 0 && len(scenario.InstanceLogs.NotContains) == 0 {
+		return fmt.Errorf("instance_logs must list at least one of contains or not_contains")
+	}
+
 	return nil
 }
 

--- a/internal/testing/scenarios/sso-tokens-never-logged.yaml
+++ b/internal/testing/scenarios/sso-tokens-never-logged.yaml
@@ -1,0 +1,101 @@
+name: "sso-tokens-never-logged"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  A caller's credentials never reach muster's own logs. The scenario drives
+  both SSO bootstrap paths that hold live JWTs in memory -- the auth-code
+  login against muster's OAuth server (an upstream ID token) and an agent
+  presenting a dex-issued OBO bearer on /mcp (a forwardable bearer) -- with
+  muster serve running at debug level, then asserts that no JWT ever appeared
+  in its stdout or stderr. "eyJ" is the base64url prefix every JWT header
+  shares; muster 5.7.8 printed the whole ssoSession struct with %v from
+  initSSOForSession and landed both tokens verbatim in the pod logs.
+tags: ["oauth", "sso", "logging", "security", "aggregator"]
+timeout: "2m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "muster-idp"
+      scopes: ["openid", "profile", "email", "groups"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "muster-client"
+      client_secret: "muster-secret"
+      use_as_muster_oauth_server: true
+
+    - name: "workload-idp"
+
+  muster_broker:
+    trusted_issuers:
+      - oauth_server_ref: "workload-idp"
+        accepted_typ_headers: [""]
+
+  mcp_servers:
+    - name: "obo-backend"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          trust_issuer_ref: "workload-idp"
+          forward_token: true
+        tools:
+          - name: "whoami"
+            description: "Echoes the caller's forwarded token claims"
+            echo_token: true
+            responses:
+              - response:
+                  status: "ok"
+
+steps:
+  - id: "verify-backend-registered"
+    description: "Backend is registered with muster"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      contains: ["obo-backend"]
+      wait_for_state: "30s"
+
+  - id: "mint-dex-obo-token"
+    description: "Dex mints the on-behalf-of token: sub=human, act=agent SA"
+    tool: "test_mint_token"
+    args:
+      server: "workload-idp"
+      name: "obo-token"
+      sub: "alice@giantswarm.io"
+      email: "alice@giantswarm.io"
+      email_verified: true
+      groups: ["customer:giantswarm:team-ai"]
+      act:
+        sub: "system:serviceaccount:kagent:sre-agent"
+    expected:
+      success: true
+
+  - id: "connect-as-agent"
+    description: |
+      Present the dex-issued OBO token as the bearer on /mcp. This is the
+      forwarded-token session bootstrap: initSSOForSession runs with the
+      bearer in hand.
+    tool: "test_reconnect_with_token"
+    args:
+      token_ref: "obo-token"
+    expected:
+      success: true
+      wait_for_state: "30s"
+
+  - id: "backend-receives-forwarded-token"
+    description: "The bearer flowed through the SSO bootstrap and reached the backend"
+    tool: "x_obo-backend_whoami"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains:
+        - "alice@giantswarm.io"
+        - "system:serviceaccount:kagent:sre-agent"
+
+# Evaluated once the steps above ran: muster serve's own stdout and stderr,
+# captured at debug level for the whole scenario, never carried a JWT.
+instance_logs:
+  not_contains: ["eyJ"]

--- a/internal/testing/test_runner.go
+++ b/internal/testing/test_runner.go
@@ -518,7 +518,72 @@ func (r *testRunner) runScenario(ctx context.Context, scenario TestScenario, con
 	// The defer cleanup will handle the actual cleanup, but we need logs now
 	r.collectInstanceLogs(instance, &result)
 
+	// Instance-log expectations describe the whole run, so they are evaluated
+	// last. A step failure is the more specific diagnosis when both hold, and
+	// keeps its place at the front of the error.
+	if scenario.InstanceLogs != nil {
+		if err := validateInstanceLogs(scenario.InstanceLogs, result.InstanceLogs); err != nil {
+			if result.Result == ResultPassed {
+				result.Result = ResultFailed
+				result.Error = err.Error()
+			} else {
+				result.Error += "; " + err.Error()
+			}
+		}
+	}
+
 	return result
+}
+
+// instanceLogMatchContextLimit caps how much of the line preceding a forbidden
+// match validateInstanceLogs quotes back.
+const instanceLogMatchContextLimit = 160
+
+// validateInstanceLogs evaluates a scenario's instance_logs expectations against
+// the captured serve output.
+//
+// A not_contains hit is reported by line number and the text of that line up to
+// the match -- never the match itself or what follows it. The typical use is
+// asserting that a credential never reached the logs, and a failure report that
+// echoed the credential into the CI output would defeat the point.
+func validateInstanceLogs(expected *InstanceLogExpectation, logs *InstanceLogs) error {
+	if expected == nil {
+		return nil
+	}
+	if logs == nil {
+		return fmt.Errorf("instance_logs expectations declared but no instance logs were captured")
+	}
+	out := logs.Stdout + "\n" + logs.Stderr
+
+	var problems []string
+	for _, want := range expected.Contains {
+		if !strings.Contains(out, want) {
+			problems = append(problems, fmt.Sprintf("instance logs do not contain %q", want))
+		}
+	}
+	for _, forbidden := range expected.NotContains {
+		idx := strings.Index(out, forbidden)
+		if idx < 0 {
+			continue
+		}
+		line := 1 + strings.Count(out[:idx], "\n")
+		lineStart := strings.LastIndex(out[:idx], "\n") + 1
+		prefix := out[lineStart:idx]
+		if len(prefix) > instanceLogMatchContextLimit {
+			prefix = prefix[:instanceLogMatchContextLimit] + "..."
+		}
+		matching := 0
+		for _, l := range strings.Split(out, "\n") {
+			if strings.Contains(l, forbidden) {
+				matching++
+			}
+		}
+		problems = append(problems, fmt.Sprintf("instance logs contain forbidden %q on %d line(s), first at line %d (line starts: %q)", forbidden, matching, line, prefix))
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", strings.Join(problems, "; "))
 }
 
 // runStep executes a single test step using the specified MCP client with template variable support

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -125,6 +125,21 @@ type TestScenario struct {
 	Skip bool `yaml:"skip,omitempty"`
 	// PreConfiguration defines muster instance setup
 	PreConfiguration *MusterPreConfiguration `yaml:"pre_configuration,omitempty"`
+	// InstanceLogs asserts on the stdout/stderr the muster serve instance
+	// produced over the whole scenario. It is evaluated once, after the last
+	// step and cleanup step ran, and is the only expectation kind that sees
+	// the instance side of a behavior -- e.g. that a credential never reached
+	// the logs.
+	InstanceLogs *InstanceLogExpectation `yaml:"instance_logs,omitempty"`
+}
+
+// InstanceLogExpectation defines what the captured muster serve output must and
+// must not contain once the scenario has run. At least one list must be set.
+type InstanceLogExpectation struct {
+	// Contains lists substrings the combined stdout+stderr must include.
+	Contains []string `yaml:"contains,omitempty"`
+	// NotContains lists substrings the combined stdout+stderr must not include.
+	NotContains []string `yaml:"not_contains,omitempty"`
 }
 
 // MusterPreConfiguration defines how to pre-configure an muster serve instance

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -243,6 +243,34 @@ func TruncateIdentifier(id string) string {
 	return id[:8] + "..."
 }
 
+// RedactSecret replaces every occurrence of secret in text with a length-only
+// marker. Use it on error strings produced by code that embeds the key it looked
+// up -- a token store reporting "token not found: <bearer>" -- before they reach
+// a log line. An empty secret leaves text unchanged.
+func RedactSecret(text, secret string) string {
+	if secret == "" {
+		return text
+	}
+	return strings.ReplaceAll(text, secret, fmt.Sprintf("<redacted len=%d>", len(secret)))
+}
+
+// FormatGroup renders a slog group value as "name{key=value key=value}" so a
+// type can implement fmt.Stringer on top of its slog.LogValuer. Types that
+// carry credentials use it so that %v and structured attrs agree on the
+// redacted view instead of fmt falling back to the raw struct layout.
+func FormatGroup(name string, v slog.Value) string {
+	v = v.Resolve()
+	if v.Kind() != slog.KindGroup {
+		return name + "{" + v.String() + "}"
+	}
+	attrs := v.Group()
+	parts := make([]string, 0, len(attrs))
+	for _, a := range attrs {
+		parts = append(parts, a.Key+"="+a.Value.Resolve().String())
+	}
+	return name + "{" + strings.Join(parts, " ") + "}"
+}
+
 // TransportSessionID returns a slog.Attr with key "transportSessionID" and a truncated MCP transport session ID.
 // The last UUID group is replaced with "..." to preserve enough of the ID for log
 // correlation while avoiding logging the full value.

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -171,3 +172,52 @@ func (h *contextProbeHandler) Handle(ctx context.Context, _ slog.Record) error {
 }
 func (h *contextProbeHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
 func (h *contextProbeHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func TestFormatGroup(t *testing.T) {
+	group := slog.GroupValue(
+		slog.String("userID", "alice..."),
+		slog.Int("idTokenLen", 812),
+	)
+	if got, want := FormatGroup("ssoSession", group), "ssoSession{userID=alice... idTokenLen=812}"; got != want {
+		t.Errorf("FormatGroup(group) = %q, want %q", got, want)
+	}
+
+	// A non-group value still renders inside the braces rather than panicking.
+	if got, want := FormatGroup("x", slog.IntValue(7)), "x{7}"; got != want {
+		t.Errorf("FormatGroup(scalar) = %q, want %q", got, want)
+	}
+
+	// LogValuers nested in the group are resolved, so a redacting LogValue is
+	// what gets printed, not the raw value behind it.
+	nested := slog.GroupValue(slog.Any("tokens", redactingValuer{}))
+	if got, want := FormatGroup("outer", nested), "outer{tokens=[len=3]}"; got != want {
+		t.Errorf("FormatGroup(nested valuer) = %q, want %q", got, want)
+	}
+}
+
+type redactingValuer struct{}
+
+func (redactingValuer) LogValue() slog.Value {
+	return slog.GroupValue(slog.Int("len", 3))
+}
+
+func TestRedactSecret(t *testing.T) {
+	const bearer = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.signature"
+	in := "token not found: " + bearer + " (also seen as " + bearer + ")"
+
+	got := RedactSecret(in, bearer)
+	if strings.Contains(got, bearer) || strings.Contains(got, "eyJ") {
+		t.Fatalf("RedactSecret left the secret in place: %q", got)
+	}
+	marker := "<redacted len=" + strconv.Itoa(len(bearer)) + ">"
+	if want := "token not found: " + marker + " (also seen as " + marker + ")"; got != want {
+		t.Errorf("RedactSecret = %q, want %q", got, want)
+	}
+
+	if got := RedactSecret("unchanged", ""); got != "unchanged" {
+		t.Errorf("an empty secret must be a no-op, got %q", got)
+	}
+	if got := RedactSecret("no secret here", bearer); got != "no secret here" {
+		t.Errorf("text without the secret must be unchanged, got %q", got)
+	}
+}


### PR DESCRIPTION
## Security defect

Confirmed live on gazelle (muster 5.7.8, 2026-09-02T15:22:13Z): `initSSOForSession` logged the `ssoSession` struct with `%v`. The struct holds the caller's ID token and bearer, so every login, session bootstrap and pool-miss re-init wrote two live JWTs (~30 min validity) to the pod logs at INFO level, and from there into whatever collects them.

Auditing `internal/aggregator/*.go` and `internal/server/*.go` for the same class turned up two more:

- `getProviderToken` (oauth_http.go) logged the token store's error verbatim. mcp-oauth's in-memory store echoes the looked-up key, which here is the caller's bearer, in its not-found error (`%w: %s`). The Valkey store does not, so production was not hit by this one, but the store is pluggable.
- The meta-tool failure log (tool_factory.go) printed the whole argument map with `%+v`. `core_mcpserver_create` args can carry an MCPServer spec with an `Authorization` header.

## Fix

- `initSSOForSession` logs the session as a structured attr. `ssoSession.LogValue` already renders truncated `userID`/`sessionID`, `idTokenLen`, `bearerLen`, `tokenSource`.
- `ssoSession` and `server.CallerTokens` implement `fmt.Stringer` and `fmt.GoStringer` on top of their `LogValue` (new `logging.FormatGroup`), so `%v`, `%+v`, `%s` and `%#v` render the redacted view. A future stray `%v` cannot leak again; unit tests assert no `eyJ` prefix survives any fmt verb or slog handler.
- `getProviderToken` strips the bearer from the store error via new `logging.RedactSecret` before logging.
- The meta-tool failure log names argument keys only.

## Acceptance test

New behavioral scenario `sso-tokens-never-logged`: auth-code login against muster's OAuth server (upstream ID token) plus an agent presenting a dex-issued OBO bearer on `/mcp`, with `muster serve --debug`, then asserts no JWT prefix ever appears in the instance's stdout/stderr.

That needed a scenario-level `instance_logs` expectation (`contains` / `not_contains` on the captured serve output). A `not_contains` hit is reported by line number and the text *before* the match, never the match itself, so a failing run does not echo the credential into CI output. Documented in `docs/contributing/testing/scenarios.md`.

Regression proof, new harness binary in both runs:

| serve binary | result |
|---|---|
| `origin/main` (f1fe8778) | fails: `instance logs contain forbidden "eyJ" on 4 line(s)` (3× store WARN, 1× `initSSOForSession` `%v`) |
| this branch | passes |

Local: `go test ./...` green, full behavioral suite 201/201 green, golangci-lint 0 issues.

## Out of scope, noted

`internal/workflow/{validation,executor}.go` debug-log workflow args and results with `%+v`. Workflow args are user data and could carry secrets; worth the same key-only treatment in a follow-up. The mcp-oauth in-memory store embedding the lookup key in `ErrTokenNotFound` is an upstream nit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
