### PR TITLE
fix(aggregator): tool calls resolve an OAuth server's issuer themselves — sessions survive a muster restart

### DIFF
--- a/internal/aggregator/auth_info_resolve.go
+++ b/internal/aggregator/auth_info_resolve.go
@@ -1,0 +1,93 @@
+package aggregator
+
+import (
+	"context"
+	"strings"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// GetAuthInfo returns the server's OAuth information, or nil.
+func (s *ServerInfo) GetAuthInfo() *AuthInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.AuthInfo
+}
+
+// SetAuthInfo records the server's OAuth information on the registry entry.
+func (s *ServerInfo) SetAuthInfo(info *AuthInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AuthInfo = info
+}
+
+// oauthProtected reports whether tool calls on the server run on a per-session
+// OAuth connection: the MCPServer declares auth type oauth, or the server
+// answered muster's probe with a 401 (a 401-time AuthInfo exists). Servers
+// that forward or exchange the caller's token are decided before this.
+func oauthProtected(s *ServerInfo) bool {
+	if s.GetAuthInfo() != nil {
+		return true
+	}
+	return s.AuthConfig != nil && strings.EqualFold(s.AuthConfig.Type, "oauth")
+}
+
+// resolveServerAuthInfo returns the server's OAuth information with the
+// issuer (and scope, resource) filled in from its RFC 9728 metadata or its
+// pinned authorization server (spec.auth.authorizationServer), and records the
+// result on the registry entry so every later caller finds it.
+//
+// The 401 that registers a server as pending auth carries only the
+// resource-metadata pointer, not the issuer. Until now only a full
+// core_auth_login filled the issuer in -- by mutating the entry's AuthInfo as
+// a side effect -- and a session whose authenticated flag outlived a muster
+// restart never runs one (its login short-circuits with "already
+// authenticated"), so its tool calls could not choose an auth method.
+//
+// A pin that cannot be applied is an error (the login must not proceed with
+// a client the operator did not intend); a discovery failure is logged and
+// leaves the caller with whatever the entry already knew.
+func (a *AggregatorServer) resolveServerAuthInfo(ctx context.Context, serverInfo *ServerInfo) (*AuthInfo, error) {
+	authInfo := &AuthInfo{}
+	if current := serverInfo.GetAuthInfo(); current != nil {
+		copied := *current
+		authInfo = &copied
+	}
+	if !needsResourceMetadata(authInfo, serverInfo.URL) {
+		return authInfo, nil
+	}
+
+	if err := pinAuthorizationServer(ctx, serverInfo); err != nil {
+		return nil, err
+	}
+	var override *api.MCPServerAuthAuthorizationServer
+	if serverInfo.AuthConfig != nil {
+		override = serverInfo.AuthConfig.AuthorizationServer
+	}
+	metadata, err := discoverProtectedResourceMetadata(ctx, serverInfo.URL, override)
+	if err != nil {
+		logging.Warn("AuthTools", "Failed to discover protected resource metadata for %s: %v", serverInfo.Name, err)
+		return authInfo, nil
+	}
+
+	changed := false
+	if authInfo.Issuer == "" && metadata.Issuer != "" {
+		authInfo.Issuer = metadata.Issuer
+		changed = true
+		logging.Info("AuthTools", "Discovered authorization server for %s: %s", serverInfo.Name, metadata.Issuer)
+	}
+	if authInfo.Scope == "" && metadata.Scope != "" {
+		authInfo.Scope = metadata.Scope
+		changed = true
+		logging.Info("AuthTools", "Discovered required scope for %s: %s", serverInfo.Name, metadata.Scope)
+	}
+	if authInfo.Resource == "" && metadata.Resource != "" {
+		authInfo.Resource = metadata.Resource
+		changed = true
+	}
+	if changed {
+		serverInfo.SetAuthInfo(authInfo)
+	}
+	return authInfo, nil
+}

