### PR TITLE
fix(testing): guard reserved instance ports through the exec window

### DIFF
--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -162,7 +163,6 @@ const defaultReadinessTimeout = 15 * time.Second
 type musterInstanceManager struct {
 	debug            bool
 	basePort         int
-	portOffset       int
 	tempDir          string
 	processes        map[string]*managedProcess // Track processes by instance ID
 	mu               sync.RWMutex
@@ -181,13 +181,30 @@ type musterInstanceManager struct {
 	// would otherwise make muster serve fail to bind. Protected by portMu.
 	reservedListeners map[int]net.Listener
 
+	// reservedGuards holds, for every reserved port, a second listener bound to
+	// portGuardHost:<port> for the whole lifetime of the reservation — across
+	// the exec window that closing the probe listener opens, and until
+	// releasePort. Linux bind-conflict rules make that guard reject every
+	// wildcard bind on the port, which is exactly what the kernel's ephemeral
+	// port search performs for net.Listen(":0") and connect(), while a bind to
+	// the distinct address 127.0.0.1:<port> — the one muster serve uses for
+	// both its aggregator and its Prometheus exporter — still succeeds. It also
+	// keeps a second harness on the same base port from reserving the port.
+	// Empty when portGuards is false. Protected by portMu.
+	reservedGuards map[int]net.Listener
+
+	// portGuards reports whether guard listeners are in use; see
+	// portGuardsSupported.
+	portGuards bool
+
 	// ephemeralLow/ephemeralHigh describe the OS ephemeral port range. Ports in
 	// this range are preferred-against when allocating instance ports: there is
-	// an unavoidable sub-millisecond window between closing the reserved probe
-	// listener and muster serve binding the port (see startMusterProcess), and
-	// during it a concurrent mock server's net.Listen(":0") can be handed that
-	// exact port by the OS. Allocating muster ports outside the ephemeral range
-	// makes that collision impossible regardless of the configured base port.
+	// an unavoidable window between closing the reserved probe listener and
+	// muster serve binding the port (exec plus process startup, see
+	// startMusterProcess), and during it the OS can hand that exact port to a
+	// concurrent net.Listen(":0") (a mock server) or connect() (any client).
+	// Where guard listeners are unavailable, allocating outside the ephemeral
+	// range is the only defense; with guards it is a cheap extra layer.
 	ephemeralLow  int
 	ephemeralHigh int
 
@@ -231,6 +248,8 @@ func NewMusterInstanceManagerWithConfig(debug bool, basePort int, logger TestLog
 		readinessTimeout:    readinessTimeout,
 		reservedPorts:       make(map[int]string),
 		reservedListeners:   make(map[int]net.Listener),
+		reservedGuards:      make(map[int]net.Listener),
+		portGuards:          portGuardsSupported(),
 		ephemeralLow:        ephemeralLow,
 		ephemeralHigh:       ephemeralHigh,
 		mockHTTPServers:     make(map[string]map[string]*mock.HTTPServer),
@@ -907,25 +926,86 @@ func (m *musterInstanceManager) findAvailablePort(instanceID string, logger Test
 	}
 
 	// Fallback: the whole configured window lies inside the ephemeral range, so
-	// no safe port is available. Allocate inside it anyway to preserve behavior,
-	// but warn: ephemeral collisions can cause rare setup flakes. Choosing a
-	// base port below the ephemeral range avoids this entirely.
-	logger.Info("⚠️  base port window [%d, %d] falls inside the OS ephemeral range [%d, %d]; "+
-		"instance ports may rarely be stolen by mock servers. Use a base port below %d to avoid this.\n",
-		m.basePort, m.basePort+99, m.ephemeralLow, m.ephemeralHigh, m.ephemeralLow)
+	// no safe port is available. Allocate inside it anyway to preserve behavior.
+	// Without guard listeners this is a real exposure — ephemeral collisions
+	// cause rare setup flakes — so warn; with guards the overlap is harmless.
+	if !m.portGuards {
+		logger.Info("⚠️  base port window [%d, %d] falls inside the OS ephemeral range [%d, %d]; "+
+			"instance ports may rarely be stolen by mock servers. Use a base port below %d to avoid this.\n",
+			m.basePort, m.basePort+portWindowSize-1, m.ephemeralLow, m.ephemeralHigh, m.ephemeralLow)
+	}
 	if port, ok := m.reservePortLocked(instanceID, logger, false); ok {
 		return port, nil
 	}
 
-	return 0, fmt.Errorf("no available ports found starting from %d (tried 100 ports)", m.basePort)
+	return 0, fmt.Errorf("no available ports found starting from %d (tried %d ports)", m.basePort, portWindowSize)
 }
 
-// reservePortLocked scans up to 100 ports from the current offset and reserves
-// the first available one, returning it. When skipEphemeral is true, ports that
+// portWindowSize is the number of ports, starting at the base port, the
+// allocator scans. --parallel 50 needs exactly 100 (MCP + metrics port per
+// instance). Allocation always takes the lowest free port so the harness's
+// footprint stays compact: every port an instance has used carries its
+// TIME_WAIT sockets for a minute afterwards, and when the window overlaps the
+// OS ephemeral range each such port is one fewer for everyone else's
+// net.Listen(":0").
+const portWindowSize = 100
+
+// portGuardHost is the loopback address guard listeners bind. Any address in
+// 127.0.0.0/8 other than 127.0.0.1 works on Linux without configuration; the
+// point is that it differs from the address muster serve binds so the two
+// listeners never conflict.
+const portGuardHost = "127.0.0.2"
+
+// portGuardsSupported reports whether the harness can hold guard listeners on
+// portGuardHost. Only Linux bind-conflict semantics are known to give a
+// specific-address listener the properties reservedGuards relies on (blocks
+// wildcard binds and the ephemeral port search, coexists with a listener on a
+// different specific address); macOS also lacks the 127.0.0.2 alias. Other
+// platforms keep the probe-only strategy.
+func portGuardsSupported() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(portGuardHost, "0"))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+// PortAllocationBanner describes the port-allocation environment for the run
+// banner: the port window, the OS ephemeral range (its overlap with the window
+// is the precondition for stolen-port flakes) and whether guard listeners are
+// active. One line per run so a CI log carries what "address already in use"
+// diagnostics need.
+func PortAllocationBanner(basePort int) string {
+	low, high := detectEphemeralPortRange()
+	guards := "off"
+	if portGuardsSupported() {
+		guards = "on"
+	}
+	return fmt.Sprintf("port window: [%d, %d], ephemeral range: [%d, %d], port guards: %s",
+		basePort, basePort+portWindowSize-1, low, high, guards)
+}
+
+// probeAddr is the address the availability probe listens on. With guards the
+// probe must bind the exact address muster serve will use (a wildcard probe
+// would collide with the harness's own guard); without guards a wildcard probe
+// catches occupants on any address, as before.
+func (m *musterInstanceManager) probeAddr(port int) string {
+	if m.portGuards {
+		return fmt.Sprintf("127.0.0.1:%d", port)
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+// reservePortLocked scans the port window from the base port and reserves the
+// lowest available port, returning it. When skipEphemeral is true, ports that
 // fall inside the OS ephemeral range are skipped. Caller must hold portMu.
 func (m *musterInstanceManager) reservePortLocked(instanceID string, logger TestLogger, skipEphemeral bool) (int, bool) {
-	for i := 0; i < 100; i++ { // Try up to 100 ports
-		port := m.basePort + m.portOffset + i
+	for i := 0; i < portWindowSize; i++ {
+		port := m.basePort + i
 
 		// Check if already reserved by another instance
 		if existingInstanceID, reserved := m.reservedPorts[port]; reserved {
@@ -943,22 +1023,44 @@ func (m *musterInstanceManager) reservePortLocked(instanceID string, logger Test
 			continue
 		}
 
-		// Check if port is actually available in general
-		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		// Guard first: it fails while a wildcard listener or another harness's
+		// guard owns the port, which covers one of the two ways the port can
+		// be taken.
+		var guard net.Listener
+		if m.portGuards {
+			g, err := net.Listen("tcp", net.JoinHostPort(portGuardHost, strconv.Itoa(port)))
+			if err != nil {
+				if m.debug {
+					logger.Debug("🔍 Port %d not available (guard bind failed): %v\n", port, err)
+				}
+				continue
+			}
+			guard = g
+		}
+
+		// Then probe the address muster serve will bind (see probeAddr); this
+		// catches occupants the guard cannot see, such as a listener or a
+		// lingering client socket on 127.0.0.1:<port>.
+		ln, err := net.Listen("tcp", m.probeAddr(port))
 		if err != nil {
+			if guard != nil {
+				_ = guard.Close()
+			}
 			if m.debug {
 				logger.Debug("🔍 Port %d not available (in use): %v\n", port, err)
 			}
 			continue // Port not available, try next
 		}
 
-		// Keep the listener open (do NOT close here). Closing it now would free
-		// the port at the OS level, letting an ephemeral net.Listen(":0") from a
-		// mock server steal it before muster serve binds. startMusterProcess
-		// closes it immediately before exec to minimize the bind race window.
+		// Keep the probe listener open (do NOT close here). Closing it now would
+		// free the port at the OS level; startMusterProcess closes it right
+		// before exec. The guard stays bound until releasePort and covers the
+		// exec window the probe cannot.
 		m.reservedPorts[port] = instanceID
 		m.reservedListeners[port] = ln
-		m.portOffset = i + 1 // Next search starts from next port
+		if guard != nil {
+			m.reservedGuards[port] = guard
+		}
 
 		if m.debug {
 			logger.Debug("✅ Reserved port %d for instance %s\n", port, instanceID)
@@ -1020,32 +1122,41 @@ func (m *musterInstanceManager) releaseReservedListenerLocked(port int) {
 	}
 }
 
+// releaseReservedGuardLocked closes and removes the guard listener for the
+// given port, making it available to the OS again. Caller must hold portMu.
+func (m *musterInstanceManager) releaseReservedGuardLocked(port int) {
+	if g, ok := m.reservedGuards[port]; ok {
+		_ = g.Close()
+		delete(m.reservedGuards, port)
+	}
+}
+
 // releasePort releases a reserved port back to the available pool
 func (m *musterInstanceManager) releasePort(port int, instanceID string, logger TestLogger) {
 	m.portMu.Lock()
 	defer m.portMu.Unlock()
 
-	// Close any probe listener still held for this port (e.g. when setup failed
-	// before muster serve was started). Idempotent if already closed.
-	m.releaseReservedListenerLocked(port)
-
 	// Check if the port is actually reserved by this instance
 	if existingInstanceID, reserved := m.reservedPorts[port]; reserved {
-		if existingInstanceID == instanceID {
-			delete(m.reservedPorts, port)
-			if m.debug {
-				logger.Debug("🔓 Released port %d from instance %s\n", port, instanceID)
-			}
-		} else {
+		if existingInstanceID != instanceID {
 			if m.debug {
 				logger.Debug("⚠️  Port %d was reserved by different instance %s, not releasing\n", port, existingInstanceID)
 			}
+			return
 		}
-	} else {
+		delete(m.reservedPorts, port)
 		if m.debug {
-			logger.Debug("ℹ️  Port %d was not reserved, nothing to release\n", port)
+			logger.Debug("🔓 Released port %d from instance %s\n", port, instanceID)
 		}
+	} else if m.debug {
+		logger.Debug("ℹ️  Port %d was not reserved, nothing to release\n", port)
 	}
+
+	// Close any probe listener still held for this port (e.g. when setup failed
+	// before muster serve was started) and the guard that protected the port
+	// for the instance's lifetime. Both idempotent if already closed.
+	m.releaseReservedListenerLocked(port)
+	m.releaseReservedGuardLocked(port)
 }
 
 // startMusterProcess starts an muster serve process.
@@ -1132,10 +1243,11 @@ func (m *musterInstanceManager) startMusterProcess(ctx context.Context, configPa
 	cmd.Stdout = logCapture.stdoutWriter
 	cmd.Stderr = logCapture.stderrWriter
 
-	// Release the OS-level port reservation just before exec: the held listener
-	// kept ephemeral listeners from stealing the port during setup, and now
-	// muster serve binds it immediately, leaving only a process-startup-sized
-	// race window.
+	// Release the probe listeners just before exec: they kept the ports from
+	// being taken during setup, and muster serve binds both early in startup.
+	// The guard listeners (reservedGuards) stay bound, so on Linux the exec
+	// window is closed to ephemeral allocations too; elsewhere it remains a
+	// process-startup-sized race window.
 	m.closeReservedListener(port)
 	m.closeReservedListener(metricsPort)
 

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -902,14 +902,37 @@ func (m *musterInstanceManager) processExitedError(instance *MusterInstance, man
 	if m.debug {
 		m.showLogs(instance, logger)
 	}
+	detail := capturedLogTail(managedProc) + portCollisionDiagnostics(instance, managedProc)
 	if managedProc.waitErr == nil {
 		// cmd.Wait returned nil: the process exited with code 0 before the
 		// instance became ready. %w on a nil error would render "%!w(<nil>)".
-		return fmt.Errorf("muster instance process exited (code 0) before becoming ready%s",
-			capturedLogTail(managedProc))
+		return fmt.Errorf("muster instance process exited (code 0) before becoming ready%s", detail)
 	}
 	return fmt.Errorf("muster instance process exited before becoming ready: %w%s",
-		managedProc.waitErr, capturedLogTail(managedProc))
+		managedProc.waitErr, detail)
+}
+
+// portCollisionDiagnostics names the sockets holding the instance's ports when
+// its process died of "address already in use" — the one startup failure whose
+// cause has left the process by the time the harness reads the error. Taken
+// the moment the exit is observed, the table usually still shows the occupant
+// (a foreign listener, a lingering client socket, another instance), which a
+// bare EADDRINUSE never does. Empty when the failure is something else or the
+// platform has no /proc.
+func portCollisionDiagnostics(instance *MusterInstance, mp *managedProcess) string {
+	if mp == nil || mp.logCapture == nil {
+		return ""
+	}
+	logs := mp.logCapture.getLogs()
+	if !strings.Contains(logs.Stderr+logs.Stdout, "address already in use") {
+		return ""
+	}
+	occupants := describePortOccupants(instance.Port, instance.MetricsPort)
+	if occupants == "" {
+		occupants = "(no socket on these ports is visible any more)\n"
+	}
+	return fmt.Sprintf("\n--- sockets on the instance's ports %d and %d at failure ---\n%s",
+		instance.Port, instance.MetricsPort, strings.TrimRight(occupants, "\n"))
 }
 
 // findAvailablePort finds an available port starting from the base port with atomic reservation

--- a/internal/testing/muster_manager_port_test.go
+++ b/internal/testing/muster_manager_port_test.go
@@ -52,14 +52,137 @@ func TestFindAvailablePort_HoldsListenerUntilClosed(t *testing.T) {
 	}
 
 	// After releasing the reservation listener (as startMusterProcess does just
-	// before exec), the port becomes available for muster serve to bind.
+	// before exec), the port becomes available for muster serve to bind on the
+	// address it uses. (A wildcard bind stays blocked by the guard listener on
+	// Linux — see TestPortGuard_ProtectsPortThroughExecWindow.)
 	m.closeReservedListener(port)
 
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		t.Fatalf("port %d not bindable after closeReservedListener: %v", port, err)
 	}
 	_ = ln.Close()
+	m.releasePort(port, "inst-hold", m.logger)
+}
+
+// TestPortGuard_ProtectsPortThroughExecWindow is the regression guard for the
+// stolen-port startup failures ("listen tcp 127.0.0.1:<port>: bind: address
+// already in use" from muster serve, CircleCI go-build job 23692): between the
+// probe listener closing for exec and muster serve binding, the kernel's
+// ephemeral port search — what net.Listen(":0") in a mock server and any
+// connect() perform — could hand the port out. The guard listener must keep
+// every wildcard bind on the port failing through that window and until the
+// reservation is released, while muster serve's own 127.0.0.1 bind succeeds,
+// and it must keep a second harness on the same base port from taking it.
+func TestPortGuard_ProtectsPortThroughExecWindow(t *testing.T) {
+	m := newPortTestManager(t, 18800)
+	if !m.portGuards {
+		t.Skip("port guards are only supported on Linux")
+	}
+
+	port, err := m.findAvailablePort("inst-guard", m.logger)
+	if err != nil {
+		t.Fatalf("findAvailablePort failed: %v", err)
+	}
+	if _, ok := m.reservedGuards[port]; !ok {
+		t.Fatalf("no guard listener held for reserved port %d", port)
+	}
+
+	// The exec point: the probe is gone, only the guard protects the port.
+	m.closeReservedListener(port)
+
+	// What an ephemeral steal looks like at the socket level: a wildcard bind on
+	// the port. It must be rejected while the instance owns the port.
+	if ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
+		_ = ln.Close()
+		t.Fatalf("wildcard bind on port %d succeeded during the exec window; the guard did not hold", port)
+	}
+
+	// A second harness process sharing the base port must not be handed it.
+	other := newPortTestManager(t, 18800)
+	otherPort, err := other.findAvailablePort("other-harness", other.logger)
+	if err != nil {
+		t.Fatalf("second manager could not reserve any port: %v", err)
+	}
+	if otherPort == port {
+		t.Fatalf("second manager was handed port %d while the first still owns it", port)
+	}
+	other.releasePort(otherPort, "other-harness", other.logger)
+
+	// muster serve binds 127.0.0.1:<port> for its aggregator and its Prometheus
+	// exporter; that bind must succeed despite the guard.
+	inst, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("instance bind on 127.0.0.1:%d failed while guarded: %v", port, err)
+	}
+	_ = inst.Close()
+
+	// Releasing the reservation drops the guard and returns the port to the OS.
+	m.releasePort(port, "inst-guard", m.logger)
+	if _, ok := m.reservedGuards[port]; ok {
+		t.Fatalf("guard listener for port %d still held after releasePort", port)
+	}
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		t.Fatalf("port %d not bindable after releasePort: %v", port, err)
+	}
+	_ = ln.Close()
+}
+
+// TestFindAvailablePort_SkipsOccupiedInstanceAddress verifies the probe checks
+// the address muster serve actually binds: a foreign listener on
+// 127.0.0.1:<base> must make the allocator move on rather than hand out a port
+// the instance cannot bind.
+func TestFindAvailablePort_SkipsOccupiedInstanceAddress(t *testing.T) {
+	m := newPortTestManager(t, 18900)
+
+	occupant, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", m.basePort))
+	if err != nil {
+		t.Fatalf("could not occupy 127.0.0.1:%d: %v", m.basePort, err)
+	}
+	defer func() { _ = occupant.Close() }()
+
+	port, err := m.findAvailablePort("inst-skip", m.logger)
+	if err != nil {
+		t.Fatalf("findAvailablePort failed: %v", err)
+	}
+	if port == m.basePort {
+		t.Fatalf("allocator handed out occupied port %d", port)
+	}
+	m.releasePort(port, "inst-skip", m.logger)
+}
+
+// TestFindAvailablePort_TakesLowestFreePort documents the allocation order:
+// the lowest free port in the window wins, so a released port is handed to the
+// next instance and the harness's footprint stays compact (see portWindowSize).
+func TestFindAvailablePort_TakesLowestFreePort(t *testing.T) {
+	m := newPortTestManager(t, 19000)
+
+	first, err := m.findAvailablePort("inst-a", m.logger)
+	if err != nil {
+		t.Fatalf("findAvailablePort failed: %v", err)
+	}
+	if first != m.basePort {
+		t.Fatalf("first reservation got %d, want the base port %d", first, m.basePort)
+	}
+	second, err := m.findAvailablePort("inst-b", m.logger)
+	if err != nil {
+		t.Fatalf("findAvailablePort failed: %v", err)
+	}
+	if second != m.basePort+1 {
+		t.Fatalf("second reservation got %d, want %d", second, m.basePort+1)
+	}
+
+	m.releasePort(first, "inst-a", m.logger)
+	third, err := m.findAvailablePort("inst-c", m.logger)
+	if err != nil {
+		t.Fatalf("findAvailablePort failed: %v", err)
+	}
+	if third != first {
+		t.Fatalf("released port %d was not reused; got %d", first, third)
+	}
+	m.releasePort(second, "inst-b", m.logger)
+	m.releasePort(third, "inst-c", m.logger)
 }
 
 // TestFindAvailablePort_DistinctPortsAreHeldSimultaneously verifies that
@@ -140,10 +263,10 @@ func TestFindAvailablePort_FallsBackInsideEphemeralRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("findAvailablePort should fall back inside the ephemeral range, got error: %v", err)
 	}
-	if port < m.basePort || port >= m.basePort+100 {
-		t.Fatalf("fallback port %d outside the configured window [%d, %d)", port, m.basePort, m.basePort+100)
+	if port < m.basePort || port >= m.basePort+portWindowSize {
+		t.Fatalf("fallback port %d outside the configured window [%d, %d)", port, m.basePort, m.basePort+portWindowSize)
 	}
-	m.closeReservedListener(port)
+	m.releasePort(port, "inst-fallback", m.logger)
 }
 
 // TestDetectEphemeralPortRange asserts the detector returns a sane range on any

--- a/internal/testing/port_occupants.go
+++ b/internal/testing/port_occupants.go
@@ -1,0 +1,159 @@
+package testing
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// describePortOccupants reports every TCP socket in this network namespace
+// whose local port is one of ports: local and remote address, state and —
+// when the owning process is visible in this pid namespace — pid and command
+// line. It is attached to instance startup failures that name "address
+// already in use", so a stolen port names its occupant instead of leaving a
+// bare EADDRINUSE. A socket without a visible owner belongs to a process in
+// another pid namespace that shares this network namespace (on CircleCI's v2
+// docker runtime the job container shares its pod's namespace with the task
+// agent). Linux only: it reads /proc/net/tcp{,6} and /proc/*/fd; elsewhere,
+// or if /proc is unavailable, it returns "".
+func describePortOccupants(ports ...int) string {
+	want := make(map[int]bool, len(ports))
+	for _, p := range ports {
+		want[p] = true
+	}
+	var entries []socketEntry
+	for _, path := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		f, err := os.Open(path) //nolint:gosec // one of two fixed /proc tables
+		if err != nil {
+			continue
+		}
+		entries = append(entries, parseProcNetTCP(f, want)...)
+		_ = f.Close()
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+	inodes := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		inodes[e.inode] = true
+	}
+	owners := socketOwners(inodes)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].localPort < entries[j].localPort })
+	var b strings.Builder
+	for _, e := range entries {
+		owner, ok := owners[e.inode]
+		if !ok {
+			owner = "owner not visible in this pid namespace"
+		}
+		fmt.Fprintf(&b, "%s -> %s %s (inode %s, %s)\n", e.local, e.remote, e.state, e.inode, owner)
+	}
+	return b.String()
+}
+
+// socketEntry is one row of /proc/net/tcp{,6} reduced to what the diagnostic
+// prints.
+type socketEntry struct {
+	local     string
+	localPort int
+	remote    string
+	state     string
+	inode     string
+}
+
+// tcpStates maps the hexadecimal st column of /proc/net/tcp to its name.
+var tcpStates = map[string]string{
+	"01": "ESTABLISHED", "02": "SYN_SENT", "03": "SYN_RECV", "04": "FIN_WAIT1",
+	"05": "FIN_WAIT2", "06": "TIME_WAIT", "07": "CLOSE", "08": "CLOSE_WAIT",
+	"09": "LAST_ACK", "0A": "LISTEN", "0B": "CLOSING", "0C": "NEW_SYN_RECV",
+}
+
+// parseProcNetTCP returns the rows of a /proc/net/tcp or /proc/net/tcp6 table
+// whose local port is in want.
+func parseProcNetTCP(r io.Reader, want map[int]bool) []socketEntry {
+	var out []socketEntry
+	sc := bufio.NewScanner(r)
+	sc.Scan() // header
+	for sc.Scan() {
+		f := strings.Fields(sc.Text())
+		// sl local_address rem_address st tx_queue:rx_queue tr:tm->when retrnsmt uid timeout inode ...
+		if len(f) < 10 {
+			continue
+		}
+		local, lport, ok := decodeProcAddr(f[1])
+		if !ok || !want[lport] {
+			continue
+		}
+		remote, _, _ := decodeProcAddr(f[2])
+		state, ok := tcpStates[strings.ToUpper(f[3])]
+		if !ok {
+			state = "state " + f[3]
+		}
+		out = append(out, socketEntry{local: local, localPort: lport, remote: remote, state: state, inode: f[9]})
+	}
+	return out
+}
+
+// decodeProcAddr turns a /proc/net/tcp address ("0100007F:7541" or its 32-hex
+// IPv6 form) into "host:port" and the port. The kernel prints each 32-bit
+// word of the address in host byte order.
+func decodeProcAddr(s string) (string, int, bool) {
+	host, portHex, ok := strings.Cut(s, ":")
+	if !ok {
+		return "", 0, false
+	}
+	port64, err := strconv.ParseUint(portHex, 16, 16)
+	if err != nil {
+		return "", 0, false
+	}
+	raw, err := hex.DecodeString(host)
+	if err != nil || (len(raw) != 4 && len(raw) != 16) {
+		return "", 0, false
+	}
+	ip := make(net.IP, len(raw))
+	for i := 0; i < len(raw); i += 4 {
+		ip[i], ip[i+1], ip[i+2], ip[i+3] = raw[i+3], raw[i+2], raw[i+1], raw[i]
+	}
+	return net.JoinHostPort(ip.String(), strconv.Itoa(int(port64))), int(port64), true
+}
+
+// socketOwners maps socket inodes to "pid N (cmdline)" for every process in
+// this pid namespace whose fd table references the socket. Processes that
+// cannot be inspected are skipped.
+func socketOwners(inodes map[string]bool) map[string]string {
+	owners := make(map[string]string)
+	procs, err := filepath.Glob("/proc/[0-9]*/fd")
+	if err != nil {
+		return owners
+	}
+	for _, fdDir := range procs {
+		fds, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue
+		}
+		for _, fd := range fds {
+			target, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+			if err != nil || !strings.HasPrefix(target, "socket:[") {
+				continue
+			}
+			inode := strings.TrimSuffix(strings.TrimPrefix(target, "socket:["), "]")
+			if !inodes[inode] {
+				continue
+			}
+			pidDir := filepath.Dir(fdDir)
+			cmdline, _ := os.ReadFile(filepath.Join(pidDir, "cmdline")) //nolint:gosec // /proc/<pid>/cmdline from a /proc glob
+			cmd := strings.TrimSpace(strings.ReplaceAll(string(cmdline), "\x00", " "))
+			if len(cmd) > 120 {
+				cmd = cmd[:120] + "…"
+			}
+			owners[inode] = fmt.Sprintf("pid %s (%s)", filepath.Base(pidDir), cmd)
+		}
+	}
+	return owners
+}

--- a/internal/testing/port_occupants_test.go
+++ b/internal/testing/port_occupants_test.go
@@ -1,0 +1,106 @@
+package testing
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestParseProcNetTCP_DecodesAddressesAndStates pins the /proc/net/tcp row
+// format the diagnostic depends on: host-byte-order hex addresses, hex port,
+// hex state, inode in column 10.
+func TestParseProcNetTCP_DecodesAddressesAndStates(t *testing.T) {
+	table := "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n" +
+		"   0: 0100007F:7541 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0\n" +
+		"   1: 0100007F:7541 0100007F:9C40 06 00000000:00000000 00:00000000 00000000     0        0 0 1 0000000000000000 100 0 0 10 0\n" +
+		"   2: 0100007F:7542 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 777 1 0000000000000000 100 0 0 10 0\n"
+	entries := parseProcNetTCP(strings.NewReader(table), map[int]bool{30017: true})
+	if len(entries) != 2 {
+		t.Fatalf("want 2 rows for port 30017, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].local != "127.0.0.1:30017" || entries[0].state != "LISTEN" || entries[0].inode != "12345" {
+		t.Fatalf("unexpected first row: %+v", entries[0])
+	}
+	if entries[1].remote != "127.0.0.1:40000" || entries[1].state != "TIME_WAIT" {
+		t.Fatalf("unexpected second row: %+v", entries[1])
+	}
+
+	v6 := "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n" +
+		"   0: 00000000000000000000000001000000:7541 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 42 1 0000000000000000 100 0 0 10 0\n"
+	entries = parseProcNetTCP(strings.NewReader(v6), map[int]bool{30017: true})
+	if len(entries) != 1 || entries[0].local != "[::1]:30017" {
+		t.Fatalf("unexpected IPv6 decode: %+v", entries)
+	}
+}
+
+// TestDescribePortOccupants_NamesThisProcess holds a listener and checks the
+// diagnostic reports it as LISTEN owned by this process.
+func TestDescribePortOccupants_NamesThisProcess(t *testing.T) {
+	if _, err := os.Stat("/proc/net/tcp"); err != nil {
+		t.Skip("/proc/net/tcp not available")
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	got := describePortOccupants(port)
+	if !strings.Contains(got, fmt.Sprintf("127.0.0.1:%d", port)) || !strings.Contains(got, "LISTEN") {
+		t.Fatalf("diagnostic does not show the held listener:\n%s", got)
+	}
+	if !strings.Contains(got, fmt.Sprintf("pid %d ", os.Getpid())) {
+		t.Fatalf("diagnostic does not attribute the listener to this process:\n%s", got)
+	}
+}
+
+// TestProcessExitedError_NamesPortOccupant checks the startup-failure error
+// carries the socket table for the instance's ports when the process died of
+// "address already in use", and stays quiet for any other exit.
+func TestProcessExitedError_NamesPortOccupant(t *testing.T) {
+	if _, err := os.Stat("/proc/net/tcp"); err != nil {
+		t.Skip("/proc/net/tcp not available")
+	}
+	m := newPortTestManager(t, 19100)
+
+	// The "thief": a listener on the port the instance was going to use for
+	// its metrics exporter.
+	thief, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = thief.Close() }()
+	metricsPort := thief.Addr().(*net.TCPAddr).Port
+	instance := &MusterInstance{ID: "inst-diag", Port: 19100, MetricsPort: metricsPort}
+
+	capture := func(stderr string) *managedProcess {
+		lc := newLogCapture()
+		_, _ = lc.stderrWriter.Write([]byte(stderr))
+		lc.close()
+		return &managedProcess{logCapture: lc, waitErr: errors.New("exit status 1"), exited: make(chan struct{})}
+	}
+
+	err = m.processExitedError(instance, capture(fmt.Sprintf(
+		"Error: init meter: otel metric reader: binding address 127.0.0.1:%d for Prometheus exporter: listen tcp 127.0.0.1:%d: bind: address already in use\n",
+		metricsPort, metricsPort)), m.logger)
+	msg := err.Error()
+	for _, want := range []string{
+		fmt.Sprintf("sockets on the instance's ports 19100 and %d at failure", metricsPort),
+		fmt.Sprintf("127.0.0.1:%d -> ", metricsPort),
+		"LISTEN",
+		fmt.Sprintf("pid %d ", os.Getpid()),
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error lacks %q:\n%s", want, msg)
+		}
+	}
+
+	err = m.processExitedError(instance, capture("Error: something unrelated\n"), m.logger)
+	if strings.Contains(err.Error(), "sockets on the instance's ports") {
+		t.Fatalf("diagnostics attached to an unrelated failure:\n%s", err)
+	}
+}