--- a/internal/aggregator/auth_info_resolve_test.go
+++ b/internal/aggregator/auth_info_resolve_test.go
@@ -1,0 +1,67 @@
+package aggregator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+func TestResolveServerAuthInfo(t *testing.T) {
+	ctx := context.Background()
+	a := &AggregatorServer{}
+
+	t.Run("fills the issuer from the pinned authorization server without a login and records it", func(t *testing.T) {
+		handler := &pinCaptureHandler{mockOAuthHandler: newMockOAuthHandler(true), pins: map[string]api.IssuerPin{}}
+		api.RegisterOAuthHandler(handler)
+		defer api.RegisterOAuthHandler(nil)
+		secrets := &mockSecretCredentialsHandler{credentials: &api.ClientCredentials{ClientID: "Iv23liApp", ClientSecret: "shh"}}
+		api.RegisterSecretCredentialsHandler(secrets)
+		defer api.RegisterSecretCredentialsHandler(nil)
+
+		// What the 401 at registration leaves behind after a restart: the
+		// resource-metadata pointer, no issuer.
+		server := githubStyleServer(&api.ClientCredentialsSecretRef{Name: "github-oauth-client"}, api.GrantScopeSubject)
+		server.AuthInfo = &AuthInfo{ResourceMetadataURL: "https://api.githubcopilot.com/.well-known/oauth-protected-resource"}
+
+		info, err := a.resolveServerAuthInfo(ctx, server)
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/login/oauth", info.Issuer)
+		assert.Equal(t, "repo read:org", info.Scope)
+		assert.NotEmpty(t, info.Resource)
+		assert.Equal(t, "https://api.githubcopilot.com/.well-known/oauth-protected-resource", info.ResourceMetadataURL, "the 401-time fields are kept")
+
+		assert.Equal(t, info, server.GetAuthInfo(), "recorded on the registry entry for every later caller")
+		assert.Contains(t, handler.pins, "https://github.com/login/oauth", "the pin is applied on the way")
+		assert.True(t, oauthProtected(server))
+	})
+
+	t.Run("leaves a complete AuthInfo alone and touches no handler", func(t *testing.T) {
+		api.RegisterOAuthHandler(nil)
+		complete := &AuthInfo{Issuer: "https://issuer.example", Scope: "read", Resource: "https://mcp.example/mcp"}
+		server := &ServerInfo{Name: "done", URL: "https://mcp.example/mcp", AuthInfo: complete}
+
+		info, err := a.resolveServerAuthInfo(ctx, server)
+		require.NoError(t, err)
+		assert.Equal(t, *complete, *info)
+		assert.Same(t, complete, server.GetAuthInfo())
+	})
+
+	t.Run("reports a pin it cannot apply instead of guessing", func(t *testing.T) {
+		api.RegisterOAuthHandler(nil)
+		server := githubStyleServer(&api.ClientCredentialsSecretRef{Name: "github-oauth-client"}, api.GrantScopeSubject)
+
+		_, err := a.resolveServerAuthInfo(ctx, server)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OAuth proxy is disabled")
+	})
+
+	t.Run("a server without auth is not OAuth-protected", func(t *testing.T) {
+		assert.False(t, oauthProtected(&ServerInfo{Name: "plain"}))
+		assert.False(t, oauthProtected(&ServerInfo{Name: "fwd", AuthConfig: &api.MCPServerAuth{Type: "forward"}}))
+		assert.True(t, oauthProtected(&ServerInfo{Name: "oauth", AuthConfig: &api.MCPServerAuth{Type: "oauth"}}))
+	})
+}

--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -192,48 +192,22 @@ func (p *AuthToolProvider) handleAuthLogin(ctx context.Context, args map[string]
 		}, nil
 	}
 
-	// Get the auth info for this server
-	authInfo := serverInfo.AuthInfo
-	if authInfo == nil {
-		authInfo = &AuthInfo{}
-	}
-
-	// Fill in whatever the flow still lacks from the server's resource
-	// metadata. When spec.auth.authorizationServer is set on the MCPServer CR,
-	// the override branch in discoverProtectedResourceMetadata bypasses PRM
-	// probing and uses the operator-pinned issuer directly (with RFC 8414 §3.3
-	// self-verification).
-	if needsResourceMetadata(authInfo, serverInfo.URL) {
-		var override *api.MCPServerAuthAuthorizationServer
-		if serverInfo.AuthConfig != nil {
-			override = serverInfo.AuthConfig.AuthorizationServer
+	// The auth info for this server: the 401-time fields plus whatever the
+	// flow still lacks from the server's resource metadata or its pin
+	// (spec.auth.authorizationServer -- the override branch in
+	// discoverProtectedResourceMetadata bypasses PRM probing and uses the
+	// operator-pinned issuer). The result is recorded on the registry entry,
+	// so the tool calls of every session find the issuer as well.
+	authInfo, err := p.aggregator.resolveServerAuthInfo(ctx, serverInfo)
+	if err != nil {
+		logging.Warn("AuthTools", "Cannot apply the authorization server pin of %s: %v", serverName, err)
+		if p.aggregator.authMetrics != nil {
+			p.aggregator.authMetrics.RecordLoginFailure(serverName, sub, "authorization_server_pin_failed")
 		}
-		if err := pinAuthorizationServer(ctx, serverInfo); err != nil {
-			logging.Warn("AuthTools", "Cannot apply the authorization server pin of %s: %v", serverName, err)
-			if p.aggregator.authMetrics != nil {
-				p.aggregator.authMetrics.RecordLoginFailure(serverName, sub, "authorization_server_pin_failed")
-			}
-			return &api.CallToolResult{
-				Content: []any{fmt.Sprintf("Cannot authenticate to '%s': %v", serverName, err)},
-				IsError: true,
-			}, nil
-		}
-		metadata, err := discoverProtectedResourceMetadata(ctx, serverInfo.URL, override)
-		if err != nil {
-			logging.Warn("AuthTools", "Failed to discover protected resource metadata for %s: %v", serverName, err)
-		} else {
-			if authInfo.Issuer == "" {
-				authInfo.Issuer = metadata.Issuer
-				logging.Info("AuthTools", "Discovered authorization server for %s: %s", serverName, metadata.Issuer)
-			}
-			if authInfo.Scope == "" && metadata.Scope != "" {
-				authInfo.Scope = metadata.Scope
-				logging.Info("AuthTools", "Discovered required scope for %s: %s", serverName, metadata.Scope)
-			}
-			if authInfo.Resource == "" && metadata.Resource != "" {
-				authInfo.Resource = metadata.Resource
-			}
-		}
+		return &api.CallToolResult{
+			Content: []any{fmt.Sprintf("Cannot authenticate to '%s': %v", serverName, err)},
+			IsError: true,
+		}, nil
 	}
 
 	// If still empty, we can't proceed

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -3101,12 +3101,28 @@ func (a *AggregatorServer) getOrCreateClientForToolCall(
 			return nil, nil, err
 		}
 
-	} else if issuer, scope := sessionOAuthIssuer(serverInfo); issuer != "" {
+	} else if oauthProtected(serverInfo) {
 		oauthHandler := api.GetOAuthHandler()
 		if oauthHandler == nil || !oauthHandler.IsEnabled() {
 			return nil, nil, fmt.Errorf("OAuth handler not available for %s", serverName)
 		}
 
+		// What the 401 discovered, else the operator's pin. A server that
+		// registered from its 401 alone after a restart and has no pin knows
+		// neither: resolve its RFC 9728 metadata once and record it on the
+		// entry, so a session that is already authenticated -- and therefore
+		// never runs core_auth_login again -- can still open its connection.
+		issuer, scope := sessionOAuthIssuer(serverInfo)
+		if issuer == "" {
+			authInfo, err := a.resolveServerAuthInfo(ctx, serverInfo)
+			if err != nil {
+				return nil, nil, fmt.Errorf("resolve the authorization server of %s: %w", serverName, err)
+			}
+			issuer, scope = authInfo.Issuer, authInfo.Scope
+		}
+		if issuer == "" {
+			return nil, nil, fmt.Errorf("unable to determine auth method for server %s: its OAuth issuer is unknown (no RFC 9728 metadata, no spec.auth.authorizationServer pin)", serverName)
+		}
 		tokenStore := internalmcp.NewMusterTokenStore(sessionID, sub, issuer, oauthHandler)
 		clientID, clientSecret := oauthHandler.GetClientCredentialsForIssuer(ctx, issuer)
 		client = internalmcp.NewDynamicAuthClient(serverInfo.URL, tokenStore, scope, clientID, clientSecret).


### PR DESCRIPTION
## What

After a muster restart, a session that had connected an OAuth server before the roll could not use it any more: tool calls failed with `unable to determine auth method for server github` while `core_auth_login` answered "already authenticated" (gazelle, 5.8.3 roll at 16:56Z today). The restart re-registers the server from its 401 alone (resource-metadata pointer, no issuer); only a full `core_auth_login` filled the issuer in, by mutating the registry entry's `AuthInfo` in passing; and the session auth flags are persisted, so a connected session never runs that login again.

#1152 (5.9.0) covers the pinned case: `sessionOAuthIssuer` falls back to `spec.auth.authorizationServer` — that is what healed gazelle's `github` and `gazelle-mcp-pro` (verified: a CLI session connected before the roll calls both without a login on 5.9.0). This PR covers the rest of the shape:

- **Servers without a pin** (any RFC 9728 server: the 401 carries only the metadata pointer) get their issuer resolved on the first tool call after a restart — `resolveServerAuthInfo` runs the same discovery `core_auth_login` runs (pin, then RFC 9728 metadata) and records the result on the registry entry via `SetAuthInfo`, so later callers find it without another lookup. Only when `sessionOAuthIssuer` knows nothing; a pinned server keeps the network-free path of #1152.
- **`core_auth_login` shares that helper** instead of mutating the entry's `AuthInfo` pointer as a side effect of discovery.
- The final error names what is missing (no RFC 9728 metadata, no pin) instead of the bare "unable to determine auth method".

## Tests

`internal/aggregator/auth_info_resolve_test.go`: the restart shape (metadata pointer without issuer + pinned GitHub AS) resolves and is recorded on the entry; a complete `AuthInfo` is left alone without touching the handler; an unapplicable pin is an error; `oauthProtected` on none/forward/oauth. Aggregator package green after the rebase onto #1152.