--- a/internal/testing/test_reporter.go
+++ b/internal/testing/test_reporter.go
@@ -50,6 +50,10 @@ func (r *testReporter) ReportStart(config TestConfiguration) {
 	// worth one line in every CI log.
 	fmt.Printf("🏗️  Using managed muster instances (base port: %d, GOMAXPROCS: %d, NumCPU: %d)\n",
 		config.BasePort, runtime.GOMAXPROCS(0), runtime.NumCPU())
+	// The ephemeral range vs the port window is the precondition for stolen
+	// instance ports ("address already in use" at startup); the guard state
+	// says whether the harness is immune to it on this platform.
+	fmt.Printf("🔌 Port allocation: %s\n", PortAllocationBanner(config.BasePort))
 
 	if r.verbose {
 		fmt.Printf("\n⚙️  Configuration:\n")


### PR DESCRIPTION
## Flake

CircleCI go-build job 23692 (PR #1128): `downstream-tool-call-metrics` died at startup with

```
Error: init meter: otel metric reader: binding address 127.0.0.1:30017 for Prometheus exporter: listen tcp 127.0.0.1:30017: bind: address already in use
```

201/202 passed; the job was rerun-from-failed. Across the last 160 pipelines (177 go-build jobs, 70 failed, 34 with a stored test report) this is the only bind collision; the other red jobs are readiness timeouts, step expectation mismatches and the `core_auth_login` server-not-found race.

## What the harness does today

The harness reserves a port by holding a probe listener on it and closes that listener right before `exec` so `muster serve` can bind. Between the close and muster's bind (exec plus process startup, roughly 20–50 ms on the CI box) the port is unbound. #763 shrank that window from seconds to this; it did not close it.

From the failed job's JSON report the failing instance was the 9th created (ports 30016/30017 had never been handed out before it), so no earlier muster process can have held 30017, and it died about 100 ms after the first instances had become ready.

## Mechanism proven and closed by this PR

The kernel's ephemeral-port search — what a mock server's `net.Listen(":0")` and every `connect()` perform — hands out any port in `ip_local_port_range` that is momentarily unbound. If that range covers the harness's port window, an instance port in its exec window is a candidate. The harness's existing defense (prefer ports outside the range) silently does nothing when the whole window lies inside the range: it falls back to allocating inside anyway and logs a warning at Info level, which the per-scenario logger drops unless the run is verbose.

Reproduced in a CI-like container (debian, `--cpus=4 --memory=8g`, overlayfs `/tmp`, the CI command) with the ephemeral range pinned onto the window via `--sysctl net.ipv4.ip_local_port_range`:

| condition | binary | runs | startup bind collisions |
|---|---|---|---|
| range 32768–60999 (default) | main | 110 | 0 |
| range 1024–65535 | main | 10 | 0 |
| range 25000–35000 | main | 10 | 0 |
| range 30000–31999 | main | 40 | 1 (aggregator port 30013, exit 0) |
| range 30000–31999 | this PR | 30 | 0 |
| range 30000–30199 + external process cycling `net.Listen(":0")` (32 held × 100 ms), `--parallel 8` | main | 10 | 7 failing runs, 31 scenarios, 26 distinct ports — both shapes: exporter (exit 1) and aggregator (exit 0) |
| same | this PR | 30 | 0 |

The hammer's port histogram shows the kernel handing out odd ports first for `bind(":0")`, as the source says (`connect()` gets the other parity), and collisions concentrate in the first run of a fresh namespace: a port an instance has used carries its TIME_WAIT sockets for a minute, and those already block ephemeral listeners.

### Fix

Hold a second listener on `127.0.0.2:<port>` for the lifetime of each reservation. Linux bind-conflict rules make a listener on a specific loopback address reject every wildcard bind on the port — which is exactly how the ephemeral search allocates — and a second harness's guard on the same port, while a bind of the *different* specific address `127.0.0.1:<port>` — what `muster serve` uses for both its aggregator (`localhost:<port>` resolves to it for listen) and its Prometheus exporter — still succeeds. Verified with a standalone program and encoded in `TestPortGuard_ProtectsPortThroughExecWindow`. The probe now binds `127.0.0.1:<port>` (the address the instance will use) because a wildcard probe would collide with the harness's own guard; `TestFindAvailablePort_SkipsOccupiedInstanceAddress` covers foreign occupants. Non-Linux platforms keep the probe-only strategy and the warning (macOS has no 127.0.0.2 alias; other kernels' conflict rules were not verified).

Also:

- run banner: `🔌 Port allocation: port window: [a, b], ephemeral range: [lo, hi], port guards: on|off`
- allocation takes the lowest free port instead of advancing a cursor that reset relative to the scan index (`portOffset = i + 1`). That cursor was not the cause. A rotating variant I tried spread the harness's TIME_WAIT footprint over the whole window, which starved mock servers when the window overlaps the ephemeral range; lowest-free keeps the footprint compact, as the old code effectively did.
- `releasePort` closes a port's listeners only when the caller owns the reservation.

## What this does not explain

The banner from this PR's own go-build job says the CircleCI executor's ephemeral range is the default **32768–60999**, so the port window is outside it there and the mechanism above cannot have produced job 23692. Nothing in muster or the harness binds a port it did not reserve (no port arithmetic, one meter init per process, mock servers bind `:0`), and the port had never been used in that run, so no TIME_WAIT socket can have been on it. The spin-up log shows CircleCI's v2 docker runtime: a pause container's network namespace shared by the job container and a separately downloaded task agent — a foreign process on the same loopback whose sockets a process listing inside the job container cannot show.

So the second commit makes the next occurrence self-explaining: when an instance dies of "address already in use", the failure report now includes every socket on the instance's two ports from `/proc/net/tcp{,6}` — addresses, state, inode and, where the owner is in this pid namespace, pid and command line. A socket with no visible owner points at the shared-namespace neighbour. Please read that section before treating a recurrence as the same flake.
