### PR TITLE
feat(metatools): per-request toolsets — X-Muster-Toolset header, toolsetPresets, filter_tools toolset argument, annotation forwarding, workflow read-only derivation

### DIFF
--- a/docs/contributing/testing/scenarios.md
+++ b/docs/contributing/testing/scenarios.md
@@ -35,6 +35,8 @@ pre_configuration:
         tools:
           - name: "tool-name"          # Simple name in mock config
             description: "Tool description"
+            annotations:                 # Optional MCP tool annotations the mock declares
+              read_only_hint: true       # (read_only_hint, destructive_hint, idempotent_hint, open_world_hint)
             input_schema:
               type: "object"
               properties:
@@ -516,6 +518,35 @@ cleanup:
   - id: "delete-resource"
     # ... proper cleanup
 ```
+
+## Per-Request Headers
+
+A step can send HTTP headers on its own requests to the muster instance with `headers:`. They
+apply to that step only — same client, same MCP session as the surrounding steps, including the
+`wait_for_state` polls — which is how a scenario proves per-request evaluation of a header such
+as `X-Muster-Toolset`: two steps on one session with different headers, then one without.
+
+```yaml
+steps:
+  - id: scoped
+    tool: test_call_meta_tool
+    args: { tool: "list_tools" }
+    headers:
+      X-Muster-Toolset: "preset:read-only,workflow:incident-triage"
+    expected:
+      success: true
+      not_contains: ["x_kubernetes_delete"]
+
+  - id: unscoped-again
+    tool: test_call_meta_tool
+    args: { tool: "list_tools" }
+    expected:
+      success: true
+      contains: ["x_kubernetes_delete"]
+```
+
+Regular tool steps (`tool: x_server_tool`) carry the headers too, since they go through
+`call_tool` on the same client.
 
 ## Multi-User Testing
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -49,6 +49,7 @@ Technical reference for commands, APIs, and configurations. Find exact syntax, p
   - [Workflow Tools](mcp-tools.md#workflow-tools) - Workflow definition and execution management
   - [Dynamic Workflow Execution](mcp-tools.md#dynamic-workflow-execution-tools) - `workflow_<name>` tools
   - [External Tools](mcp-tools.md#external-tools) - Tools from connected MCP servers
+- **[Toolsets](toolsets.md)** - Declared toolsets: the `X-Muster-Toolset` header, inline selector grammar, `toolsetPresets` configuration, built-in presets, per-request evaluation and the refusal
 
 ### Configuration
 - **[Configuration Reference](configuration.md)** - Complete system configuration documentation

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -58,6 +58,31 @@ namespace: "default"            # Kubernetes namespace for CR discovery (default
 | `kubernetes` | `bool` | `false` | Enable Kubernetes CRD mode. When `true`, uses Kubernetes CRDs for resource storage and requires the apiserver: if the Kubernetes client cannot be created at startup (apiserver unreachable, muster CRDs not installed), `muster serve` retries for about half a minute and then exits with an error instead of falling back to the filesystem, so the kubelet restarts it. When `false`, uses filesystem YAML files. The Helm chart sets this to `true` by default. |
 | `aggregator` | `AggregatorConfig` | see below | Aggregator service configuration |
 | `auth` | `AuthConfig` | see below | Authentication settings for CLI |
+| `toolsetPresets` | `map[string]Preset` | `{}` | Toolset presets an agent's `X-Muster-Toolset` header can name as `preset:<name>`; `read-only`, `none` and `full` are built in and cannot be redefined. See [Toolsets](toolsets.md). |
+
+### Toolset Presets
+
+Presets are named selections of the tool catalogue that a request's `X-Muster-Toolset` header
+(or the `filter_tools` `toolset` argument) references as `preset:<name>`. They are evaluated
+against the live catalogue on every request. Each rule sets exactly one of `tool`, `pattern`,
+`server`, `workflow`, `readOnly: true`, `preset` (composition, include only) or `label`
+(presets only; see [Toolsets](toolsets.md)).
+
+```yaml
+toolsetPresets:
+  infrastructure:
+    description: Every infrastructure server, without deletes
+    include:
+      - server: mcp-kubernetes
+      - server: mcp-prometheus
+    exclude:
+      - pattern: "*_delete"
+```
+
+`read-only`, `none` and `full` are built in; configuration that redefines one, sets a rule with
+no key or more than one, uses an invalid `pattern`, composes an unknown preset or cycles fails
+`muster serve` at startup with the preset named. The Helm chart exposes this block as
+`muster.toolsetPresets`.
 
 ### Aggregator Configuration
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -29,8 +29,12 @@ Reference guide for AI agents and MCP clients working with Muster's tools. This 
 | `include_schema` | bool | `false` | Return full descriptions **and** input schemas instead of one-line summaries. |
 | `limit` | number | `25` | Max tools per page. |
 | `offset` | number | `0` | Tools to skip before this page. |
+| `toolset` | string[] | — | Inline toolset selectors (`preset:<name>`, `server:<name>`, `workflow:<name>`, `tool:<name>`, at most 32) to resolve against the caller's catalogue. The response adds `toolset` (echo), `toolset_unmatched` (selectors that selected nothing for the caller) and `presets`. With `X-Muster-Toolset` also on the request, the argument resolves within the header's toolset and never widens it. See [Toolsets](toolsets.md). |
+| `include_presets` | bool | `false` | Add the known toolset presets (`name`, `description`, `built_in`) to the response. |
 
-The response carries `total` (matches across the whole catalogue), `truncated` (more matches exist beyond this page), and per-tool a one-line `summary` (plus `score` when ranked and `labels` when present). Get the authoritative full schema of a chosen tool with `describe_tool` before executing it.
+The response carries `total` (matches across the caller's catalogue), `truncated` (more matches exist beyond this page), and per-tool a one-line `summary` (plus `score` when ranked and `labels` when present), the owning `server` (omitted for workflows and core tools), the `kind` (`tool` | `workflow` | `core`) and the tool's `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` as the server declared them; for a workflow the derived `readOnlyHint` when every step tool is read-only; omitted when none). Get the authoritative full schema of a chosen tool with `describe_tool` before executing it — it carries the same `server`, `kind` and `annotations`.
+
+When the request declares a toolset (`X-Muster-Toolset` header), every discovery meta-tool reads the catalogue intersected with it, `call_tool` refuses anything outside it (`tool "<name>" is outside the toolset [<selectors>]`), and an invalid toolset (empty, unknown preset, reserved `toolset:`, inline `label:`, more than 32 selectors, malformed) is an error result on every meta-tool call. Without the header nothing changes.
 
 ```bash
 # Rank workflows by intent instead of guessing a pattern
@@ -47,7 +51,7 @@ filter_tools(pattern="*workflow*", limit=25, offset=25)
 
 | Meta-Tool | Description | Arguments |
 |-----------|-------------|-----------|
-| `call_tool` | Execute any tool by name | `{"name": "tool_name", "arguments": {...}}` |
+| `call_tool` | Execute any tool by name. With `X-Muster-Toolset` on the request, only tools inside the toolset can be called; others are refused naming the toolset (see [Toolsets](toolsets.md)) | `{"name": "tool_name", "arguments": {...}}` |
 
 **Example:**
 ```json

--- a/docs/reference/toolsets.md
+++ b/docs/reference/toolsets.md
@@ -1,0 +1,182 @@
+# Toolsets Reference
+
+A **toolset** is the selector list an agent declares to say which of the gateway's tools it is
+composed with. muster evaluates it **per request**, statelessly, as the third filter on the
+caller's catalogue — after server-authentication visibility and workflow availability — so
+`list_tools`, `filter_tools`, `describe_tool`, `list_core_tools`, the resource and prompt
+accessors and `call_tool` all answer within it.
+
+A toolset never widens access. The catalogue it filters is already the caller's own: a tool
+from a server the session has not signed in to is not in the catalogue, so a selector naming
+it matches nothing. The invoking human's identity and the backends' own authorization
+remain the boundary; a toolset bounds what the *model* can discover and call.
+
+## Declaring a toolset
+
+### The `X-Muster-Toolset` request header
+
+```http
+X-Muster-Toolset: preset:read-only, workflow:incident-triage
+```
+
+A comma-separated list of inline selectors; whitespace around each selector is trimmed. The
+header is read on **every** request. Nothing is bound to the MCP session: two requests on the
+same session with different headers get different catalogues, and a request without the header
+is unscoped — exactly today's behaviour. muster's session for a forwarded token is derived from
+the token, so all the agents one person drives share one session; per-request evaluation is
+what keeps agent A's toolset from applying to agent B.
+
+The platform's Generic `agent` chart renders this header from its `toolset` value onto the
+agent's muster tool entry (`headersFrom`), so an agent declares its toolset once, on its own
+release.
+
+### Inline selector grammar
+
+| Selector | Selects |
+|---|---|
+| `preset:<name>` | A preset from `toolsetPresets` or a built-in (below). |
+| `server:<name>` | Every tool of the MCPServer `<name>`. For a family, the family name selects the family surface; a member's name selects it too. |
+| `workflow:<name>` | The workflow's execution tool (`workflow_<name>`). |
+| `tool:<name>` | One tool by its exposed name (`x_<server>_<tool>`, `workflow_<name>`, `core_*`). |
+
+Names are exact and case-sensitive (regex `^(preset|server|workflow|tool):[^\s,]+$`). At most
+**32** selectors inline — larger selections are presets. Core tools (`core_*`) are selectable
+only explicitly: `tool:core_workflow_list` inline, `pattern: core_*` in a preset. There is no
+`core` pseudo-server.
+
+Rejected inline, with an error naming the toolset and the selector:
+
+| Input | Error |
+|---|---|
+| empty header / empty list | `toolset [] is empty; use "preset:none" for an agent without tools` |
+| `toolset:<name>` | `… selector "toolset:x" is reserved for shared toolsets` |
+| `label:<k>=<v>` | `… selector "label:…" is allowed inside presets only` |
+| anything else | `… selector "…" is malformed; expected preset:<name>, server:<name>, workflow:<name> or tool:<name>` |
+| more than 32 | `toolset [...] has 33 selectors, more than the 32 allowed inline; define a preset` |
+| unknown preset | `toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full, …` |
+
+These are **error results on every meta-tool call** — including `get_resource` and
+`get_prompt` — never a silent fall-back to the unscoped catalogue and never silent degradation
+to the selectors that did parse. They are not sticky: the next request without the header is
+unscoped again.
+
+## Presets
+
+Presets are muster configuration (`toolsetPresets:` in `config.yaml`; chart value
+`muster.toolsetPresets`, rendered into the ConfigMap). They are GitOps-managed by
+construction and evaluated against the live catalogue on each request, so a preset selecting
+by server or by annotation stays correct when a server adds tools.
+
+```yaml
+toolsetPresets:
+  infrastructure:
+    description: Every infrastructure server, without deletes
+    include:
+      - server: mcp-kubernetes
+      - server: mcp-prometheus
+    exclude:
+      - pattern: "*_delete"
+  safe-ops:
+    description: infrastructure narrowed to read-only, plus one workflow
+    include:
+      - preset: infrastructure
+      - readOnly: true
+      - workflow: incident-triage
+    exclude:
+      - workflow: rollout
+```
+
+Each preset has an optional `description` (shown by `filter_tools` with `include_presets`),
+an `include` list and an optional `exclude` list. A preset resolves to the union of its
+includes minus its excludes. Every rule sets **exactly one** key:
+
+| Rule | Selects |
+|---|---|
+| `tool: <name>` | One tool by exposed name. |
+| `pattern: <glob>` | Tools whose exposed name matches the glob (`core_*`, `x_mcp-kubernetes_*`; Go `path.Match` syntax). |
+| `server: <name>` | Every tool of that server (family name or member name for families). |
+| `workflow: <name>` | The workflow's execution tool. |
+| `readOnly: true` | Every tool annotated `readOnlyHint: true`, including workflows carrying the derived hint (below). |
+| `preset: <name>` | Composition: everything another preset selects. `include` only. |
+| `label: <key>=<value>` / `label: <key>` | Tools of every MCPServer carrying that label (value match or presence). Presets only; see #1168. |
+
+### Built-in presets
+
+Three presets are built in and **cannot be redefined** — configuration that tries fails muster's
+startup naming the preset:
+
+| Preset | Resolves to |
+|---|---|
+| `read-only` | Every tool its server annotates `readOnlyHint: true`, plus every workflow whose step tools are all read-only. Core tools carry no annotations today and are therefore not included. |
+| `none` | Nothing. A `preset:none` header hides and refuses every tool; the Generic chart omits the muster tool entry altogether for an agent whose toolset is exactly `["preset:none"]`. |
+| `full` | The whole catalogue, core tools included (`pattern: "*"`). |
+
+The platform charts ship `infrastructure` and `agent-platform` as values (by the
+`agent-platform.giantswarm.io/tool-group` label); installations add their own the same way.
+
+### Validation at startup
+
+`muster serve` refuses to start when `toolsetPresets` redefines a built-in preset, when a rule
+sets no key or more than one, when a `pattern` does not compile, when `readOnly` is `false`,
+when `exclude` composes a preset, when a composition names an unknown preset, or when
+compositions cycle. Every error names the preset and the rule position.
+
+### Workflow read-only derivation
+
+A workflow is read-only when every tool its steps reference — conditions, `forEach` and
+`parallel` sub-steps and `onFailure` handlers included, nested workflows followed — resolves in
+the caller's catalogue to a tool annotated read-only. A step calling a core tool (no
+annotation), an unknown tool, or a cycle makes the workflow not read-only. The derived hint
+fills the workflow tool's `readOnlyHint` annotation slot, so `describe_tool` shows it and
+`preset:read-only` includes the pure-query workflows.
+
+## What the meta-tools do with a toolset
+
+- `list_tools`, `filter_tools`, `describe_tool`, `list_core_tools` read the filtered catalogue.
+  `describe_tool` of a tool the session can see but the toolset excludes answers
+  `tool "<name>" is outside the toolset [<selectors>]`; an unknown name is still `Tool not found`.
+- `call_tool` — including workflow execution (`workflow_<name>`) — of a name outside the
+  toolset is refused with `tool "<name>" is outside the toolset [<selectors>]` and logged once
+  at info level with the tool, the toolset and the session. The tools a workflow's steps call
+  internally are the workflow author's composition and are not re-checked.
+- Resources and prompts follow the servers: a server is inside the toolset when at least one
+  of its tools is selected. `list_resources`, `filter_resources`, `describe_resource`,
+  `list_prompts`, `filter_prompts`, `describe_prompt` hide the others; `get_resource` and
+  `get_prompt` refuse them (`resource "<uri>" is outside the toolset […]`).
+- `list_tools`' `servers_requiring_auth` is not narrowed: it tells the caller which sign-in
+  would make more of the toolset resolve.
+- `tools/list` — the meta-tools themselves — is unchanged.
+
+### `filter_tools` and toolsets
+
+`filter_tools` accepts `toolset` (an array of inline selectors) and `include_presets` (bool):
+
+```json
+{"name": "filter_tools", "arguments": {"toolset": ["preset:read-only", "server:pro"], "include_presets": true}}
+```
+
+The response carries the tools the toolset resolves to **for the caller**, `toolset` (the
+selectors as given), `toolset_unmatched` (the selectors that selected nothing for the caller —
+for example a server the caller has not signed in to; `preset:none` is never reported) and
+`presets` (`[{name, description, built_in}]`, built-ins first). When the request also carries
+`X-Muster-Toolset`, the argument resolves **within** the header's toolset and never widens it.
+Argument errors use the header's texts.
+
+### Tool information
+
+Every entry of `list_tools` / `filter_tools`, and `describe_tool`, carries:
+
+- `server` — the owning MCPServer (the family name for a family tool); omitted for workflows and core tools,
+- `kind` — `tool` (served by an MCPServer), `workflow` or `core`,
+- `annotations` — the hints the server declared (`readOnlyHint`, `destructiveHint`,
+  `idempotentHint`, `openWorldHint`), or the derived `readOnlyHint` of a workflow; omitted when
+  the tool carries none.
+
+## Composition, not authorization
+
+The toolset is declared by the request. A client that omits the header reaches everything the
+invoking human may reach — which is what it could reach before toolsets existed. Enforcing a
+toolset against an agent runtime's will needs an agent identity muster can trust; when that
+exists, muster resolves the toolset from the identity through the same seam
+(`toolset.SourceFromRequest`) and presets, resolution, the refusal and the scenarios carry over
+unchanged.

--- a/helm/muster/README.md
+++ b/helm/muster/README.md
@@ -99,6 +99,7 @@ A Helm chart for muster - Universal Control Plane for AI Agents built on MCP
 | muster.namespace | string | `""` |  |
 | muster.debug | bool | `false` |  |
 | muster.writesAsCaller.kubernetesAudience | string | `""` |  |
+| muster.toolsetPresets | object | `{}` |  |
 | muster.extraCaFile.path | string | `"/etc/muster/ca/extra-ca.pem"` |  |
 | muster.extraCaFile.secret.name | string | `""` |  |
 | muster.extraCaFile.secret.key | string | `"ca.pem"` |  |

--- a/helm/muster/templates/configmap.yaml
+++ b/helm/muster/templates/configmap.yaml
@@ -116,5 +116,9 @@ data:
     writesAsCaller:
       kubernetesAudience: {{ . | quote }}
     {{- end }}
+    {{- with .Values.muster.toolsetPresets }}
+    toolsetPresets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     namespace: {{ include "muster.namespace" . | quote }}
     kubernetes: true

--- a/helm/muster/tests/configmap_test.yaml
+++ b/helm/muster/tests/configmap_test.yaml
@@ -174,3 +174,28 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: "writesAsCaller:\n  kubernetesAudience: \"custom-audience\""
+
+  - it: omits toolsetPresets by default (only the built-in presets exist)
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "toolsetPresets:"
+
+  - it: renders muster.toolsetPresets verbatim into config.yaml
+    set:
+      muster.toolsetPresets:
+        infrastructure:
+          description: "Every infrastructure server"
+          include:
+            - server: mcp-kubernetes
+            - pattern: "x_mcp-prometheus_*"
+          exclude:
+            - pattern: "*_delete"
+        agent-platform:
+          include:
+            - server: agent-manager
+            - pattern: "core_*"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "toolsetPresets:\n  agent-platform:\n    include:\n    - server: agent-manager\n    - pattern: core_\\*\n  infrastructure:\n    description: Every infrastructure server\n    exclude:\n    - pattern: '\\*_delete'\n    include:\n    - server: mcp-kubernetes\n    - pattern: x_mcp-prometheus_\\*"

--- a/helm/muster/values.schema.json
+++ b/helm/muster/values.schema.json
@@ -532,6 +532,10 @@
                         }
                     }
                 },
+                "toolsetPresets": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "writesAsCaller": {
                     "type": "object",
                     "additionalProperties": false,

--- a/helm/muster/values.yaml
+++ b/helm/muster/values.yaml
@@ -295,6 +295,26 @@ muster:
     # ("dex-k8s-authenticator").
     kubernetesAudience: ""
 
+  # Toolset presets: named selections of the tool catalogue that an agent's
+  # X-Muster-Toolset header (or the filter_tools toolset argument) can reference
+  # as preset:<name>. Rendered verbatim into muster's config.yaml as
+  # `toolsetPresets`. Every preset has a description, `include` rules and
+  # optional `exclude` rules; each rule sets exactly one of
+  #   tool: <exact exposed name>        pattern: <glob on the exposed name>
+  #   server: <MCPServer or family>     workflow: <workflow name>
+  #   readOnly: true                    preset: <name>   (include only)
+  # read-only, none and full are built into muster and cannot be redefined
+  # here (the pod fails to start naming the offending preset). Example:
+  #   toolsetPresets:
+  #     infrastructure:
+  #       description: Every infrastructure server
+  #       include:
+  #         - server: mcp-kubernetes
+  #         - server: mcp-prometheus
+  #       exclude:
+  #         - pattern: "*_delete"
+  toolsetPresets: {}  # @schema additionalProperties: true
+
   # Append a PEM file to muster's system trust pool at startup. Use this when
   # muster talks to backends served by an internal CA (for example, the SPIFFE
   # bundle that tunnelport tunnels on a Giant Swarm MC). The chart mounts the

--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -16,6 +16,7 @@ import (
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/metatools"
 	oauthstore "github.com/giantswarm/muster/internal/oauth/store"
+	"github.com/giantswarm/muster/internal/toolset"
 	"github.com/giantswarm/muster/pkg/logging"
 )
 
@@ -670,6 +671,7 @@ func (r *ServerRegistry) assembleExposedTools(contributions []serverToolContribu
 			for _, tool := range c.tools {
 				exposedTool := tool
 				exposedTool.Name = r.ExposedToolName(c.serverName, tool.Name)
+				toolset.SetToolOrigin(&exposedTool, toolset.ToolOrigin{Kind: toolset.OriginKindTool, Server: c.serverName})
 				soloTools = append(soloTools, exposedTool)
 			}
 			continue
@@ -735,6 +737,9 @@ func (r *ServerRegistry) assembleExposedTools(contributions []serverToolContribu
 		exposedTool.Name = r.familyExposedName(key.family, key.toolName)
 		exposedTool.InputSchema = injectInstanceEnum(exposedTool.InputSchema, entry.instanceArg, sortedServers)
 		exposedTool.Description = annotateMultiServer(exposedTool.Description, sortedServers)
+		// The exposed name carries the family, so the family is the owning
+		// server; the members are recorded so server:<member> selects it too.
+		toolset.SetToolOrigin(&exposedTool, toolset.ToolOrigin{Kind: toolset.OriginKindTool, Server: key.family, Servers: sortedServers})
 
 		soloTools = append(soloTools, exposedTool)
 		for _, sn := range sortedServers {

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -21,6 +21,7 @@ import (
 	internalmcp "github.com/giantswarm/muster/internal/mcpserver"
 	oauthstore "github.com/giantswarm/muster/internal/oauth/store"
 	"github.com/giantswarm/muster/internal/server"
+	"github.com/giantswarm/muster/internal/toolset"
 	"github.com/giantswarm/muster/pkg/logging"
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 
@@ -910,10 +911,11 @@ func (a *AggregatorServer) Start(ctx context.Context) error {
 		a.sseServer = mcpserver.NewSSEServer(
 			a.mcpServer,
 			mcpserver.WithBaseURL(baseURL),
-			mcpserver.WithSSEEndpoint("/sse"),               // Main SSE endpoint for events
-			mcpserver.WithMessageEndpoint("/message"),       // Endpoint for sending messages
-			mcpserver.WithKeepAlive(true),                   // Enable keep-alive for connection stability
-			mcpserver.WithKeepAliveInterval(30*time.Second), // Keep-alive interval
+			mcpserver.WithSSEEndpoint("/sse"),                     // Main SSE endpoint for events
+			mcpserver.WithMessageEndpoint("/message"),             // Endpoint for sending messages
+			mcpserver.WithKeepAlive(true),                         // Enable keep-alive for connection stability
+			mcpserver.WithKeepAliveInterval(30*time.Second),       // Keep-alive interval
+			mcpserver.WithSSEContextFunc(toolset.HTTPContextFunc), // Per-request toolset source (X-Muster-Toolset)
 		)
 
 		// Create a mux that routes to both MCP and OAuth handlers
@@ -978,8 +980,12 @@ func (a *AggregatorServer) Start(ctx context.Context) error {
 	case config.MCPTransportStreamableHTTP:
 		fallthrough
 	default:
-		// Streamable HTTP transport (default) - HTTP-based streaming protocol
-		a.streamableHTTPServer = mcpserver.NewStreamableHTTPServer(a.mcpServer)
+		// Streamable HTTP transport (default) - HTTP-based streaming protocol.
+		// The context func runs per POST, after mcp-go bound the client
+		// session, and stashes the request's toolset source so the meta-tools
+		// evaluate X-Muster-Toolset per request — never per session.
+		a.streamableHTTPServer = mcpserver.NewStreamableHTTPServer(a.mcpServer,
+			mcpserver.WithHTTPContextFunc(toolset.HTTPContextFunc))
 
 		// Create a mux that routes to both MCP and OAuth handlers
 		handler, err := a.createHTTPMux(a.streamableHTTPServer)
@@ -3306,6 +3312,7 @@ func (a *AggregatorServer) ListToolsForContext(ctx context.Context) []mcp.Tool {
 	allTools := make([]mcp.Tool, 0, len(mcpServerTools)+len(coreTools))
 	allTools = append(allTools, mcpServerTools...)
 	allTools = append(allTools, coreTools...)
+	deriveWorkflowReadOnlyHints(allTools, api.GetWorkflow())
 
 	logging.DebugWithAttrs("Aggregator", "ListToolsForContext: returning tools",
 		slog.Int("total", len(allTools)),

--- a/internal/aggregator/tool_factory.go
+++ b/internal/aggregator/tool_factory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/giantswarm/muster/internal/api"
 	"github.com/giantswarm/muster/internal/metatools"
+	"github.com/giantswarm/muster/internal/toolset"
 	"github.com/giantswarm/muster/pkg/logging"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -246,6 +247,14 @@ func (a *AggregatorServer) getAllCoreToolsAsMCPTools() []mcp.Tool {
 						AdditionalFields: map[string]any{api.MetaKeyLabels: labels},
 					}
 				}
+				// Record what kind of tool this is so the meta-tools can
+				// report it and toolsets can select workflows and core tools
+				// apart from server tools.
+				kind := toolset.OriginKindCore
+				if strings.HasPrefix(name, "workflow_") {
+					kind = toolset.OriginKindWorkflow
+				}
+				toolset.SetToolOrigin(&tool, toolset.ToolOrigin{Kind: kind})
 				tools = append(tools, tool)
 			}
 		}
@@ -305,6 +314,9 @@ func (a *AggregatorServer) getAllCoreToolsAsMCPTools() []mcp.Tool {
 				Required: []string{"server"},
 			},
 		},
+	}
+	for i := range authTools {
+		toolset.SetToolOrigin(&authTools[i], toolset.ToolOrigin{Kind: toolset.OriginKindCore})
 	}
 	tools = append(tools, authTools...)
 

--- a/internal/aggregator/workflow_readonly.go
+++ b/internal/aggregator/workflow_readonly.go
@@ -1,0 +1,89 @@
+package aggregator
+
+import (
+	"strings"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/toolset"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// workflowToolPrefix is the exposed-name prefix of workflow execution tools.
+const workflowToolPrefix = "workflow_"
+
+// deriveWorkflowReadOnlyHints fills the readOnlyHint annotation of every
+// workflow execution tool in tools: a workflow is read-only when every tool
+// its steps reference resolves, in this same catalogue, to a tool annotated
+// read-only. Nested workflows are followed; a step whose tool is not in the
+// catalogue, a core tool (which carries no annotation) or a cycle makes the
+// workflow not read-only. The derived hint fills the same annotation slot a
+// server's own readOnlyHint does, so the read-only preset and the meta-tools
+// treat workflows and server tools alike.
+//
+// The catalogue passed in is the caller's own (already session-scoped), so the
+// derivation is per request like every other catalogue property. It is a
+// single pass over data the aggregator already holds; no workflow handler
+// (tests, bootstrap order) means no hint is derived.
+func deriveWorkflowReadOnlyHints(tools []mcp.Tool, workflows api.WorkflowHandler) {
+	if workflows == nil {
+		return
+	}
+	byName := make(map[string]*mcp.Tool, len(tools))
+	for i := range tools {
+		byName[tools[i].Name] = &tools[i]
+	}
+	memo := map[string]bool{}
+	for i := range tools {
+		if !isWorkflowExecutionTool(tools[i]) {
+			continue
+		}
+		if workflowIsReadOnly(strings.TrimPrefix(tools[i].Name, workflowToolPrefix), workflows, byName, memo, map[string]bool{}) {
+			yes := true
+			tools[i].Annotations.ReadOnlyHint = &yes
+		}
+	}
+}
+
+// isWorkflowExecutionTool reports whether tool is a workflow_<name> tool,
+// preferring the recorded origin over the name prefix.
+func isWorkflowExecutionTool(tool mcp.Tool) bool {
+	if origin, ok := toolset.ToolOriginOf(tool); ok {
+		return origin.Kind == toolset.OriginKindWorkflow
+	}
+	return strings.HasPrefix(tool.Name, workflowToolPrefix)
+}
+
+func workflowIsReadOnly(name string, workflows api.WorkflowHandler, byName map[string]*mcp.Tool, memo map[string]bool, visiting map[string]bool) bool {
+	if ro, done := memo[name]; done {
+		return ro
+	}
+	if visiting[name] {
+		return false // a cycle can never be proven read-only
+	}
+	visiting[name] = true
+	defer delete(visiting, name)
+
+	wf, err := workflows.GetWorkflow(name)
+	if err != nil || wf == nil {
+		memo[name] = false
+		return false
+	}
+	readOnly := true
+	for _, stepTool := range api.WorkflowStepTools(wf) {
+		if nested, ok := strings.CutPrefix(stepTool, workflowToolPrefix); ok {
+			if !workflowIsReadOnly(nested, workflows, byName, memo, visiting) {
+				readOnly = false
+				break
+			}
+			continue
+		}
+		t, ok := byName[stepTool]
+		if !ok || t.Annotations.ReadOnlyHint == nil || !*t.Annotations.ReadOnlyHint {
+			readOnly = false
+			break
+		}
+	}
+	memo[name] = readOnly
+	return readOnly
+}

--- a/internal/api/workflow_tools.go
+++ b/internal/api/workflow_tools.go
@@ -1,0 +1,45 @@
+package api
+
+// WorkflowStepTools returns, in discovery order and deduplicated, every tool
+// name a workflow's steps reference: top-level step tools, condition tools,
+// the tools of forEach and parallel sub-steps, and onFailure handler tools.
+// Nested workflow_<name> steps are returned as such; callers that need
+// transitive resolution descend into them.
+func WorkflowStepTools(wf *Workflow) []string {
+	if wf == nil {
+		return nil
+	}
+	var tools []string
+	seen := map[string]struct{}{}
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		tools = append(tools, name)
+	}
+	addCondition := func(c *WorkflowCondition) {
+		if c != nil {
+			add(c.Tool)
+		}
+	}
+	addSub := func(subs []WorkflowSubStep) {
+		for _, sub := range subs {
+			addCondition(sub.Condition)
+			add(sub.Tool)
+		}
+	}
+	for _, step := range wf.Steps {
+		addCondition(step.Condition)
+		add(step.Tool)
+		if step.ForEach != nil {
+			addSub(step.ForEach.Steps)
+		}
+		addSub(step.Parallel)
+	}
+	addSub(wf.OnFailure)
+	return tools
+}

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	mcpserverPkg "github.com/giantswarm/muster/internal/mcpserver"
 	aggregatorService "github.com/giantswarm/muster/internal/services/aggregator"
+	"github.com/giantswarm/muster/internal/toolset"
 
 	"github.com/giantswarm/muster/internal/aggregator"
 	"github.com/giantswarm/muster/internal/api"
@@ -288,9 +290,17 @@ func InitializeServices(cfg *Config) (*Services, error) {
 		// The metatools adapter provides the MetaToolsHandler interface that the
 		// metatools package uses. The aggregator is registered as the data provider
 		// which gives the adapter access to list/call tools, resources, and prompts.
-		metaToolsAdapter := metatools.NewAdapter()
+		//
+		// Toolset presets are validated here, once, so a configuration that
+		// redefines a built-in preset or composes an unknown one stops startup
+		// with the preset named instead of surfacing as a request error later.
+		toolsetPresets, err := toolset.NewRegistry(cfg.MusterConfig.ToolsetPresets)
+		if err != nil {
+			return nil, fmt.Errorf("invalid toolset presets: %w", err)
+		}
+		metaToolsAdapter := metatools.NewAdapter(metatools.WithPresets(toolsetPresets))
 		metaToolsAdapter.Register()
-		logging.Info("Services", "Registered meta-tools adapter")
+		logging.Info("Services", "Registered meta-tools adapter with toolset presets: %s", strings.Join(toolsetPresets.Names(), ", "))
 	}
 
 	// Step 5: Initialize reconciliation manager for automatic change detection

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,6 +1,10 @@
 package config
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/giantswarm/muster/internal/toolset"
+)
 
 // MusterConfig is the top-level configuration structure for muster.
 type MusterConfig struct {
@@ -8,6 +12,13 @@ type MusterConfig struct {
 	Namespace      string               `yaml:"namespace,omitempty"`      // Namespace for MCPServer and Workflow discovery
 	Kubernetes     bool                 `yaml:"kubernetes,omitempty"`     // Enable Kubernetes CRD mode (uses CRDs instead of filesystem)
 	WritesAsCaller WritesAsCallerConfig `yaml:"writesAsCaller,omitempty"` // Caller-identity writes: kubernetesAudience override
+	// ToolsetPresets are the installation's toolset presets (chart value
+	// muster.toolsetPresets): named selections of the catalogue an agent's
+	// X-Muster-Toolset header can reference as preset:<name>. read-only, none
+	// and full are built in and cannot be redefined here; startup fails on a
+	// preset that tries, on a malformed rule, or on a composition that names
+	// an unknown preset.
+	ToolsetPresets toolset.PresetsConfig `yaml:"toolsetPresets,omitempty"`
 }
 
 // WritesAsCallerConfig configures caller-identity writes. In Kubernetes mode,

--- a/internal/metatools/api_adapter.go
+++ b/internal/metatools/api_adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/toolset"
 	"github.com/giantswarm/muster/pkg/logging"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -21,15 +22,41 @@ type Adapter struct {
 	provider *Provider
 }
 
+// AdapterOption configures the adapter's provider.
+type AdapterOption func(*Provider)
+
+// WithPresets makes the meta-tools resolve toolsets against the given preset
+// registry (built-ins plus the installation's toolsetPresets). Without it
+// only the built-in presets are known.
+func WithPresets(presets *toolset.Registry) AdapterOption {
+	return func(p *Provider) {
+		if presets != nil {
+			p.presets = presets
+		}
+	}
+}
+
+// WithServerLabels supplies the MCPServer label lookup the label: preset
+// selector resolves through (#1168).
+func WithServerLabels(labels toolset.ServerLabels) AdapterOption {
+	return func(p *Provider) {
+		p.serverLabels = labels
+	}
+}
+
 // NewAdapter creates a new metatools adapter instance.
 // The adapter manages the metatools provider and handles registration
 // with the API layer.
 //
 // Returns:
 //   - *Adapter: A new adapter instance ready for registration
-func NewAdapter() *Adapter {
+func NewAdapter(opts ...AdapterOption) *Adapter {
+	provider := NewProvider()
+	for _, opt := range opts {
+		opt(provider)
+	}
 	return &Adapter{
-		provider: NewProvider(),
+		provider: provider,
 	}
 }
 

--- a/internal/metatools/formatters.go
+++ b/internal/metatools/formatters.go
@@ -101,8 +101,11 @@ func (f *Formatters) FormatToolsListJSON(tools []mcp.Tool) (string, error) {
 //	}
 func (f *Formatters) FormatToolsListWithAuthJSON(tools []mcp.Tool, serversRequiringAuth []api.ServerAuthInfo) (string, error) {
 	type ToolInfo struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		Name        string           `json:"name"`
+		Description string           `json:"description"`
+		Server      string           `json:"server,omitempty"`
+		Kind        string           `json:"kind,omitempty"`
+		Annotations *ToolAnnotations `json:"annotations,omitempty"`
 	}
 
 	type Response struct {
@@ -112,9 +115,13 @@ func (f *Formatters) FormatToolsListWithAuthJSON(tools []mcp.Tool, serversRequir
 
 	toolList := make([]ToolInfo, len(tools))
 	for i, tool := range tools {
+		server, kind := originOf(tool)
 		toolList[i] = ToolInfo{
 			Name:        tool.Name,
 			Description: tool.Description,
+			Server:      server,
+			Kind:        kind,
+			Annotations: annotationsOf(tool),
 		}
 	}
 
@@ -243,6 +250,17 @@ func (f *Formatters) FormatToolDetailJSON(tool mcp.Tool) (string, error) {
 		api.FieldName:            tool.Name,
 		api.SchemaKeyDescription: tool.Description,
 		api.FieldInputSchema:     tool.InputSchema,
+	}
+	// Origin and annotations: where the tool comes from, what kind it is and
+	// the hints its server declared (or, for a workflow, the derived read-only
+	// hint), so a client can tell read-only tools apart without calling them.
+	server, kind := originOf(tool)
+	if server != "" {
+		toolInfo[api.FieldServer] = server
+	}
+	toolInfo["kind"] = kind
+	if annotations := annotationsOf(tool); annotations != nil {
+		toolInfo["annotations"] = annotations
 	}
 
 	jsonData, err := json.MarshalIndent(toolInfo, "", "  ")

--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/toolset"
 	"github.com/giantswarm/muster/pkg/logging"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -50,6 +51,19 @@ func (p *Provider) getHandler() (api.MetaToolsHandler, *api.CallToolResult) {
 func (p *Provider) ExecuteTool(ctx context.Context, toolName string, args map[string]any) (*api.CallToolResult, error) {
 	// Argument values are caller data and can carry credentials: log names only.
 	logging.Debug("metatools", "Executing tool %s with args: %s", toolName, logging.KeyNames(args))
+
+	// A request that declares a toolset must declare a valid one: an empty
+	// header, a malformed, reserved or preset-only selector, more than the
+	// inline cap, or an unknown preset is an error on every meta-tool call
+	// (D12) — never a silent fall-back to the unscoped catalogue and never
+	// silent degradation to the selectors that did parse.
+	if ts, present, err := toolset.FromContext(ctx); err != nil {
+		return errorResult(err.Error()), nil
+	} else if present {
+		if err := p.presets.Check(ts); err != nil {
+			return errorResult(err.Error()), nil
+		}
+	}
 
 	// Dispatch to the appropriate handler
 	switch toolName {
@@ -93,15 +107,18 @@ func (p *Provider) handleListTools(ctx context.Context, _ map[string]any) (*api.
 		return errResult, nil
 	}
 
-	tools, err := handler.ListTools(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list tools: %v", err)), nil
+	cat, errResult := p.catalogue(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	// Get servers requiring authentication for the current session
+	// Get servers requiring authentication for the current session. The list
+	// is informational (which servers a sign-in would unlock) and is not
+	// narrowed by the toolset: a toolset selector can only match a server's
+	// tools once the caller has signed in to it.
 	serversRequiringAuth := handler.ListServersRequiringAuth(ctx)
 
-	jsonData, err := p.formatters.FormatToolsListWithAuthJSON(tools, serversRequiringAuth)
+	jsonData, err := p.formatters.FormatToolsListWithAuthJSON(cat.tools, serversRequiringAuth)
 	if err != nil {
 		return errorResult(fmt.Sprintf("Failed to format tools: %v", err)), nil
 	}
@@ -122,13 +139,16 @@ func (p *Provider) handleDescribeTool(ctx context.Context, args map[string]any) 
 		return errResult, nil
 	}
 
-	tools, err := handler.ListTools(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list tools: %v", err)), nil
+	cat, errResult := p.catalogue(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	tool := p.formatters.FindTool(tools, name)
+	tool := p.formatters.FindTool(cat.tools, name)
 	if tool == nil {
+		if errResult := cat.outside(name); errResult != nil {
+			return errResult, nil
+		}
 		return errorResult(fmt.Sprintf("Tool not found: %s", name)), nil
 	}
 
@@ -166,6 +186,12 @@ type filterToolsOptions struct {
 	summarize         bool
 	limit             int // 0 means no limit
 	offset            int
+	// toolsetArg is the inline toolset to resolve against the caller's
+	// catalogue (nil when the argument was not given; an empty list is an
+	// error, like an empty header).
+	toolsetArg []string
+	// includePresets adds the known presets to the response.
+	includePresets bool
 }
 
 // handleListCoreTools handles the list_core_tools meta-tool.
@@ -247,8 +273,39 @@ func (p *Provider) handleFilterTools(ctx context.Context, args map[string]any) (
 		}
 		opts.offset = offset
 	}
+	if raw, ok := args["toolset"]; ok && raw != nil {
+		selectors, err := toStringList(raw)
+		if err != nil {
+			return errorResult("toolset must be an array of selector strings"), nil
+		}
+		opts.toolsetArg = selectors
+	}
+	if v, ok := args["include_presets"].(bool); ok {
+		opts.includePresets = v
+	}
 
 	return p.filterToolsWithOptions(ctx, opts)
+}
+
+// toStringList coerces a JSON-decoded array (or a native string slice) to
+// []string. A non-array, or an element that is not a string, is an error.
+func toStringList(v any) ([]string, error) {
+	switch list := v.(type) {
+	case []string:
+		return append([]string(nil), list...), nil
+	case []any:
+		out := make([]string, 0, len(list))
+		for _, item := range list {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("element %v is not a string", item)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("not an array")
+	}
 }
 
 // filterToolsWithOptions is the shared filter/rank/paginate engine behind both
@@ -259,11 +316,34 @@ func (p *Provider) filterToolsWithOptions(ctx context.Context, opts filterToolsO
 		return errResult, nil
 	}
 
-	tools, err := handler.ListTools(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list tools: %v", err)), nil
+	cat, errResult := p.catalogue(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
-	if len(tools) == 0 {
+	tools := cat.tools
+
+	// The toolset argument resolves within the caller's catalogue — which,
+	// when the request itself declares a toolset, is already that toolset, so
+	// the argument can narrow it but never widen it.
+	var argToolset *toolset.Toolset
+	var argResolution toolset.Resolution
+	if opts.toolsetArg != nil {
+		ts, err := toolset.ParseInline(opts.toolsetArg)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		res, err := p.presets.Resolve(ts, toolset.EntriesFromTools(tools, p.serverLabels))
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		argToolset, argResolution = &ts, res
+		tools = toolset.Filter(tools, res)
+	}
+
+	// Without any toolset in play the legacy text answer is kept; a toolset
+	// that resolves to nothing (preset:none, a selector matching nothing) is a
+	// real, structured answer the caller can read.
+	if len(tools) == 0 && !cat.scoped && argToolset == nil {
 		return textResult("No tools available to filter"), nil
 	}
 
@@ -334,6 +414,8 @@ func (p *Provider) filterToolsWithOptions(ctx context.Context, opts filterToolsO
 		if labels := toolLabels(st.tool); len(labels) > 0 {
 			info.Labels = labels
 		}
+		info.Server, info.Kind = originOf(st.tool)
+		info.Annotations = annotationsOf(st.tool)
 		if opts.includeSchema {
 			info.InputSchema = st.tool.InputSchema
 		}
@@ -351,11 +433,21 @@ func (p *Provider) filterToolsWithOptions(ctx context.Context, opts filterToolsO
 			Limit:             opts.limit,
 			Offset:            opts.offset,
 		},
-		TotalTools:    len(tools),
+		TotalTools:    len(cat.tools),
 		FilteredCount: len(toolInfos),
 		Total:         total,
 		Truncated:     truncated,
 		Tools:         toolInfos,
+	}
+	switch {
+	case argToolset != nil:
+		resp.Toolset = argToolset.Raw
+		resp.ToolsetUnmatched = argResolution.Unmatched
+	case cat.scoped:
+		resp.ToolsetUnmatched = cat.res.Unmatched
+	}
+	if opts.includePresets || argToolset != nil {
+		resp.Presets = p.presets.List()
 	}
 
 	jsonData, err := json.MarshalIndent(resp, "", "  ")
@@ -498,6 +590,18 @@ func (p *Provider) handleCallTool(ctx context.Context, args map[string]any) (*ap
 		return errResult, nil
 	}
 
+	// A declared toolset bounds what the model may call: the refusal names
+	// the tool and the toolset, and is logged with the session so an operator
+	// can see which agent asked for what. Workflow execution (workflow_<name>)
+	// goes through the same gate; the tools a workflow's steps call
+	// internally are the workflow author's composition, not the model's, and
+	// are not re-checked here.
+	if cat, errResult := p.catalogue(ctx, handler); errResult != nil {
+		return errResult, nil
+	} else if errResult := cat.refuse(ctx, name); errResult != nil {
+		return errResult, nil
+	}
+
 	// Execute the tool via the handler
 	result, err := handler.CallTool(ctx, name, toolArgs)
 	if err != nil {
@@ -541,9 +645,9 @@ func (p *Provider) handleListResources(ctx context.Context, _ map[string]any) (*
 		return errResult, nil
 	}
 
-	resources, err := handler.ListResources(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list resources: %v", err)), nil
+	resources, _, errResult := p.scopedResources(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	jsonData, err := p.formatters.FormatResourcesListJSON(resources)
@@ -570,13 +674,16 @@ func (p *Provider) handleDescribeResource(ctx context.Context, args map[string]a
 		return errResult, nil
 	}
 
-	resources, err := handler.ListResources(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list resources: %v", err)), nil
+	resources, cat, errResult := p.scopedResources(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	matches := p.formatters.FindResource(resources, uri)
 	if len(matches) == 0 {
+		if cat.scoped {
+			return cat.outsideError("resource", uri), nil
+		}
 		return errorResult(fmt.Sprintf("Resource not found: %s", uri)), nil
 	}
 
@@ -628,6 +735,25 @@ func (p *Provider) handleGetResource(ctx context.Context, args map[string]any) (
 	handler, errResult := p.getHandler()
 	if errResult != nil {
 		return errResult, nil
+	}
+
+	// With a toolset declared, a resource is readable only when its server is
+	// inside the toolset. Without one the read is unchanged.
+	if _, present, _ := toolset.FromContext(ctx); present {
+		resources, cat, errResult := p.scopedResources(ctx, handler)
+		if errResult != nil {
+			return errResult, nil
+		}
+		inside := false
+		for _, m := range p.formatters.FindResource(resources, uri) {
+			if serverName == "" || m.Server == serverName {
+				inside = true
+				break
+			}
+		}
+		if !inside {
+			return cat.outsideError("resource", uri), nil
+		}
 	}
 
 	result, err := handler.GetResource(ctx, uri, serverName)
@@ -720,9 +846,9 @@ func (p *Provider) handleFilterResources(ctx context.Context, args map[string]an
 		return errResult, nil
 	}
 
-	resources, err := handler.ListResources(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list resources: %v", err)), nil
+	resources, _, errResult := p.scopedResources(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	matched := make([]api.ResourceOrigin, 0, len(resources))
@@ -785,9 +911,9 @@ func (p *Provider) handleFilterPrompts(ctx context.Context, args map[string]any)
 		return errResult, nil
 	}
 
-	prompts, err := handler.ListPrompts(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list prompts: %v", err)), nil
+	prompts, _, errResult := p.scopedPrompts(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	matched := make([]api.PromptOrigin, 0, len(prompts))
@@ -837,9 +963,9 @@ func (p *Provider) handleListPrompts(ctx context.Context, _ map[string]any) (*ap
 		return errResult, nil
 	}
 
-	prompts, err := handler.ListPrompts(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list prompts: %v", err)), nil
+	prompts, _, errResult := p.scopedPrompts(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	jsonData, err := p.formatters.FormatPromptsListJSON(prompts)
@@ -863,13 +989,16 @@ func (p *Provider) handleDescribePrompt(ctx context.Context, args map[string]any
 		return errResult, nil
 	}
 
-	prompts, err := handler.ListPrompts(ctx)
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to list prompts: %v", err)), nil
+	prompts, cat, errResult := p.scopedPrompts(ctx, handler)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	prompt := p.formatters.FindPrompt(prompts, name)
 	if prompt == nil {
+		if cat.scoped {
+			return cat.outsideError("prompt", name), nil
+		}
 		return errorResult(fmt.Sprintf("Prompt not found: %s", name)), nil
 	}
 
@@ -905,6 +1034,18 @@ func (p *Provider) handleGetPrompt(ctx context.Context, args map[string]any) (*a
 	handler, errResult := p.getHandler()
 	if errResult != nil {
 		return errResult, nil
+	}
+
+	// With a toolset declared, a prompt is available only when its server is
+	// inside the toolset. Without one the call is unchanged.
+	if _, present, _ := toolset.FromContext(ctx); present {
+		prompts, cat, errResult := p.scopedPrompts(ctx, handler)
+		if errResult != nil {
+			return errResult, nil
+		}
+		if p.formatters.FindPrompt(prompts, name) == nil {
+			return cat.outsideError("prompt", name), nil
+		}
 	}
 
 	result, err := handler.GetPrompt(ctx, name, promptArgs)

--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -596,7 +596,7 @@ func (p *Provider) handleCallTool(ctx context.Context, args map[string]any) (*ap
 	// goes through the same gate; the tools a workflow's steps call
 	// internally are the workflow author's composition, not the model's, and
 	// are not re-checked here.
-	if cat, errResult := p.catalogue(ctx, handler); errResult != nil {
+	if cat, errResult := p.scope(ctx, handler); errResult != nil {
 		return errResult, nil
 	} else if errResult := cat.refuse(ctx, name); errResult != nil {
 		return errResult, nil
@@ -681,7 +681,7 @@ func (p *Provider) handleDescribeResource(ctx context.Context, args map[string]a
 
 	matches := p.formatters.FindResource(resources, uri)
 	if len(matches) == 0 {
-		if cat.scoped {
+		if cat.isScoped() {
 			return cat.outsideError("resource", uri), nil
 		}
 		return errorResult(fmt.Sprintf("Resource not found: %s", uri)), nil
@@ -996,7 +996,7 @@ func (p *Provider) handleDescribePrompt(ctx context.Context, args map[string]any
 
 	prompt := p.formatters.FindPrompt(prompts, name)
 	if prompt == nil {
-		if cat.scoped {
+		if cat.isScoped() {
 			return cat.outsideError("prompt", name), nil
 		}
 		return errorResult(fmt.Sprintf("Prompt not found: %s", name)), nil

--- a/internal/metatools/handlers_toolset_test.go
+++ b/internal/metatools/handlers_toolset_test.go
@@ -1,0 +1,326 @@
+package metatools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/toolset"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ro(t mcp.Tool, readOnly bool) mcp.Tool {
+	if readOnly {
+		yes := true
+		t.Annotations.ReadOnlyHint = &yes
+	} else {
+		no, yes := false, true
+		t.Annotations.ReadOnlyHint = &no
+		t.Annotations.DestructiveHint = &yes
+	}
+	return t
+}
+
+func tagged(name string, origin toolset.ToolOrigin) mcp.Tool {
+	t := mcp.Tool{Name: name, Description: name + " description", InputSchema: mcp.ToolInputSchema{Type: "object"}}
+	toolset.SetToolOrigin(&t, origin)
+	return t
+}
+
+// toolsetFixture is a catalogue with a kubernetes server (read-only get,
+// destructive delete), a workflow with the derived read-only hint, and a core
+// tool; plus resources and prompts on two servers.
+func toolsetFixture() *mockMetaToolsHandler {
+	return &mockMetaToolsHandler{
+		tools: []mcp.Tool{
+			ro(tagged("x_k8s_get", toolset.ToolOrigin{Kind: toolset.OriginKindTool, Server: "k8s"}), true),
+			ro(tagged("x_k8s_delete", toolset.ToolOrigin{Kind: toolset.OriginKindTool, Server: "k8s"}), false),
+			tagged("x_gh_issues", toolset.ToolOrigin{Kind: toolset.OriginKindTool, Server: "gh"}),
+			ro(tagged("workflow_triage", toolset.ToolOrigin{Kind: toolset.OriginKindWorkflow}), true),
+			tagged("core_workflow_list", toolset.ToolOrigin{Kind: toolset.OriginKindCore}),
+		},
+		resources: []api.ResourceOrigin{
+			{Resource: mcp.Resource{URI: "k8s://pods", Name: "pods"}, Server: "k8s"},
+			{Resource: mcp.Resource{URI: "gh://repos", Name: "repos"}, Server: "gh"},
+		},
+		prompts: []api.PromptOrigin{
+			{Prompt: mcp.Prompt{Name: "x_k8s_debug"}, Server: "k8s"},
+			{Prompt: mcp.Prompt{Name: "x_gh_review"}, Server: "gh"},
+		},
+		callToolResult: &mcp.CallToolResult{Content: []mcp.Content{mcp.TextContent{Type: "text", Text: "ok"}}},
+		getResourceResult: &mcp.ReadResourceResult{Contents: []mcp.ResourceContents{
+			mcp.TextResourceContents{URI: "k8s://pods", Text: "pods"},
+		}},
+		getPromptResult: &mcp.GetPromptResult{Messages: []mcp.PromptMessage{{Role: mcp.RoleUser, Content: mcp.TextContent{Type: "text", Text: "hi"}}}},
+	}
+}
+
+// withHeader returns a context as the transport would build it for a request
+// carrying (or, with present=false, not carrying) X-Muster-Toolset.
+func withHeader(value string, present bool) context.Context {
+	req, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
+	if present {
+		req.Header.Set(toolset.HeaderName, value)
+	}
+	return toolset.HTTPContextFunc(context.Background(), req)
+}
+
+func decode(t *testing.T, result *api.CallToolResult) map[string]any {
+	t.Helper()
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "expected success, got %v", result.Content)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Content[0].(string)), &out))
+	return out
+}
+
+func toolNames(t *testing.T, resp map[string]any) []string {
+	t.Helper()
+	raw, _ := resp["tools"].([]any)
+	names := make([]string, 0, len(raw))
+	for _, item := range raw {
+		names = append(names, item.(map[string]any)["name"].(string))
+	}
+	return names
+}
+
+func errorText(t *testing.T, result *api.CallToolResult) string {
+	t.Helper()
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "expected an error result, got %v", result.Content)
+	return result.Content[0].(string)
+}
+
+func TestToolset_NoHeaderIsUnscoped(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProvider()
+
+	result, err := p.ExecuteTool(withHeader("", false), "list_tools", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x_k8s_get", "x_k8s_delete", "x_gh_issues", "workflow_triage", "core_workflow_list"}, toolNames(t, decode(t, result)))
+
+	result, err = p.ExecuteTool(withHeader("", false), "call_tool", map[string]any{"name": "x_k8s_delete"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestToolset_HeaderFiltersEveryReader(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProvider()
+	ctx := withHeader("tool:x_k8s_get, workflow:triage", true)
+
+	result, err := p.ExecuteTool(ctx, "list_tools", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x_k8s_get", "workflow_triage"}, toolNames(t, decode(t, result)))
+
+	result, err = p.ExecuteTool(ctx, "filter_tools", map[string]any{"limit": float64(10)})
+	require.NoError(t, err)
+	resp := decode(t, result)
+	assert.Equal(t, []string{"x_k8s_get", "workflow_triage"}, toolNames(t, resp))
+	assert.EqualValues(t, 2, resp["total_tools"], "total_tools is the size of the caller's (scoped) catalogue")
+
+	result, err = p.ExecuteTool(ctx, "list_core_tools", nil)
+	require.NoError(t, err)
+	assert.Empty(t, toolNames(t, decode(t, result)), "core tools are hidden unless the toolset includes them")
+
+	result, err = p.ExecuteTool(ctx, "describe_tool", map[string]any{"name": "x_k8s_get"})
+	require.NoError(t, err)
+	detail := decode(t, result)
+	assert.Equal(t, "k8s", detail["server"])
+	assert.Equal(t, "tool", detail["kind"])
+	assert.Equal(t, map[string]any{"readOnlyHint": true}, detail["annotations"])
+
+	result, err = p.ExecuteTool(ctx, "describe_tool", map[string]any{"name": "x_k8s_delete"})
+	require.NoError(t, err)
+	assert.Equal(t, `tool "x_k8s_delete" is outside the toolset [tool:x_k8s_get,workflow:triage]`, errorText(t, result))
+
+	result, err = p.ExecuteTool(ctx, "describe_tool", map[string]any{"name": "x_unknown"})
+	require.NoError(t, err)
+	assert.Equal(t, "Tool not found: x_unknown", errorText(t, result), "an unknown tool is still simply not found")
+}
+
+func TestToolset_CallToolRefusesOutsideAndAllowsInside(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProvider()
+	ctx := withHeader("preset:read-only", true)
+
+	result, err := p.ExecuteTool(ctx, "call_tool", map[string]any{"name": "x_k8s_get"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	result, err = p.ExecuteTool(ctx, "call_tool", map[string]any{"name": "workflow_triage"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "a workflow with the derived read-only hint is inside read-only")
+
+	result, err = p.ExecuteTool(ctx, "call_tool", map[string]any{"name": "x_k8s_delete"})
+	require.NoError(t, err)
+	assert.Equal(t, `tool "x_k8s_delete" is outside the toolset [preset:read-only]`, errorText(t, result))
+
+	result, err = p.ExecuteTool(ctx, "call_tool", map[string]any{"name": "core_workflow_list"})
+	require.NoError(t, err)
+	assert.Contains(t, errorText(t, result), "is outside the toolset")
+}
+
+func TestToolset_HeaderErrorsOnEveryMetaTool(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProvider()
+
+	cases := map[string]string{
+		"":                    `toolset [] is empty; use "preset:none"`,
+		"preset:foo":          `toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full`,
+		"toolset:shared":      `selector "toolset:shared" is reserved for shared toolsets`,
+		"label:tier=infra":    `selector "label:tier=infra" is allowed inside presets only`,
+		"preset:none,garbage": `selector "garbage" is malformed`,
+	}
+	for header, want := range cases {
+		for _, tool := range MetaToolNames {
+			args := map[string]any{"name": "x_k8s_get", "uri": "k8s://pods"}
+			result, err := p.ExecuteTool(withHeader(header, true), tool, args)
+			require.NoError(t, err, tool)
+			assert.Contains(t, errorText(t, result), want, "%s with header %q", tool, header)
+		}
+	}
+}
+
+func TestToolset_SameSessionDifferentHeaders(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProvider()
+
+	a, _ := p.ExecuteTool(withHeader("server:k8s", true), "list_tools", nil)
+	b, _ := p.ExecuteTool(withHeader("server:gh", true), "list_tools", nil)
+	c, _ := p.ExecuteTool(withHeader("", false), "list_tools", nil)
+	assert.Equal(t, []string{"x_k8s_get", "x_k8s_delete"}, toolNames(t, decode(t, a)))
+	assert.Equal(t, []string{"x_gh_issues"}, toolNames(t, decode(t, b)))
+	assert.Len(t, toolNames(t, decode(t, c)), 5)
+}
+
+func TestToolset_FilterToolsArgument(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProviderWithPresets(must(toolset.NewRegistry(toolset.PresetsConfig{
+		"infrastructure": {Description: "infra", Include: []toolset.Rule{{Server: "k8s"}}},
+	})))
+
+	// Unscoped request, argument given: resolution, unmatched, presets.
+	result, err := p.ExecuteTool(withHeader("", false), "filter_tools", map[string]any{
+		"toolset": []any{"preset:infrastructure", "server:nope", "tool:core_workflow_list"},
+	})
+	require.NoError(t, err)
+	resp := decode(t, result)
+	assert.Equal(t, []string{"x_k8s_get", "x_k8s_delete", "core_workflow_list"}, toolNames(t, resp))
+	assert.Equal(t, []any{"preset:infrastructure", "server:nope", "tool:core_workflow_list"}, resp["toolset"])
+	assert.Equal(t, []any{"server:nope"}, resp["toolset_unmatched"])
+	presets, _ := resp["presets"].([]any)
+	require.Len(t, presets, 4)
+	assert.Equal(t, map[string]any{"name": "read-only", "description": presets[0].(map[string]any)["description"], "built_in": true}, presets[0])
+	assert.Equal(t, "infrastructure", presets[3].(map[string]any)["name"])
+	assert.Equal(t, false, presets[3].(map[string]any)["built_in"])
+
+	// include_presets alone lists presets without resolving anything.
+	result, err = p.ExecuteTool(withHeader("", false), "filter_tools", map[string]any{"include_presets": true, "limit": float64(10)})
+	require.NoError(t, err)
+	resp = decode(t, result)
+	assert.Len(t, toolNames(t, resp), 5)
+	assert.Len(t, resp["presets"], 4)
+	assert.Nil(t, resp["toolset"])
+
+	// Header and argument: the argument resolves within the header's toolset.
+	result, err = p.ExecuteTool(withHeader("preset:read-only", true), "filter_tools", map[string]any{
+		"toolset": []any{"server:k8s"},
+	})
+	require.NoError(t, err)
+	resp = decode(t, result)
+	assert.Equal(t, []string{"x_k8s_get"}, toolNames(t, resp), "server:k8s cannot widen read-only to the destructive tool")
+
+	// preset:none resolves to a structured empty answer, not the legacy text.
+	result, err = p.ExecuteTool(withHeader("", false), "filter_tools", map[string]any{"toolset": []any{"preset:none"}})
+	require.NoError(t, err)
+	resp = decode(t, result)
+	assert.Empty(t, toolNames(t, resp))
+	assert.Nil(t, resp["toolset_unmatched"])
+
+	// Argument errors use the header's texts.
+	for _, tc := range []struct{ arg, want any }{
+		{[]any{}, `toolset [] is empty`},
+		{[]any{"preset:foo"}, `names unknown preset "foo"; known presets: read-only, none, full, infrastructure`},
+		{[]any{"label:a=b"}, `is allowed inside presets only`},
+		{"preset:none", `toolset must be an array of selector strings`},
+	} {
+		result, err = p.ExecuteTool(withHeader("", false), "filter_tools", map[string]any{"toolset": tc.arg})
+		require.NoError(t, err)
+		assert.Contains(t, errorText(t, result), tc.want)
+	}
+}
+
+func TestToolset_ResourcesAndPromptsFollowTheServers(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProvider()
+	ctx := withHeader("server:k8s", true)
+
+	result, err := p.ExecuteTool(ctx, "list_resources", nil)
+	require.NoError(t, err)
+	text := result.Content[0].(string)
+	assert.Contains(t, text, "k8s://pods")
+	assert.NotContains(t, text, "gh://repos")
+
+	result, err = p.ExecuteTool(ctx, "get_resource", map[string]any{"uri": "gh://repos"})
+	require.NoError(t, err)
+	assert.Equal(t, `resource "gh://repos" is outside the toolset [server:k8s]`, errorText(t, result))
+
+	result, err = p.ExecuteTool(ctx, "get_resource", map[string]any{"uri": "k8s://pods"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	result, err = p.ExecuteTool(ctx, "filter_prompts", map[string]any{})
+	require.NoError(t, err)
+	text = result.Content[0].(string)
+	assert.Contains(t, text, "x_k8s_debug")
+	assert.NotContains(t, text, "x_gh_review")
+
+	result, err = p.ExecuteTool(ctx, "get_prompt", map[string]any{"name": "x_gh_review"})
+	require.NoError(t, err)
+	assert.Equal(t, `prompt "x_gh_review" is outside the toolset [server:k8s]`, errorText(t, result))
+
+	result, err = p.ExecuteTool(ctx, "describe_prompt", map[string]any{"name": "x_gh_review"})
+	require.NoError(t, err)
+	assert.Contains(t, errorText(t, result), "is outside the toolset")
+}
+
+func TestToolInfo_CarriesOriginAndAnnotations(t *testing.T) {
+	defer registerMockHandler(toolsetFixture())()
+	p := NewProvider()
+
+	result, err := p.ExecuteTool(withHeader("", false), "list_tools", nil)
+	require.NoError(t, err)
+	tools := decode(t, result)["tools"].([]any)
+	first := tools[0].(map[string]any)
+	assert.Equal(t, "k8s", first["server"])
+	assert.Equal(t, "tool", first["kind"])
+	assert.Equal(t, map[string]any{"readOnlyHint": true}, first["annotations"])
+	deleteTool := tools[1].(map[string]any)
+	assert.Equal(t, map[string]any{"readOnlyHint": false, "destructiveHint": true}, deleteTool["annotations"])
+	plain := tools[2].(map[string]any)
+	assert.Nil(t, plain["annotations"], "a tool without annotations has none")
+	wf := tools[3].(map[string]any)
+	assert.Equal(t, "workflow", wf["kind"])
+	assert.Nil(t, wf["server"])
+	core := tools[4].(map[string]any)
+	assert.Equal(t, "core", core["kind"])
+
+	result, err = p.ExecuteTool(withHeader("", false), "filter_tools", map[string]any{"pattern": "workflow_*"})
+	require.NoError(t, err)
+	item := decode(t, result)["tools"].([]any)[0].(map[string]any)
+	assert.Equal(t, "workflow", item["kind"])
+	assert.Equal(t, map[string]any{"readOnlyHint": true}, item["annotations"])
+}
+
+func must(r *toolset.Registry, err error) *toolset.Registry {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}

--- a/internal/metatools/provider.go
+++ b/internal/metatools/provider.go
@@ -2,6 +2,7 @@ package metatools
 
 import (
 	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/toolset"
 )
 
 // Provider implements the api.ToolProvider interface for meta-tools.
@@ -13,18 +14,41 @@ import (
 // prompts through the API layer's service locator pattern.
 type Provider struct {
 	formatters *Formatters
+	// presets are the toolset presets a request's X-Muster-Toolset (or the
+	// filter_tools toolset argument) may name: the built-ins plus the
+	// installation's toolsetPresets configuration.
+	presets *toolset.Registry
+	// serverLabels resolves an MCPServer name to its resource labels for the
+	// label: preset selector (#1168); nil when unavailable.
+	serverLabels toolset.ServerLabels
 }
 
-// NewProvider creates a new meta-tools provider instance.
-// The provider is stateless except for the formatters and can be safely
-// used concurrently across multiple requests.
+// NewProvider creates a new meta-tools provider instance knowing the built-in
+// toolset presets only. The provider is stateless except for the formatters
+// and the preset registry and can be safely used concurrently across multiple
+// requests.
 //
 // Returns:
 //   - *Provider: A new provider instance ready to handle meta-tool requests
 func NewProvider() *Provider {
+	return NewProviderWithPresets(toolset.BuiltIns())
+}
+
+// NewProviderWithPresets creates a meta-tools provider that resolves toolsets
+// against the given preset registry (built-ins plus configured presets).
+func NewProviderWithPresets(presets *toolset.Registry) *Provider {
+	if presets == nil {
+		presets = toolset.BuiltIns()
+	}
 	return &Provider{
 		formatters: NewFormatters(),
+		presets:    presets,
 	}
+}
+
+// Presets returns the preset registry the provider resolves toolsets against.
+func (p *Provider) Presets() *toolset.Registry {
+	return p.presets
 }
 
 // GetTools returns metadata for all meta-tools this provider offers.
@@ -73,8 +97,22 @@ func (p *Provider) GetTools() []api.ToolMetadata {
 		},
 		{
 			Name:        "filter_tools",
-			Description: "Discover tools cheaply: filter by name pattern, description, or labels, optionally rank by a natural-language query, and get a bounded, summarised page. Full descriptions and schemas are omitted by default — use describe_tool for the authoritative detail of a chosen tool.",
+			Description: "Discover tools cheaply: filter by name pattern, description, or labels, optionally rank by a natural-language query, and get a bounded, summarised page. Full descriptions and schemas are omitted by default — use describe_tool for the authoritative detail of a chosen tool. Pass a toolset to see which tools a set of selectors resolves to for you, and include_presets to list the known toolset presets.",
 			Args: []api.ArgMetadata{
+				{
+					Name:        "toolset",
+					Type:        api.ArgTypeArray,
+					Required:    false,
+					Description: "Inline toolset selectors to resolve against your catalogue: preset:<name>, server:<name>, workflow:<name>, tool:<name> (exact names, at most 32). The response carries the tools they select, the selectors that matched nothing (toolset_unmatched) and the known presets. When the request also declares a toolset (X-Muster-Toolset), the argument resolves within it and never widens it.",
+					Schema:      map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				},
+				{
+					Name:        "include_presets",
+					Type:        api.ArgTypeBoolean,
+					Required:    false,
+					Description: "Include the known toolset presets (name, description, built_in) in the response (default: false)",
+					Default:     false,
+				},
 				{
 					Name:        "pattern",
 					Type:        api.ArgTypeString,
@@ -133,7 +171,7 @@ func (p *Provider) GetTools() []api.ToolMetadata {
 		// Execution tool
 		{
 			Name:        "call_tool",
-			Description: "Execute a tool with the given arguments",
+			Description: "Execute a tool with the given arguments. A request that declares a toolset (X-Muster-Toolset) can only call tools inside it; anything else is refused naming the toolset.",
 			Args: []api.ArgMetadata{
 				{
 					Name:        "name",

--- a/internal/metatools/scope.go
+++ b/internal/metatools/scope.go
@@ -57,6 +57,26 @@ func (p *Provider) catalogue(ctx context.Context, handler api.MetaToolsHandler) 
 	return cat, nil
 }
 
+// scope is catalogue for the accessors that do not otherwise list tools
+// (call_tool, resources, prompts): it returns nil when the request declared
+// no toolset, so an unscoped request does not list the catalogue at all.
+// Listing has side effects the unscoped paths never had — ListToolsForContext
+// adopts the person's subject-scoped grants, connecting the session to servers
+// the caller may be about to sign in to explicitly — and a request without a
+// header must stay byte-for-byte today's behaviour.
+func (p *Provider) scope(ctx context.Context, handler api.MetaToolsHandler) (*scopedCatalogue, *api.CallToolResult) {
+	if _, present, _ := toolset.FromContext(ctx); !present {
+		return nil, nil
+	}
+	return p.catalogue(ctx, handler)
+}
+
+// isScoped reports whether the request declared a toolset. Nil-safe, so the
+// accessors can hold the nil scope of an unscoped request.
+func (c *scopedCatalogue) isScoped() bool {
+	return c != nil && c.scoped
+}
+
 // outsideError is the refusal every accessor uses for a name that exists in
 // the session's catalogue but not in the request's toolset.
 func (c *scopedCatalogue) outsideError(kind, name string) *api.CallToolResult {
@@ -68,7 +88,7 @@ func (c *scopedCatalogue) outsideError(kind, name string) *api.CallToolResult {
 // request is unscoped or the tool is unknown altogether (callers then report
 // "not found", exactly as without a toolset).
 func (c *scopedCatalogue) outside(name string) *api.CallToolResult {
-	if !c.scoped || c.res.Contains(name) {
+	if !c.isScoped() || c.res.Contains(name) {
 		return nil
 	}
 	for _, t := range c.all {
@@ -83,7 +103,7 @@ func (c *scopedCatalogue) outside(name string) *api.CallToolResult {
 // refused — known or not, since either way it is not something the agent was
 // composed with — and the refusal is logged with tool, toolset and session.
 func (c *scopedCatalogue) refuse(ctx context.Context, name string) *api.CallToolResult {
-	if !c.scoped || c.res.Contains(name) {
+	if !c.isScoped() || c.res.Contains(name) {
 		return nil
 	}
 	attrs := []slog.Attr{
@@ -103,7 +123,7 @@ func (c *scopedCatalogue) refuse(ctx context.Context, name string) *api.CallTool
 // resources narrows the session's resources to the servers inside the
 // toolset: a server is inside when at least one of its tools is selected.
 func (c *scopedCatalogue) resources(resources []api.ResourceOrigin) []api.ResourceOrigin {
-	if !c.scoped {
+	if !c.isScoped() {
 		return resources
 	}
 	out := make([]api.ResourceOrigin, 0, len(resources))
@@ -117,7 +137,7 @@ func (c *scopedCatalogue) resources(resources []api.ResourceOrigin) []api.Resour
 
 // prompts narrows the session's prompts the same way resources does.
 func (c *scopedCatalogue) prompts(prompts []api.PromptOrigin) []api.PromptOrigin {
-	if !c.scoped {
+	if !c.isScoped() {
 		return prompts
 	}
 	out := make([]api.PromptOrigin, 0, len(prompts))
@@ -134,7 +154,7 @@ func (c *scopedCatalogue) prompts(prompts []api.PromptOrigin) []api.PromptOrigin
 // is untouched) and lets get_resource refuse a resource whose server is
 // outside the toolset.
 func (p *Provider) scopedResources(ctx context.Context, handler api.MetaToolsHandler) ([]api.ResourceOrigin, *scopedCatalogue, *api.CallToolResult) {
-	cat, errResult := p.catalogue(ctx, handler)
+	cat, errResult := p.scope(ctx, handler)
 	if errResult != nil {
 		return nil, nil, errResult
 	}
@@ -147,7 +167,7 @@ func (p *Provider) scopedResources(ctx context.Context, handler api.MetaToolsHan
 
 // scopedPrompts mirrors scopedResources for prompts.
 func (p *Provider) scopedPrompts(ctx context.Context, handler api.MetaToolsHandler) ([]api.PromptOrigin, *scopedCatalogue, *api.CallToolResult) {
-	cat, errResult := p.catalogue(ctx, handler)
+	cat, errResult := p.scope(ctx, handler)
 	if errResult != nil {
 		return nil, nil, errResult
 	}

--- a/internal/metatools/scope.go
+++ b/internal/metatools/scope.go
@@ -1,0 +1,159 @@
+package metatools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/toolset"
+	"github.com/giantswarm/muster/pkg/logging"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// scopedCatalogue is the catalogue a meta-tool reads for one request: the
+// session's own tools (server-authentication visibility and workflow
+// availability already applied by the aggregator), narrowed by the toolset
+// the request declared — the third filter. It is built once per meta-tool
+// call and never cached across requests, so two requests on the same session
+// with different X-Muster-Toolset headers see different catalogues.
+type scopedCatalogue struct {
+	// all is the session's catalogue before the toolset filter.
+	all []mcp.Tool
+	// tools is the catalogue after the toolset filter (equal to all when the
+	// request declared no toolset).
+	tools []mcp.Tool
+	// scoped is true when the request declared a toolset.
+	scoped bool
+	ts     toolset.Toolset
+	res    toolset.Resolution
+}
+
+// catalogue lists the session's tools through the handler and applies the
+// request's toolset, if any. An invalid toolset was already rejected by
+// ExecuteTool; a resolution error here (unknown preset) is returned verbatim.
+func (p *Provider) catalogue(ctx context.Context, handler api.MetaToolsHandler) (*scopedCatalogue, *api.CallToolResult) {
+	tools, err := handler.ListTools(ctx)
+	if err != nil {
+		return nil, errorResult(fmt.Sprintf("Failed to list tools: %v", err))
+	}
+	cat := &scopedCatalogue{all: tools, tools: tools}
+
+	ts, present, err := toolset.FromContext(ctx)
+	if err != nil {
+		return nil, errorResult(err.Error())
+	}
+	if !present {
+		return cat, nil
+	}
+	res, err := p.presets.Resolve(ts, toolset.EntriesFromTools(tools, p.serverLabels))
+	if err != nil {
+		return nil, errorResult(err.Error())
+	}
+	cat.scoped, cat.ts, cat.res = true, ts, res
+	cat.tools = toolset.Filter(tools, res)
+	return cat, nil
+}
+
+// outsideError is the refusal every accessor uses for a name that exists in
+// the session's catalogue but not in the request's toolset.
+func (c *scopedCatalogue) outsideError(kind, name string) *api.CallToolResult {
+	return errorResult(fmt.Sprintf("%s %q is outside the toolset %s", kind, name, c.ts))
+}
+
+// outside returns the outside-toolset error when the request declared a
+// toolset and name is a tool the session could otherwise see; nil when the
+// request is unscoped or the tool is unknown altogether (callers then report
+// "not found", exactly as without a toolset).
+func (c *scopedCatalogue) outside(name string) *api.CallToolResult {
+	if !c.scoped || c.res.Contains(name) {
+		return nil
+	}
+	for _, t := range c.all {
+		if t.Name == name {
+			return c.outsideError("tool", name)
+		}
+	}
+	return nil
+}
+
+// refuse gates call_tool: with a toolset declared, any name outside it is
+// refused — known or not, since either way it is not something the agent was
+// composed with — and the refusal is logged with tool, toolset and session.
+func (c *scopedCatalogue) refuse(ctx context.Context, name string) *api.CallToolResult {
+	if !c.scoped || c.res.Contains(name) {
+		return nil
+	}
+	attrs := []slog.Attr{
+		slog.String("tool", name),
+		slog.String("toolset", c.ts.String()),
+	}
+	if sessionID := api.GetSessionIDFromContext(ctx); sessionID != "" {
+		attrs = append(attrs, slog.String("session", logging.TruncateIdentifier(sessionID)))
+	}
+	if cs := mcpserver.ClientSessionFromContext(ctx); cs != nil {
+		attrs = append(attrs, logging.TransportSessionID(cs.SessionID()))
+	}
+	logging.InfoWithAttrs("metatools", fmt.Sprintf("call_tool refused: tool %q is outside the toolset %s", name, c.ts), attrs...)
+	return c.outsideError("tool", name)
+}
+
+// resources narrows the session's resources to the servers inside the
+// toolset: a server is inside when at least one of its tools is selected.
+func (c *scopedCatalogue) resources(resources []api.ResourceOrigin) []api.ResourceOrigin {
+	if !c.scoped {
+		return resources
+	}
+	out := make([]api.ResourceOrigin, 0, len(resources))
+	for _, r := range resources {
+		if c.res.ContainsServer(r.Server) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// prompts narrows the session's prompts the same way resources does.
+func (c *scopedCatalogue) prompts(prompts []api.PromptOrigin) []api.PromptOrigin {
+	if !c.scoped {
+		return prompts
+	}
+	out := make([]api.PromptOrigin, 0, len(prompts))
+	for _, p := range prompts {
+		if c.res.ContainsServer(p.Server) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// scopedResources lists the session's resources within the toolset. The
+// returned catalogue is nil-safe for unscoped requests (no toolset ⇒ the list
+// is untouched) and lets get_resource refuse a resource whose server is
+// outside the toolset.
+func (p *Provider) scopedResources(ctx context.Context, handler api.MetaToolsHandler) ([]api.ResourceOrigin, *scopedCatalogue, *api.CallToolResult) {
+	cat, errResult := p.catalogue(ctx, handler)
+	if errResult != nil {
+		return nil, nil, errResult
+	}
+	resources, err := handler.ListResources(ctx)
+	if err != nil {
+		return nil, nil, errorResult(fmt.Sprintf("Failed to list resources: %v", err))
+	}
+	return cat.resources(resources), cat, nil
+}
+
+// scopedPrompts mirrors scopedResources for prompts.
+func (p *Provider) scopedPrompts(ctx context.Context, handler api.MetaToolsHandler) ([]api.PromptOrigin, *scopedCatalogue, *api.CallToolResult) {
+	cat, errResult := p.catalogue(ctx, handler)
+	if errResult != nil {
+		return nil, nil, errResult
+	}
+	prompts, err := handler.ListPrompts(ctx)
+	if err != nil {
+		return nil, nil, errorResult(fmt.Sprintf("Failed to list prompts: %v", err))
+	}
+	return cat.prompts(prompts), cat, nil
+}

--- a/internal/metatools/types.go
+++ b/internal/metatools/types.go
@@ -1,5 +1,11 @@
 package metatools
 
+import (
+	"github.com/giantswarm/muster/internal/toolset"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
 // Meta-tool name constants.
 // These are the meta-tools exposed by the aggregator that wrap actual tool access.
 const (
@@ -68,7 +74,49 @@ type ToolInfo struct {
 	Summary     string            `json:"summary,omitempty"`
 	Score       float64           `json:"score,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
-	InputSchema interface{}       `json:"inputSchema,omitempty"`
+	// Server is the MCPServer (or family) the tool comes from; omitted for
+	// workflows and core tools.
+	Server string `json:"server,omitempty"`
+	// Kind is "tool" (served by an MCPServer), "workflow" or "core".
+	Kind string `json:"kind,omitempty"`
+	// Annotations are the tool's MCP annotations as its server declared them
+	// (for a workflow, the derived readOnlyHint); omitted when it has none.
+	Annotations *ToolAnnotations `json:"annotations,omitempty"`
+	InputSchema interface{}      `json:"inputSchema,omitempty"`
+}
+
+// ToolAnnotations are the MCP tool annotations muster forwards from the
+// downstream server, plus the derived read-only hint of a workflow whose step
+// tools are all read-only. Only the hints the server set are present.
+type ToolAnnotations struct {
+	ReadOnlyHint    *bool `json:"readOnlyHint,omitempty"`
+	DestructiveHint *bool `json:"destructiveHint,omitempty"`
+	IdempotentHint  *bool `json:"idempotentHint,omitempty"`
+	OpenWorldHint   *bool `json:"openWorldHint,omitempty"`
+}
+
+// annotationsOf projects a tool's MCP annotations; nil when it carries none.
+func annotationsOf(tool mcp.Tool) *ToolAnnotations {
+	a := tool.Annotations
+	if a.ReadOnlyHint == nil && a.DestructiveHint == nil && a.IdempotentHint == nil && a.OpenWorldHint == nil {
+		return nil
+	}
+	return &ToolAnnotations{
+		ReadOnlyHint:    a.ReadOnlyHint,
+		DestructiveHint: a.DestructiveHint,
+		IdempotentHint:  a.IdempotentHint,
+		OpenWorldHint:   a.OpenWorldHint,
+	}
+}
+
+// originOf projects the origin the aggregator recorded on a tool into the
+// server and kind fields the meta-tools report.
+func originOf(tool mcp.Tool) (server, kind string) {
+	kind = string(toolset.KindOf(tool))
+	if origin, ok := toolset.ToolOriginOf(tool); ok {
+		server = origin.Server
+	}
+	return server, kind
 }
 
 // ListToolsResponse is the response structure from the list_tools meta-tool.
@@ -106,6 +154,15 @@ type FilterToolsResponse struct {
 	Total         int        `json:"total"`
 	Truncated     bool       `json:"truncated"`
 	Tools         []ToolInfo `json:"tools"`
+	// Toolset echoes the inline selectors of the toolset argument when one was
+	// given; the tools above are those it resolves to for the caller.
+	Toolset []string `json:"toolset,omitempty"`
+	// ToolsetUnmatched lists the selectors (of the toolset argument, else of
+	// the request's X-Muster-Toolset) that select no tool for the caller.
+	ToolsetUnmatched []string `json:"toolset_unmatched,omitempty"`
+	// Presets lists the known toolset presets when include_presets is set or a
+	// toolset argument was given.
+	Presets []toolset.Info `json:"presets,omitempty"`
 }
 
 // FilterCriteria describes the filter parameters applied.
@@ -220,7 +277,10 @@ type CapabilityFilterCriteria struct {
 
 // DescribeToolResponse is the response structure from the describe_tool meta-tool.
 type DescribeToolResponse struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	InputSchema interface{} `json:"inputSchema,omitempty"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Server      string           `json:"server,omitempty"`
+	Kind        string           `json:"kind,omitempty"`
+	Annotations *ToolAnnotations `json:"annotations,omitempty"`
+	InputSchema interface{}      `json:"inputSchema,omitempty"`
 }

--- a/internal/testing/mcp_client.go
+++ b/internal/testing/mcp_client.go
@@ -101,6 +101,9 @@ func (c *mcpTestClient) connectWithOptions(ctx context.Context, endpoint, access
 			opts = append(opts, transport.WithHTTPHeaders(h))
 		}
 	}
+	// Per-request headers: a step's `headers:` travel in the step context and
+	// are applied to that request only (mcp-go applies the header func last).
+	opts = append(opts, transport.WithHTTPHeaderFunc(requestHeadersFromContext))
 
 	// Create streamable HTTP client for muster aggregator
 	httpClient, err := client.NewStreamableHttpClient(endpoint, opts...)

--- a/internal/testing/mock/handler.go
+++ b/internal/testing/mock/handler.go
@@ -165,7 +165,9 @@ func (h *ToolHandler) valuesEqual(expected, actual interface{}) bool {
 
 // createMCPTool creates an MCP tool definition from the tool configuration
 func (h *ToolHandler) createMCPTool() mcp.Tool {
-	return mcp.NewTool(h.config.Name, mcp.WithDescription(h.config.Description))
+	tool := mcp.NewTool(h.config.Name, mcp.WithDescription(h.config.Description))
+	h.config.Annotations.Apply(&tool)
+	return tool
 }
 
 // createMCPHandler creates an MCP tool handler function

--- a/internal/testing/mock/server.go
+++ b/internal/testing/mock/server.go
@@ -166,12 +166,19 @@ func NewServerFromFile(configPath string, debug bool) (*Server, error) {
 // shapes (the former is documented as incompatible with ToolOption); we
 // pick one or the other based on whether a schema was declared.
 func toolWithSchema(toolConfig ToolConfig) mcp.Tool {
+	var tool mcp.Tool
 	if len(toolConfig.InputSchema) > 0 {
 		if raw, err := json.Marshal(toolConfig.InputSchema); err == nil {
-			return mcp.NewToolWithRawSchema(toolConfig.Name, toolConfig.Description, raw)
+			tool = mcp.NewToolWithRawSchema(toolConfig.Name, toolConfig.Description, raw)
 		}
 	}
-	return mcp.NewTool(toolConfig.Name, mcp.WithDescription(toolConfig.Description))
+	if tool.Name == "" {
+		tool = mcp.NewTool(toolConfig.Name, mcp.WithDescription(toolConfig.Description))
+	}
+	// Annotations are set on the struct directly: ToolOptions are incompatible
+	// with the raw-schema constructor, and this works for both shapes.
+	toolConfig.Annotations.Apply(&tool)
+	return tool
 }
 
 // createToolHandler creates an MCP tool handler function for the given tool name

--- a/internal/testing/mock/types.go
+++ b/internal/testing/mock/types.go
@@ -1,5 +1,7 @@
 package mock
 
+import "github.com/mark3labs/mcp-go/mcp"
+
 // ToolConfig defines configuration for a mock tool
 type ToolConfig struct {
 	// Name is the unique identifier for the tool
@@ -19,6 +21,30 @@ type ToolConfig struct {
 	// configured response. Used to assert the protocol revision muster's
 	// outbound client negotiates with a downstream server.
 	EchoHandshake bool `yaml:"echo_handshake,omitempty"`
+	// Annotations are the MCP tool annotations the mock declares, so scenarios
+	// can exercise what muster does with a downstream server's read-only /
+	// destructive hints (annotation forwarding, the read-only toolset preset).
+	Annotations *ToolAnnotationsConfig `yaml:"annotations,omitempty"`
+}
+
+// ToolAnnotationsConfig mirrors mcp.ToolAnnotation with the hints a mock tool
+// may declare. A hint that is not set is not sent, like a real server.
+type ToolAnnotationsConfig struct {
+	ReadOnlyHint    *bool `yaml:"read_only_hint,omitempty"`
+	DestructiveHint *bool `yaml:"destructive_hint,omitempty"`
+	IdempotentHint  *bool `yaml:"idempotent_hint,omitempty"`
+	OpenWorldHint   *bool `yaml:"open_world_hint,omitempty"`
+}
+
+// Apply sets the configured hints on tool.
+func (a *ToolAnnotationsConfig) Apply(tool *mcp.Tool) {
+	if a == nil {
+		return
+	}
+	tool.Annotations.ReadOnlyHint = a.ReadOnlyHint
+	tool.Annotations.DestructiveHint = a.DestructiveHint
+	tool.Annotations.IdempotentHint = a.IdempotentHint
+	tool.Annotations.OpenWorldHint = a.OpenWorldHint
 }
 
 // ResourceConfig defines a static MCP resource served by the mock server.

--- a/internal/testing/muster_manager_oauth.go
+++ b/internal/testing/muster_manager_oauth.go
@@ -552,6 +552,20 @@ func (m *musterInstanceManager) extractToolConfigs(config map[string]interface{}
 		if schema, ok := toolMap["input_schema"].(map[string]interface{}); ok {
 			tool.InputSchema = schema
 		}
+		if annotations, ok := toStringMap(toolMap["annotations"]); ok {
+			tool.Annotations = &mock.ToolAnnotationsConfig{}
+			for key, target := range map[string]**bool{
+				"read_only_hint":   &tool.Annotations.ReadOnlyHint,
+				"destructive_hint": &tool.Annotations.DestructiveHint,
+				"idempotent_hint":  &tool.Annotations.IdempotentHint,
+				"open_world_hint":  &tool.Annotations.OpenWorldHint,
+			} {
+				if v, ok := annotations[key].(bool); ok {
+					hint := v
+					*target = &hint
+				}
+			}
+		}
 
 		// Extract responses
 		if responses, ok := toolMap["responses"].([]interface{}); ok {

--- a/internal/testing/request_headers.go
+++ b/internal/testing/request_headers.go
@@ -1,0 +1,23 @@
+package testing
+
+import "context"
+
+type requestHeadersKey struct{}
+
+// WithRequestHeaders returns a context carrying HTTP headers the test client
+// adds to every request it sends under that context. A step's headers are
+// stashed this way so they ride on exactly that step's requests — same client,
+// same MCP session, different headers per request.
+func WithRequestHeaders(ctx context.Context, headers map[string]string) context.Context {
+	if len(headers) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, requestHeadersKey{}, headers)
+}
+
+// requestHeadersFromContext is the client's transport.HTTPHeaderFunc: it
+// returns the headers stashed by WithRequestHeaders, if any.
+func requestHeadersFromContext(ctx context.Context) map[string]string {
+	headers, _ := ctx.Value(requestHeadersKey{}).(map[string]string)
+	return headers
+}

--- a/internal/testing/scenarios/toolset-annotations-forwarded.yaml
+++ b/internal/testing/scenarios/toolset-annotations-forwarded.yaml
@@ -1,0 +1,131 @@
+name: "toolset-annotations-forwarded"
+description: "list_tools, filter_tools and describe_tool carry each tool's downstream annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint), its owning server and its kind (tool | workflow | core), plus the derived read-only hint of a workflow; a tool without annotations carries none (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "annotations", "metatools", "1169"]
+timeout: "5m"
+
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true, idempotent_hint: true, open_world_hint: false }
+            responses: [{ response: { pods: [] } }]
+          - name: "delete_pod"
+            description: "Delete a pod"
+            annotations: { read_only_hint: false, destructive_hint: true }
+            responses: [{ response: { deleted: true } }]
+          - name: "restart"
+            description: "Restart a deployment without annotations"
+            responses: [{ response: { restarted: true } }]
+  workflows:
+    - name: "triage"
+      config:
+        name: "triage"
+        steps:
+          - id: "pods"
+            tool: "x_k8s_get_pods"
+            args: {}
+
+steps:
+  - id: "wait-for-server"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s"]
+
+  - id: "describe-read-only-tool"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "x_k8s_get_pods" } }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      json_path:
+        name: "x_k8s_get_pods"
+        server: "k8s"
+        kind: "tool"
+        annotations.readOnlyHint: true
+        annotations.idempotentHint: true
+        annotations.openWorldHint: false
+      not_contains: ["destructiveHint"]
+
+  - id: "describe-destructive-tool"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "x_k8s_delete_pod" } }
+    expected:
+      success: true
+      json_path:
+        server: "k8s"
+        kind: "tool"
+        annotations.readOnlyHint: false
+        annotations.destructiveHint: true
+
+  - id: "describe-default-annotated-tool"
+    description: "a tool whose server (mcp-go) declared no hints still sends the SDK defaults; they are forwarded verbatim, not invented or dropped"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "x_k8s_restart" } }
+    expected:
+      success: true
+      json_path:
+        server: "k8s"
+        kind: "tool"
+        annotations.readOnlyHint: false
+        annotations.destructiveHint: true
+
+  - id: "describe-workflow"
+    description: "a workflow has kind workflow, no server, and the derived read-only hint"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "workflow_triage" } }
+    expected:
+      success: true
+      json_path:
+        kind: "workflow"
+        annotations.readOnlyHint: true
+
+  - id: "describe-core"
+    description: "a core tool has kind core and carries no annotations field at all today"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "core_workflow_list" } }
+    expected:
+      success: true
+      json_path:
+        kind: "core"
+      not_contains: ["annotations", "readOnlyHint", "server"]
+
+  - id: "filter-tools-carries-them"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "x_k8s_*", limit: 50 } }
+    expected:
+      success: true
+      # The mock server lists its tools alphabetically.
+      json_path:
+        total: 3
+        tools.0.name: "x_k8s_delete_pod"
+        tools.0.server: "k8s"
+        tools.0.kind: "tool"
+        tools.0.annotations.destructiveHint: true
+        tools.0.annotations.readOnlyHint: false
+        tools.1.name: "x_k8s_get_pods"
+        tools.1.annotations.readOnlyHint: true
+        tools.1.annotations.idempotentHint: true
+        tools.2.name: "x_k8s_restart"
+        tools.2.kind: "tool"
+
+  - id: "list-tools-carries-them"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    expected:
+      success: true
+      json_path:
+        tools.0.name: "x_k8s_delete_pod"
+        tools.0.server: "k8s"
+        tools.0.kind: "tool"
+        tools.0.annotations.destructiveHint: true
+        tools.1.name: "x_k8s_get_pods"
+        tools.1.annotations.readOnlyHint: true
+      contains: ["workflow_triage", "core_workflow_list"]

--- a/internal/testing/scenarios/toolset-builtin-presets.yaml
+++ b/internal/testing/scenarios/toolset-builtin-presets.yaml
@@ -1,0 +1,200 @@
+name: "toolset-builtin-presets"
+description: "read-only, none and full resolve with no configuration: read-only is every tool annotated read-only plus every workflow whose step tools are all read-only (the derived hint), none is empty, full is the whole catalogue including core tools; describe_tool carries the derived workflow hint (#1169)"
+category: "behavioral"
+concept: "workflow"
+tags: ["toolset", "presets", "read-only", "workflow", "1169"]
+timeout: "5m"
+
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+          - name: "delete_pod"
+            description: "Delete a pod"
+            annotations: { read_only_hint: false, destructive_hint: true }
+            responses: [{ response: { deleted: true } }]
+          - name: "restart"
+            description: "Restart a deployment (no annotations)"
+            responses: [{ response: { restarted: true } }]
+    - name: "gh"
+      config:
+        tools:
+          - name: "issues"
+            description: "List issues"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { issues: [] } }]
+  workflows:
+    - name: "ro-triage"
+      config:
+        name: "ro-triage"
+        description: "All steps read-only"
+        steps:
+          - id: "pods"
+            tool: "x_k8s_get_pods"
+            args: {}
+          - id: "issues"
+            tool: "x_gh_issues"
+            args: {}
+    - name: "rw-rollout"
+      config:
+        name: "rw-rollout"
+        description: "One destructive step"
+        steps:
+          - id: "pods"
+            tool: "x_k8s_get_pods"
+            args: {}
+          - id: "delete"
+            tool: "x_k8s_delete_pod"
+            args: {}
+    - name: "nested-ro"
+      config:
+        name: "nested-ro"
+        description: "Calls a read-only workflow and a read-only tool"
+        steps:
+          - id: "triage"
+            tool: "workflow_ro-triage"
+            args: {}
+          - id: "issues"
+            tool: "x_gh_issues"
+            args: {}
+    - name: "core-step"
+      config:
+        name: "core-step"
+        description: "Calls a core tool, which carries no annotation"
+        steps:
+          - id: "list"
+            tool: "core_workflow_list"
+            args: {}
+
+steps:
+  - id: "wait-for-servers"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s", "gh"]
+
+  - id: "read-only"
+    description: "preset:read-only = annotated read-only tools + workflows whose steps are all read-only (transitively)"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:read-only" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      json_path:
+        total: 4
+      contains: ["x_k8s_get_pods", "x_gh_issues", "workflow_ro-triage", "workflow_nested-ro"]
+      not_contains: ["x_k8s_delete_pod", "x_k8s_restart", "workflow_rw-rollout", "workflow_core-step", "core_workflow_list", "toolset_unmatched"]
+
+  - id: "read-only-call-allowed"
+    tool: "workflow_ro-triage"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:read-only" }
+    expected:
+      success: true
+      json_path:
+        status: "completed"
+
+  - id: "read-only-call-refused"
+    description: "the workflow with a destructive step is not in read-only"
+    tool: "workflow_rw-rollout"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:read-only" }
+    expected:
+      success: false
+      error_contains: ['tool "workflow_rw-rollout" is outside the toolset [preset:read-only]']
+
+  - id: "none"
+    description: "preset:none resolves to nothing — a structured empty answer, not an error"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:none" }
+    expected:
+      success: true
+      json_path:
+        total: 0
+        total_tools: 0
+      not_contains: ["toolset_unmatched", "x_k8s_get_pods"]
+
+  - id: "none-refuses-everything"
+    tool: "x_k8s_get_pods"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:none" }
+    expected:
+      success: false
+      error_contains: ['tool "x_k8s_get_pods" is outside the toolset [preset:none]']
+
+  - id: "full"
+    description: "preset:full is the whole catalogue, core tools included"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "preset:full" }
+    expected:
+      success: true
+      contains: ["x_k8s_get_pods", "x_k8s_delete_pod", "x_k8s_restart", "x_gh_issues", "workflow_ro-triage", "workflow_rw-rollout", "core_workflow_list", "core_auth_login"]
+
+  - id: "full-calls-destructive"
+    tool: "x_k8s_delete_pod"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:full" }
+    expected:
+      success: true
+      json_path:
+        deleted: true
+
+  - id: "describe-derived-hint"
+    description: "describe_tool carries the derived read-only hint of a workflow"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "workflow_ro-triage" } }
+    expected:
+      success: true
+      json_path:
+        kind: "workflow"
+        annotations.readOnlyHint: true
+
+  - id: "describe-nested-derived-hint"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "workflow_nested-ro" } }
+    expected:
+      success: true
+      json_path:
+        kind: "workflow"
+        annotations.readOnlyHint: true
+
+  - id: "describe-no-hint-for-destructive-workflow"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "workflow_rw-rollout" } }
+    expected:
+      success: true
+      json_path:
+        kind: "workflow"
+      not_contains: ["readOnlyHint"]
+
+  - id: "describe-no-hint-for-core-step-workflow"
+    description: "a core tool carries no annotation, so a workflow calling one is not read-only"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "workflow_core-step" } }
+    expected:
+      success: true
+      json_path:
+        kind: "workflow"
+      not_contains: ["readOnlyHint"]
+
+  - id: "preset-plus-inline"
+    description: "inline selectors add to a preset"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:read-only,workflow:rw-rollout,tool:core_workflow_list" }
+    expected:
+      success: true
+      json_path:
+        total: 6
+      contains: ["workflow_rw-rollout", "core_workflow_list", "x_k8s_get_pods"]
+      not_contains: ["x_k8s_delete_pod", "core_auth_login"]

--- a/internal/testing/scenarios/toolset-configured-presets.yaml
+++ b/internal/testing/scenarios/toolset-configured-presets.yaml
@@ -1,0 +1,159 @@
+name: "toolset-configured-presets"
+description: "Presets from muster's toolsetPresets configuration resolve tool, pattern, server, workflow, readOnly, exclude and composition rules per request; filter_tools include_presets lists them next to the built-ins; an unknown preset error names the configured presets too (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "presets", "configuration", "1169"]
+timeout: "5m"
+
+pre_configuration:
+  main_config:
+    config:
+      toolsetPresets:
+        infra:
+          description: "Infrastructure servers without deletes"
+          include:
+            - server: k8s
+            - server: prom
+          exclude:
+            - pattern: "*_delete_*"
+        ops:
+          description: "infra plus the rollout workflow and one core tool"
+          include:
+            - preset: infra
+            - workflow: rw-rollout
+            - tool: core_workflow_list
+        safe:
+          description: "ops narrowed to read-only, rollout removed"
+          include:
+            - preset: ops
+            - readOnly: true
+          exclude:
+            - workflow: rw-rollout
+        platform:
+          description: "muster's core tools"
+          include:
+            - pattern: "core_*"
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+          - name: "delete_pod"
+            description: "Delete a pod"
+            annotations: { read_only_hint: false, destructive_hint: true }
+            responses: [{ response: { deleted: true } }]
+    - name: "prom"
+      config:
+        tools:
+          - name: "query"
+            description: "Query metrics"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { result: [] } }]
+    - name: "gh"
+      config:
+        tools:
+          - name: "issues"
+            description: "List issues"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { issues: [] } }]
+  workflows:
+    - name: "rw-rollout"
+      config:
+        name: "rw-rollout"
+        steps:
+          - id: "delete"
+            tool: "x_k8s_delete_pod"
+            args: {}
+
+steps:
+  - id: "wait-for-servers"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s", "prom", "gh"]
+
+  - id: "server-and-exclude"
+    description: "infra = both servers minus the excluded pattern"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:infra" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      json_path:
+        total: 2
+      contains: ["x_k8s_get_pods", "x_prom_query"]
+      not_contains: ["x_k8s_delete_pod", "x_gh_issues", "core_"]
+
+  - id: "composition"
+    description: "ops composes infra and adds a workflow and a core tool"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:ops" }
+    expected:
+      success: true
+      json_path:
+        total: 4
+      contains: ["x_k8s_get_pods", "x_prom_query", "workflow_rw-rollout", "core_workflow_list"]
+      not_contains: ["x_k8s_delete_pod", "core_auth_login"]
+
+  - id: "readonly-and-exclude-after-compose"
+    description: "safe = ops ∪ readOnly, then the exclude removes the rollout workflow"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:safe" }
+    expected:
+      success: true
+      json_path:
+        total: 4
+      contains: ["x_k8s_get_pods", "x_prom_query", "x_gh_issues", "core_workflow_list"]
+      not_contains: ["workflow_rw-rollout", "x_k8s_delete_pod"]
+
+  - id: "core-pattern"
+    description: "core tools join a preset through a pattern"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 100 } }
+    headers: { X-Muster-Toolset: "preset:platform" }
+    expected:
+      success: true
+      contains: ["core_workflow_list", "core_auth_login", "core_mcpserver_list"]
+      not_contains: ["x_k8s_get_pods", "workflow_rw-rollout"]
+
+  - id: "presets-listed"
+    description: "include_presets lists built-ins first, then the configured presets"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { include_presets: true, limit: 1 } }
+    expected:
+      success: true
+      json_path:
+        presets.0.name: "read-only"
+        presets.0.built_in: true
+        presets.1.name: "none"
+        presets.2.name: "full"
+        presets.3.name: "infra"
+        presets.3.built_in: false
+        presets.3.description: "Infrastructure servers without deletes"
+        presets.4.name: "ops"
+        presets.5.name: "platform"
+        presets.6.name: "safe"
+
+  - id: "unknown-preset-names-the-configured-ones"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "preset:test-clusters" }
+    expected:
+      success: false
+      error_contains: ['toolset [preset:test-clusters] names unknown preset "test-clusters"; known presets: read-only, none, full, infra, ops, platform, safe']
+
+  - id: "configured-preset-gates-call-tool"
+    tool: "x_k8s_delete_pod"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:infra" }
+    expected:
+      success: false
+      error_contains: ['tool "x_k8s_delete_pod" is outside the toolset [preset:infra]']

--- a/internal/testing/scenarios/toolset-filter-tools-argument.yaml
+++ b/internal/testing/scenarios/toolset-filter-tools-argument.yaml
@@ -1,0 +1,172 @@
+name: "toolset-filter-tools-argument"
+description: "filter_tools resolves an inline toolset argument for the caller and reports the tools, the selectors that matched nothing (toolset_unmatched) and the known presets; with X-Muster-Toolset also present the argument resolves within the header's toolset and never widens it; argument errors use the header's texts (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "filter_tools", "metatools", "1169"]
+timeout: "5m"
+
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+          - name: "delete_pod"
+            description: "Delete a pod"
+            annotations: { read_only_hint: false, destructive_hint: true }
+            responses: [{ response: { deleted: true } }]
+  workflows:
+    - name: "triage"
+      config:
+        name: "triage"
+        steps:
+          - id: "pods"
+            tool: "x_k8s_get_pods"
+            args: {}
+
+steps:
+  - id: "wait-for-server"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s"]
+
+  - id: "resolution-unmatched-presets"
+    description: "the argument resolves; unmatched selectors and presets come back with it"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["preset:read-only", "server:nope", "workflow:missing", "tool:core_workflow_list"]
+        limit: 50
+    expected:
+      success: true
+      wait_for_state: "20s"
+      json_path:
+        total: 3
+        toolset.0: "preset:read-only"
+        toolset.3: "tool:core_workflow_list"
+        toolset_unmatched.0: "server:nope"
+        toolset_unmatched.1: "workflow:missing"
+        presets.0.name: "read-only"
+        presets.0.built_in: true
+        presets.1.name: "none"
+        presets.2.name: "full"
+        presets.2.built_in: true
+      contains: ["x_k8s_get_pods", "workflow_triage", "core_workflow_list"]
+      not_contains: ["x_k8s_delete_pod"]
+
+  - id: "include-presets-alone"
+    description: "include_presets lists presets without narrowing the catalogue"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        include_presets: true
+        pattern: "x_k8s_*"
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 2
+        presets.0.name: "read-only"
+      not_contains: ["toolset_unmatched"]
+
+  - id: "never-widens"
+    description: "header preset:read-only + argument server:k8s resolves within read-only: the destructive tool stays out"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["server:k8s"]
+        limit: 50
+    headers: { X-Muster-Toolset: "preset:read-only" }
+    expected:
+      success: true
+      json_path:
+        total: 1
+        total_tools: 2
+        tools.0.name: "x_k8s_get_pods"
+      not_contains: ["x_k8s_delete_pod", "toolset_unmatched"]
+
+  - id: "argument-outside-header-is-unmatched"
+    description: "a selector the header excludes matches nothing for this request"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["tool:x_k8s_delete_pod"]
+    headers: { X-Muster-Toolset: "preset:read-only" }
+    expected:
+      success: true
+      json_path:
+        total: 0
+        toolset_unmatched.0: "tool:x_k8s_delete_pod"
+
+  - id: "none-is-structured"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["preset:none"]
+    expected:
+      success: true
+      json_path:
+        total: 0
+        toolset.0: "preset:none"
+      not_contains: ["toolset_unmatched", "No tools available"]
+
+  - id: "argument-unknown-preset"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["preset:foo"]
+    expected:
+      success: false
+      error_contains: ['toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full']
+
+  - id: "argument-empty"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: []
+    expected:
+      success: false
+      error_contains: ['toolset [] is empty; use "preset:none"']
+
+  - id: "argument-reserved"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["toolset:shared"]
+    expected:
+      success: false
+      error_contains: ['selector "toolset:shared" is reserved for shared toolsets']
+
+  - id: "argument-label"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["label:tier=infra"]
+    expected:
+      success: false
+      error_contains: ['selector "label:tier=infra" is allowed inside presets only']
+
+  - id: "argument-not-an-array"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: "preset:none"
+    expected:
+      success: false
+      error_contains: ["toolset must be an array of selector strings"]

--- a/internal/testing/scenarios/toolset-header-errors-every-meta-tool.yaml
+++ b/internal/testing/scenarios/toolset-header-errors-every-meta-tool.yaml
@@ -1,0 +1,177 @@
+name: "toolset-header-errors-every-meta-tool"
+description: "A present but invalid X-Muster-Toolset — empty, unknown preset, reserved toolset:, inline label:, more than 32 selectors, malformed — is an error result on every meta-tool call, naming the toolset and the offending selector; it never falls back to the unscoped catalogue and is not sticky (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "metatools", "errors", "1169"]
+timeout: "5m"
+
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+
+steps:
+  - id: "wait-for-server"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s"]
+
+  # --- an unknown preset errors on every one of the 13 meta-tools ---
+  - id: "unknown-preset-list-tools"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full']
+  - id: "unknown-preset-describe-tool"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_tool", arguments: { name: "x_k8s_get_pods" } }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-list-core-tools"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_core_tools" }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-filter-tools"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*" } }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-call-tool"
+    description: "call_tool errors too — never silent full access"
+    tool: "x_k8s_get_pods"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['toolset [preset:foo] names unknown preset "foo"']
+  - id: "unknown-preset-list-resources"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_resources" }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-filter-resources"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_resources", arguments: {} }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-describe-resource"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_resource", arguments: { uri: "k8s://pods" } }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-get-resource"
+    tool: "test_call_meta_tool"
+    args: { tool: "get_resource", arguments: { uri: "k8s://pods" } }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-list-prompts"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_prompts" }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-filter-prompts"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_prompts", arguments: {} }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-describe-prompt"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_prompt", arguments: { name: "x_k8s_debug" } }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+  - id: "unknown-preset-get-prompt"
+    tool: "test_call_meta_tool"
+    args: { tool: "get_prompt", arguments: { name: "x_k8s_debug" } }
+    headers: { X-Muster-Toolset: "preset:foo" }
+    expected:
+      success: false
+      error_contains: ['names unknown preset "foo"']
+
+  # --- the other invalid shapes, each naming the offending selector ---
+  - id: "empty-header"
+    description: "a present but empty header is a declared, invalid toolset — not 'no toolset'"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "" }
+    expected:
+      success: false
+      error_contains: ['toolset [] is empty; use "preset:none"']
+  - id: "reserved-toolset-selector"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "preset:read-only,toolset:shared" }
+    expected:
+      success: false
+      error_contains: ['toolset [preset:read-only,toolset:shared] selector "toolset:shared" is reserved for shared toolsets']
+  - id: "inline-label-selector"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "label:agent-platform.giantswarm.io/tool-group=infrastructure" }
+    expected:
+      success: false
+      error_contains: ['selector "label:agent-platform.giantswarm.io/tool-group=infrastructure" is allowed inside presets only']
+  - id: "malformed-selector"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "preset:none,pattern:core_*" }
+    expected:
+      success: false
+      error_contains: ['selector "pattern:core_*" is malformed; expected preset:<name>, server:<name>, workflow:<name> or tool:<name>']
+  - id: "too-many-selectors"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers:
+      X-Muster-Toolset: "tool:t1,tool:t2,tool:t3,tool:t4,tool:t5,tool:t6,tool:t7,tool:t8,tool:t9,tool:t10,tool:t11,tool:t12,tool:t13,tool:t14,tool:t15,tool:t16,tool:t17,tool:t18,tool:t19,tool:t20,tool:t21,tool:t22,tool:t23,tool:t24,tool:t25,tool:t26,tool:t27,tool:t28,tool:t29,tool:t30,tool:t31,tool:t32,tool:t33"
+    expected:
+      success: false
+      error_contains: ["has 33 selectors, more than the 32 allowed inline; define a preset"]
+  - id: "thirty-two-is-fine"
+    description: "the cap is inclusive"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*" } }
+    headers:
+      X-Muster-Toolset: "tool:t1,tool:t2,tool:t3,tool:t4,tool:t5,tool:t6,tool:t7,tool:t8,tool:t9,tool:t10,tool:t11,tool:t12,tool:t13,tool:t14,tool:t15,tool:t16,tool:t17,tool:t18,tool:t19,tool:t20,tool:t21,tool:t22,tool:t23,tool:t24,tool:t25,tool:t26,tool:t27,tool:t28,tool:t29,tool:t30,tool:t31,tool:x_k8s_get_pods"
+    expected:
+      success: true
+      json_path:
+        total: 1
+        tools.0.name: "x_k8s_get_pods"
+
+  - id: "not-sticky"
+    description: "the errors above bound nothing to the session: the next request without a header is unscoped"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    expected:
+      success: true
+      contains: ["x_k8s_get_pods", "core_workflow_list"]

--- a/internal/testing/scenarios/toolset-header-filters-catalogue.yaml
+++ b/internal/testing/scenarios/toolset-header-filters-catalogue.yaml
@@ -1,0 +1,227 @@
+name: "toolset-header-filters-catalogue"
+description: "A request carrying X-Muster-Toolset sees the session catalogue intersected with the toolset on list_tools, filter_tools, describe_tool and list_core_tools; call_tool of an in-toolset tool behaves as unscoped; an out-of-toolset call_tool or workflow execution is refused naming the toolset and logged (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "metatools", "1169"]
+timeout: "5m"
+
+# Given: two mock servers (k8s with a read-only, a destructive and an
+#        unannotated tool; gh with a read-only tool), a workflow whose steps are
+#        all read-only and one with a destructive step.
+# When:  the meta-tools are called with X-Muster-Toolset: tool:x_k8s_get_pods,workflow:ro-triage
+# Then:  only those two tools are listed, described and callable; everything
+#        else — including core tools — is hidden and refused with the toolset
+#        named; the refusal is logged. A workflow inside the toolset runs even
+#        though its steps call tools outside it: the toolset bounds the model,
+#        not the workflow author's composition.
+
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: ["api-0"] } }]
+          - name: "delete_pod"
+            description: "Delete a pod"
+            annotations: { read_only_hint: false, destructive_hint: true }
+            responses: [{ response: { deleted: true } }]
+          - name: "restart"
+            description: "Restart a deployment"
+            responses: [{ response: { restarted: true } }]
+    - name: "gh"
+      config:
+        tools:
+          - name: "issues"
+            description: "List issues"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { issues: [] } }]
+  workflows:
+    - name: "ro-triage"
+      config:
+        name: "ro-triage"
+        description: "Read-only triage"
+        steps:
+          - id: "pods"
+            tool: "x_k8s_get_pods"
+            args: {}
+          - id: "issues"
+            tool: "x_gh_issues"
+            args: {}
+    - name: "rw-rollout"
+      config:
+        name: "rw-rollout"
+        description: "Rollout with a destructive step"
+        steps:
+          - id: "pods"
+            tool: "x_k8s_get_pods"
+            args: {}
+          - id: "delete"
+            tool: "x_k8s_delete_pod"
+            args: {}
+
+steps:
+  - id: "wait-for-servers"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s", "gh"]
+
+  - id: "unscoped-baseline"
+    description: "Without the header the whole catalogue is visible, core tools included"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "list_tools"
+    expected:
+      success: true
+      wait_for_state: "20s"
+      contains: ["x_k8s_get_pods", "x_k8s_delete_pod", "x_gh_issues", "workflow_ro-triage", "workflow_rw-rollout", "core_workflow_list"]
+
+  - id: "list-tools-scoped"
+    description: "list_tools returns catalogue ∩ toolset"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "list_tools"
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods, workflow:ro-triage"
+    expected:
+      success: true
+      contains: ["x_k8s_get_pods", "workflow_ro-triage"]
+      not_contains: ["x_k8s_delete_pod", "x_k8s_restart", "x_gh_issues", "workflow_rw-rollout", "core_workflow_list", "core_auth_login"]
+
+  - id: "filter-tools-scoped"
+    description: "filter_tools reads the same filtered catalogue"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        pattern: "*"
+        limit: 50
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: true
+      json_path:
+        total: 2
+        total_tools: 2
+      contains: ["x_k8s_get_pods", "workflow_ro-triage"]
+      not_contains: ["x_k8s_delete_pod", "toolset_unmatched"]
+
+  - id: "list-core-tools-scoped"
+    description: "core tools are hidden unless the toolset includes them"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "list_core_tools"
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: true
+      json_path:
+        total: 0
+      not_contains: ["core_workflow_list"]
+
+  - id: "describe-inside"
+    description: "describe_tool works inside the toolset and reports origin and annotations"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "describe_tool"
+      arguments:
+        name: "x_k8s_get_pods"
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: true
+      json_path:
+        name: "x_k8s_get_pods"
+        server: "k8s"
+        kind: "tool"
+        annotations.readOnlyHint: true
+
+  - id: "describe-outside"
+    description: "describe_tool of a visible-but-outside tool names the toolset"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "describe_tool"
+      arguments:
+        name: "x_k8s_delete_pod"
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: false
+      error_contains: ['tool "x_k8s_delete_pod" is outside the toolset [tool:x_k8s_get_pods,workflow:ro-triage]']
+
+  - id: "call-inside"
+    description: "call_tool of an in-toolset tool behaves exactly as unscoped"
+    tool: "x_k8s_get_pods"
+    args: {}
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: true
+      json_path:
+        pods.0: "api-0"
+
+  - id: "call-outside"
+    description: "call_tool of an out-of-toolset tool is refused with the toolset named"
+    tool: "x_k8s_delete_pod"
+    args: {}
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: false
+      error_contains: ['tool "x_k8s_delete_pod" is outside the toolset [tool:x_k8s_get_pods,workflow:ro-triage]']
+
+  - id: "call-core-outside"
+    description: "core tools are refused too unless included"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "call_tool"
+      arguments:
+        name: "core_workflow_list"
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: false
+      error_contains: ['tool "core_workflow_list" is outside the toolset']
+
+  - id: "workflow-inside-runs"
+    description: "a workflow inside the toolset executes; its steps are the author's composition and are not re-checked"
+    tool: "workflow_ro-triage"
+    args: {}
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: true
+      json_path:
+        status: "completed"
+        steps.1.id: "issues"
+        steps.1.status: "completed"
+
+  - id: "workflow-outside-refused"
+    description: "a workflow outside the toolset is refused like any tool"
+    tool: "workflow_rw-rollout"
+    args: {}
+    headers:
+      X-Muster-Toolset: "tool:x_k8s_get_pods,workflow:ro-triage"
+    expected:
+      success: false
+      error_contains: ['tool "workflow_rw-rollout" is outside the toolset [tool:x_k8s_get_pods,workflow:ro-triage]']
+
+  - id: "unscoped-after"
+    description: "the next request without the header is unscoped again — nothing was bound to the session"
+    tool: "x_k8s_delete_pod"
+    args: {}
+    expected:
+      success: true
+      json_path:
+        deleted: true
+
+instance_logs:
+  contains:
+    - "call_tool refused"
+    - "x_k8s_delete_pod"
+    - "workflow_rw-rollout"

--- a/internal/testing/scenarios/toolset-per-request-same-session.yaml
+++ b/internal/testing/scenarios/toolset-per-request-same-session.yaml
@@ -1,0 +1,95 @@
+name: "toolset-per-request-same-session"
+description: "Two requests on the same token and MCP session with different X-Muster-Toolset headers get different catalogues; a request without the header on that same session is unchanged. Nothing about the toolset is bound to the session (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "metatools", "session", "1169"]
+timeout: "5m"
+
+# Why this matters: muster's session for a forwarded token is derived from the
+# token, so every agent one human drives shares one session. A session-bound
+# toolset would apply agent A's toolset to agent B. All steps below run on the
+# one client the harness opened — same session, header varies per step.
+
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+    - name: "gh"
+      config:
+        tools:
+          - name: "issues"
+            description: "List issues"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { issues: [] } }]
+
+steps:
+  - id: "wait-for-servers"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s", "gh"]
+
+  - id: "agent-a-view"
+    description: "request 1 on the session: toolset server:k8s"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      contains: ["x_k8s_get_pods"]
+      not_contains: ["x_gh_issues", "core_workflow_list"]
+
+  - id: "agent-b-view"
+    description: "request 2 on the same session: toolset server:gh sees a different catalogue"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "server:gh" }
+    expected:
+      success: true
+      contains: ["x_gh_issues"]
+      not_contains: ["x_k8s_get_pods", "core_workflow_list"]
+
+  - id: "agent-a-again"
+    description: "request 3 switches back — the previous header left nothing behind"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: true
+      contains: ["x_k8s_get_pods"]
+      not_contains: ["x_gh_issues"]
+
+  - id: "none-view"
+    description: "preset:none on the same session resolves to nothing"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:none" }
+    expected:
+      success: true
+      json_path:
+        total: 0
+        total_tools: 0
+        filtered_count: 0
+
+  - id: "human-view"
+    description: "request without the header on the same session: the unscoped catalogue, core tools included"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    expected:
+      success: true
+      contains: ["x_k8s_get_pods", "x_gh_issues", "core_workflow_list", "core_auth_login"]
+
+  - id: "human-can-call-anything"
+    description: "and it can call what the scoped requests could not"
+    tool: "x_gh_issues"
+    args: {}
+    expected:
+      success: true

--- a/internal/testing/scenarios/toolset-resources-prompts-follow-servers.yaml
+++ b/internal/testing/scenarios/toolset-resources-prompts-follow-servers.yaml
@@ -1,0 +1,153 @@
+name: "toolset-resources-prompts-follow-servers"
+description: "The resource and prompt accessors read the toolset-filtered catalogue: a server is inside the toolset when at least one of its tools is selected; resources and prompts of other servers are hidden and refused naming the toolset; without a header nothing changes (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "resources", "prompts", "metatools", "1169"]
+timeout: "5m"
+
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+        resources:
+          - uri: "k8s://pods"
+            name: "Pods"
+            description: "Pod inventory."
+            text: "pod inventory"
+        prompts:
+          - name: "debug"
+            description: "Debug a pod."
+            text: "Debug this pod."
+    - name: "gh"
+      config:
+        tools:
+          - name: "issues"
+            description: "List issues"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { issues: [] } }]
+        resources:
+          - uri: "gh://repos"
+            name: "Repos"
+            description: "Repository list."
+            text: "repository list"
+        prompts:
+          - name: "review"
+            description: "Review a pull request."
+            text: "Review this PR."
+
+steps:
+  - id: "wait-for-servers"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s", "gh"]
+
+  - id: "unscoped-resources"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_resources" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      contains: ["k8s://pods", "gh://repos"]
+
+  - id: "scoped-resources"
+    description: "server:k8s selects k8s tools, so only k8s resources are inside"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_resources" }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: true
+      contains: ["k8s://pods"]
+      not_contains: ["gh://repos"]
+
+  - id: "scoped-filter-resources"
+    description: "a single selected tool is enough to bring its server's resources inside"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_resources", arguments: {} }
+    headers: { X-Muster-Toolset: "tool:x_k8s_get_pods" }
+    expected:
+      success: true
+      json_path:
+        total: 1
+        total_resources: 1
+        resources.0.uri: "k8s://pods"
+
+  - id: "scoped-get-resource-outside"
+    tool: "test_call_meta_tool"
+    args: { tool: "get_resource", arguments: { uri: "gh://repos" } }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: false
+      error_contains: ['resource "gh://repos" is outside the toolset [server:k8s]']
+
+  - id: "scoped-describe-resource-outside"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_resource", arguments: { uri: "gh://repos" } }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: false
+      error_contains: ['resource "gh://repos" is outside the toolset [server:k8s]']
+
+  - id: "scoped-get-resource-inside"
+    tool: "test_call_meta_tool"
+    args: { tool: "get_resource", arguments: { uri: "k8s://pods" } }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: true
+      contains: ["pod inventory"]
+
+  - id: "scoped-prompts"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_prompts" }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: true
+      contains: ["x_k8s_debug"]
+      not_contains: ["x_gh_review"]
+
+  - id: "scoped-get-prompt-outside"
+    tool: "test_call_meta_tool"
+    args: { tool: "get_prompt", arguments: { name: "x_gh_review" } }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: false
+      error_contains: ['prompt "x_gh_review" is outside the toolset [server:k8s]']
+
+  - id: "scoped-describe-prompt-outside"
+    tool: "test_call_meta_tool"
+    args: { tool: "describe_prompt", arguments: { name: "x_gh_review" } }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: false
+      error_contains: ['prompt "x_gh_review" is outside the toolset [server:k8s]']
+
+  - id: "scoped-get-prompt-inside"
+    tool: "test_call_meta_tool"
+    args: { tool: "get_prompt", arguments: { name: "x_k8s_debug" } }
+    headers: { X-Muster-Toolset: "server:k8s" }
+    expected:
+      success: true
+      contains: ["Debug this pod."]
+
+  - id: "none-hides-all"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_prompts" }
+    headers: { X-Muster-Toolset: "preset:none" }
+    expected:
+      success: true
+      not_contains: ["x_k8s_debug", "x_gh_review"]
+
+  - id: "unscoped-again"
+    description: "without the header the gh prompt is reachable on the same session"
+    tool: "test_call_meta_tool"
+    args: { tool: "get_prompt", arguments: { name: "x_gh_review" } }
+    expected:
+      success: true
+      contains: ["Review this PR."]

--- a/internal/testing/scenarios/toolset-visibility-wins.yaml
+++ b/internal/testing/scenarios/toolset-visibility-wins.yaml
@@ -1,0 +1,133 @@
+name: "toolset-visibility-wins"
+description: "A toolset never widens access: a selector naming a server the session has not authenticated with resolves to nothing (reported in toolset_unmatched), its tools are absent and refused; after the session signs in the same toolset resolves to them (#1169)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "oauth", "visibility", "1169"]
+timeout: "5m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "toolset-idp"
+      scopes: ["openid", "profile"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+  mcp_servers:
+    - name: "k8s"
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+    - name: "protected"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "toolset-idp"
+        tools:
+          - name: "secret_op"
+            description: "A protected read-only operation"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { status: "ok" } }]
+
+steps:
+  - id: "wait-for-servers"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s", "protected"]
+
+  - id: "before-login-listing"
+    description: "the toolset names the protected server, but the session cannot see it: visibility wins"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "server:protected,server:k8s" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      contains: ["x_k8s_get_pods", "servers_requiring_auth", "protected"]
+      not_contains: ["x_protected_secret_op"]
+
+  - id: "before-login-unmatched"
+    description: "filter_tools reports the selector as matching nothing for this caller"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["server:protected", "server:k8s"]
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 1
+        tools.0.name: "x_k8s_get_pods"
+        toolset_unmatched.0: "server:protected"
+
+  - id: "before-login-refused"
+    description: "calling the protected tool is refused as outside the toolset — it is not in the caller's catalogue"
+    tool: "test_call_meta_tool"
+    args: { tool: "call_tool", arguments: { name: "x_protected_secret_op" } }
+    headers: { X-Muster-Toolset: "server:protected" }
+    expected:
+      success: false
+      error_contains: ['tool "x_protected_secret_op" is outside the toolset [server:protected]']
+
+  - id: "start-login"
+    tool: "core_auth_login"
+    args: { server: "protected" }
+    expected:
+      success: true
+      contains: ["http"]
+
+  - id: "complete-login"
+    tool: "test_simulate_oauth_callback"
+    args: { server: "protected" }
+    expected:
+      success: true
+      contains: ["success"]
+
+  - id: "establish-connection"
+    tool: "core_auth_login"
+    args: { server: "protected" }
+    expected:
+      success: true
+
+  - id: "after-login-listing"
+    description: "the same toolset on the same session now resolves to the protected tool"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "server:protected" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      contains: ["x_protected_secret_op"]
+      not_contains: ["x_k8s_get_pods"]
+
+  - id: "after-login-matched"
+    tool: "test_call_meta_tool"
+    args:
+      tool: "filter_tools"
+      arguments:
+        toolset: ["server:protected"]
+        limit: 50
+    expected:
+      success: true
+      json_path:
+        total: 1
+        tools.0.name: "x_protected_secret_op"
+        tools.0.server: "protected"
+        tools.0.annotations.readOnlyHint: true
+      not_contains: ["toolset_unmatched"]
+
+  - id: "after-login-call"
+    tool: "x_protected_secret_op"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:read-only" }
+    expected:
+      success: true
+      json_path:
+        status: "ok"

--- a/internal/testing/step_fields_test.go
+++ b/internal/testing/step_fields_test.go
@@ -69,6 +69,7 @@ func TestEveryStepFieldIsActedOn(t *testing.T) {
 		"Expected":    "test_runner.go",
 		"Timeout":     "test_runner.go",
 		"AsUser":      "test_runner.go",
+		"Headers":     "test_runner.go", // stashed in the step ctx; the client's header func sends them
 	}
 
 	// rejectedAtLoadTime holds the fields that are deliberately inert: accepted

--- a/internal/testing/test_runner.go
+++ b/internal/testing/test_runner.go
@@ -601,6 +601,10 @@ func (r *testRunner) runStep(ctx context.Context, step TestStep, config TestConf
 		stepCtx, cancel = context.WithTimeout(ctx, step.Timeout)
 		defer cancel()
 	}
+	// The step's HTTP headers ride in its context; the client's header func
+	// sends them on exactly this step's requests (wait_for_state polls
+	// included), so per-request evaluation can be proven on one session.
+	stepCtx = WithRequestHeaders(stepCtx, step.Headers)
 
 	// Resolve template variables in step arguments if scenario context is available
 	resolvedArgs := step.Args
@@ -725,6 +729,10 @@ func (r *testRunner) runTestToolStep(ctx context.Context, step TestStep, config 
 		stepCtx, cancel = context.WithTimeout(ctx, step.Timeout)
 		defer cancel()
 	}
+	// The step's HTTP headers ride in its context; the client's header func
+	// sends them on exactly this step's requests (wait_for_state polls
+	// included), so per-request evaluation can be proven on one session.
+	stepCtx = WithRequestHeaders(stepCtx, step.Headers)
 
 	// Resolve template variables in step arguments if scenario context is available
 	resolvedArgs := step.Args

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -517,6 +517,12 @@ type TestStep struct {
 	// AsUser specifies which user session to execute this step as.
 	// For multi-user testing scenarios. If not set, uses the current user.
 	AsUser string `yaml:"as_user,omitempty"`
+	// Headers are HTTP headers sent on this step's requests to the muster
+	// instance (e.g. X-Muster-Toolset). They apply to this step only, on the
+	// same client and session as the surrounding steps, which is what lets a
+	// scenario prove per-request evaluation: two steps on one session with
+	// different headers, or a step without any.
+	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
 // TestExpectation defines what result is expected from a test step

--- a/internal/toolset/catalogue.go
+++ b/internal/toolset/catalogue.go
@@ -1,0 +1,95 @@
+package toolset
+
+import (
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Kind classifies a catalogue entry the way the meta-tools report it.
+type Kind string
+
+const (
+	KindEntryTool     Kind = "tool"
+	KindEntryWorkflow Kind = "workflow"
+	KindEntryCore     Kind = "core"
+)
+
+// Entry is what toolset resolution knows about one exposed tool.
+type Entry struct {
+	// Name is the exposed tool name (x_<server>_<tool>, workflow_<name>, core_*).
+	Name string
+	// Kind is tool, workflow or core.
+	Kind Kind
+	// Server is the owning MCPServer (the family name for a family tool).
+	// Empty for workflows and core tools.
+	Server string
+	// Servers lists the member servers of a family tool.
+	Servers []string
+	// ReadOnly is the tool's readOnlyHint annotation (for a workflow the
+	// derived hint the aggregator computed from its step tools).
+	ReadOnly bool
+	// Labels are the labels of the owning MCPServer resource (#1168). Nil
+	// when unknown.
+	Labels map[string]string
+}
+
+// ServerLabels resolves an MCPServer name to its resource labels. It is
+// consulted for server tools when non-nil; see #1168.
+type ServerLabels func(server string) map[string]string
+
+// EntriesFromTools projects exposed tools to resolution entries. Kind and
+// server come from the origin the aggregator stashed on the tool; tools
+// without one are classified by name prefix, which is how the aggregator
+// itself tells core and workflow tools apart.
+func EntriesFromTools(tools []mcp.Tool, labels ServerLabels) []Entry {
+	entries := make([]Entry, 0, len(tools))
+	for _, t := range tools {
+		e := Entry{Name: t.Name, Kind: KindOf(t)}
+		if origin, ok := ToolOriginOf(t); ok {
+			e.Server = origin.Server
+			e.Servers = origin.Servers
+		}
+		if t.Annotations.ReadOnlyHint != nil && *t.Annotations.ReadOnlyHint {
+			e.ReadOnly = true
+		}
+		if labels != nil && e.Kind == KindEntryTool && e.Server != "" {
+			e.Labels = labels(e.Server)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+// KindOf classifies an exposed tool: from its origin when the aggregator
+// recorded one, else by the name prefixes the aggregator uses.
+func KindOf(t mcp.Tool) Kind {
+	if origin, ok := ToolOriginOf(t); ok {
+		switch origin.Kind {
+		case OriginKindWorkflow:
+			return KindEntryWorkflow
+		case OriginKindCore:
+			return KindEntryCore
+		case OriginKindTool:
+			return KindEntryTool
+		}
+	}
+	switch {
+	case strings.HasPrefix(t.Name, "workflow_"):
+		return KindEntryWorkflow
+	case strings.HasPrefix(t.Name, "core_"):
+		return KindEntryCore
+	}
+	return KindEntryTool
+}
+
+// Filter returns the tools whose names the resolution selected, in input order.
+func Filter(tools []mcp.Tool, res Resolution) []mcp.Tool {
+	out := make([]mcp.Tool, 0, len(res.Selected))
+	for _, t := range tools {
+		if _, ok := res.Selected[t.Name]; ok {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/toolset/doc.go
+++ b/internal/toolset/doc.go
@@ -1,0 +1,20 @@
+// Package toolset implements declared toolsets: the selector list an agent
+// sends in the X-Muster-Toolset header (or passes to filter_tools) that bounds
+// which of the gateway's tools its meta-tools can see and call.
+//
+// A toolset is evaluated per request, statelessly, as the third filter on the
+// per-session catalogue — after server-authentication visibility and workflow
+// availability. It never widens access: the catalogue it filters is already
+// the caller's own.
+//
+// Inline grammar (header, filter_tools argument): preset:<name>, server:<name>,
+// workflow:<name>, tool:<name> with exact names, at most MaxInlineSelectors.
+// toolset:<name> is reserved; label: exists inside presets only. Patterns,
+// excludes, the read-only predicate and composition live in presets, which are
+// muster configuration (toolsetPresets) with read-only, none and full built in.
+//
+// The package has one scope-source seam, SourceFromRequest: the header is the
+// first source of a request's toolset, an actor claim from a future agent
+// identity the second. Parsing, resolution and the refusal do not change with
+// the source.
+package toolset

--- a/internal/toolset/origin.go
+++ b/internal/toolset/origin.go
@@ -1,0 +1,69 @@
+package toolset
+
+import (
+	"maps"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// MetaKeyOrigin is the mcp.Tool._meta.AdditionalFields key under which the
+// aggregator records where an exposed tool comes from (ToolOrigin). Like the
+// discovery labels key it is an in-process annotation: the meta-tools project
+// it into their own response fields (server, kind) and it is never sent to a
+// client as _meta.
+const MetaKeyOrigin = "muster.giantswarm.io/origin"
+
+// MetaKeyLabels mirrors api.MetaKeyLabels for tests in this package; the
+// aggregator stashes discovery labels under it.
+const MetaKeyLabels = "muster.giantswarm.io/labels"
+
+// OriginKind classifies an exposed tool by what serves it.
+type OriginKind string
+
+const (
+	// OriginKindTool is a tool served by a registered MCP server
+	// (x_<server>_<tool> or x_<family>_<tool>).
+	OriginKindTool OriginKind = "tool"
+	// OriginKindWorkflow is a workflow execution tool (workflow_<name>).
+	OriginKindWorkflow OriginKind = "workflow"
+	// OriginKindCore is one of muster's own core_* tools.
+	OriginKindCore OriginKind = "core"
+)
+
+// ToolOrigin records where an exposed tool comes from. It is stashed on the
+// mcp.Tool by the aggregator when the exposed catalogue is assembled and read
+// by the meta-tools (server / kind in list_tools, filter_tools, describe_tool)
+// and by toolset resolution (server:<name> selectors).
+type ToolOrigin struct {
+	// Kind classifies the tool: tool, workflow or core.
+	Kind OriginKind
+	// Server is the owning MCPServer for a server tool. For a family-grouped
+	// tool it is the family name, which is what the exposed name carries.
+	// Empty for workflows and core tools.
+	Server string
+	// Servers lists the member servers providing a family-grouped tool, in
+	// sorted order. Empty for solo tools, workflows and core tools.
+	Servers []string
+}
+
+// SetToolOrigin records origin on tool. The tool's _meta is cloned before it
+// is written to, because exposed tools are shallow copies of the downstream
+// tools the registry keeps and share their Meta pointer.
+func SetToolOrigin(tool *mcp.Tool, origin ToolOrigin) {
+	meta := &mcp.Meta{AdditionalFields: map[string]any{}}
+	if tool.Meta != nil {
+		meta.ProgressToken = tool.Meta.ProgressToken
+		maps.Copy(meta.AdditionalFields, tool.Meta.AdditionalFields)
+	}
+	meta.AdditionalFields[MetaKeyOrigin] = origin
+	tool.Meta = meta
+}
+
+// ToolOriginOf returns the origin recorded on tool, if any.
+func ToolOriginOf(tool mcp.Tool) (ToolOrigin, bool) {
+	if tool.Meta == nil || tool.Meta.AdditionalFields == nil {
+		return ToolOrigin{}, false
+	}
+	origin, ok := tool.Meta.AdditionalFields[MetaKeyOrigin].(ToolOrigin)
+	return origin, ok
+}

--- a/internal/toolset/preset.go
+++ b/internal/toolset/preset.go
@@ -1,0 +1,246 @@
+package toolset
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Built-in preset names. They are always defined and cannot be redefined by
+// configuration, so a toolset naming one of them can never hit the
+// unknown-preset error.
+const (
+	PresetReadOnly = "read-only"
+	PresetNone     = "none"
+	PresetFull     = "full"
+)
+
+// builtInOrder is the order built-in presets are listed in.
+var builtInOrder = []string{PresetReadOnly, PresetNone, PresetFull}
+
+// presetNamePattern bounds preset names to what fits a selector and a values
+// key: letters, digits, dot, underscore and dash.
+var presetNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// Rule is one selector inside a preset. Exactly one field is set.
+//
+//   - tool: <exact exposed name>
+//   - pattern: <glob on the exposed name>   (e.g. core_*, x_mcp-kubernetes_*)
+//   - server: <name>                         (every tool of that server; a family
+//     name selects the family surface)
+//   - workflow: <name>                       (the workflow's execution tool)
+//   - readOnly: true                         (every tool annotated read-only,
+//     including the derived workflow hint)
+//   - preset: <name>                         (composition; include only)
+type Rule struct {
+	Tool     string `yaml:"tool,omitempty" json:"tool,omitempty"`
+	Pattern  string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
+	Server   string `yaml:"server,omitempty" json:"server,omitempty"`
+	Workflow string `yaml:"workflow,omitempty" json:"workflow,omitempty"`
+	ReadOnly *bool  `yaml:"readOnly,omitempty" json:"readOnly,omitempty"`
+	Preset   string `yaml:"preset,omitempty" json:"preset,omitempty"`
+}
+
+// ruleKeys are the accepted rule keys, named in validation errors.
+const ruleKeys = "tool, pattern, server, workflow, readOnly, preset"
+
+// String renders the rule the way it is written in configuration.
+func (r Rule) String() string {
+	switch {
+	case r.Tool != "":
+		return "tool: " + r.Tool
+	case r.Pattern != "":
+		return "pattern: " + r.Pattern
+	case r.Server != "":
+		return "server: " + r.Server
+	case r.Workflow != "":
+		return "workflow: " + r.Workflow
+	case r.ReadOnly != nil:
+		return fmt.Sprintf("readOnly: %t", *r.ReadOnly)
+	case r.Preset != "":
+		return "preset: " + r.Preset
+	}
+	return "{}"
+}
+
+// setKeys counts how many rule keys are set.
+func (r Rule) setKeys() int {
+	n := 0
+	for _, set := range []bool{r.Tool != "", r.Pattern != "", r.Server != "", r.Workflow != "", r.ReadOnly != nil, r.Preset != ""} {
+		if set {
+			n++
+		}
+	}
+	return n
+}
+
+// Preset is a named, described selection of tools: the union of its include
+// rules minus its exclude rules.
+type Preset struct {
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	Include     []Rule `yaml:"include" json:"include"`
+	Exclude     []Rule `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+}
+
+// PresetsConfig is the `toolsetPresets:` block of muster's configuration.
+type PresetsConfig map[string]Preset
+
+// Info describes a preset for discovery (filter_tools include_presets).
+type Info struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	BuiltIn     bool   `json:"built_in"`
+}
+
+// Registry holds the built-in presets and the configured ones, validated.
+type Registry struct {
+	presets    map[string]Preset
+	builtIn    map[string]bool
+	configured []string // sorted configured names
+}
+
+func builtInPresets() map[string]Preset {
+	yes := true
+	return map[string]Preset{
+		PresetReadOnly: {
+			Description: "Every tool its server annotates read-only, plus every workflow whose step tools are all read-only",
+			Include:     []Rule{{ReadOnly: &yes}},
+		},
+		PresetNone: {
+			Description: "No tools",
+			Include:     []Rule{},
+		},
+		PresetFull: {
+			Description: "The whole catalogue, including muster's core tools",
+			Include:     []Rule{{Pattern: "*"}},
+		},
+	}
+}
+
+// BuiltIns returns a registry with only the built-in presets.
+func BuiltIns() *Registry {
+	r, _ := NewRegistry(nil)
+	return r
+}
+
+// NewRegistry validates cfg and returns the registry of built-in plus
+// configured presets. Every validation error names the preset (and rule) so
+// the operator can fix the values; the first error stops startup.
+func NewRegistry(cfg PresetsConfig) (*Registry, error) {
+	r := &Registry{presets: builtInPresets(), builtIn: map[string]bool{}}
+	for name := range r.presets {
+		r.builtIn[name] = true
+	}
+
+	names := make([]string, 0, len(cfg))
+	for name := range cfg {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if r.builtIn[name] {
+			return nil, fmt.Errorf("toolsetPresets: preset %q is built in and cannot be redefined", name)
+		}
+		if !presetNamePattern.MatchString(name) {
+			return nil, fmt.Errorf("toolsetPresets: preset name %q is invalid; use letters, digits, '.', '_' or '-'", name)
+		}
+		p := cfg[name]
+		if err := validateRules(name, "include", p.Include, true); err != nil {
+			return nil, err
+		}
+		if err := validateRules(name, "exclude", p.Exclude, false); err != nil {
+			return nil, err
+		}
+		r.presets[name] = p
+		r.configured = append(r.configured, name)
+	}
+
+	// Composition must reference known presets and must not cycle.
+	for _, name := range r.configured {
+		if err := r.checkComposition(name, nil); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+func validateRules(preset, list string, rules []Rule, allowPreset bool) error {
+	for i, rule := range rules {
+		at := fmt.Sprintf("toolsetPresets: preset %q %s[%d]", preset, list, i)
+		if rule.setKeys() != 1 {
+			return fmt.Errorf("%s must set exactly one of %s", at, ruleKeys)
+		}
+		switch {
+		case rule.Pattern != "":
+			if _, err := filepath.Match(rule.Pattern, ""); err != nil {
+				return fmt.Errorf("%s pattern %q is invalid: %v", at, rule.Pattern, err)
+			}
+		case rule.ReadOnly != nil && !*rule.ReadOnly:
+			return fmt.Errorf("%s readOnly: false selects nothing; omit the rule", at)
+		case rule.Preset != "" && !allowPreset:
+			return fmt.Errorf("%s cannot compose a preset in %s; only include may", at, list)
+		}
+	}
+	return nil
+}
+
+func (r *Registry) checkComposition(name string, path []string) error {
+	for _, seen := range path {
+		if seen == name {
+			return fmt.Errorf("toolsetPresets: preset composition cycles: %s -> %s", strings.Join(path, " -> "), name)
+		}
+	}
+	path = append(path, name)
+	p, ok := r.presets[name]
+	if !ok {
+		return fmt.Errorf("toolsetPresets: preset %q includes unknown preset %q; known presets: %s",
+			path[len(path)-2], name, strings.Join(r.Names(), ", "))
+	}
+	for _, rule := range p.Include {
+		if rule.Preset != "" {
+			if err := r.checkComposition(rule.Preset, path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Get returns a preset by name.
+func (r *Registry) Get(name string) (Preset, bool) {
+	p, ok := r.presets[name]
+	return p, ok
+}
+
+// Names lists every known preset: built-ins first, then configured presets
+// sorted by name. This is the order error messages and List use.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.presets))
+	names = append(names, builtInOrder...)
+	names = append(names, r.configured...)
+	return names
+}
+
+// List describes every known preset for discovery.
+func (r *Registry) List() []Info {
+	infos := make([]Info, 0, len(r.presets))
+	for _, name := range r.Names() {
+		infos = append(infos, Info{Name: name, Description: r.presets[name].Description, BuiltIn: r.builtIn[name]})
+	}
+	return infos
+}
+
+// Check verifies that every preset the toolset names is known. It is what
+// makes an unknown preset an error on every meta-tool call, before any
+// catalogue is consulted.
+func (r *Registry) Check(ts Toolset) error {
+	for _, name := range ts.Presets() {
+		if _, ok := r.presets[name]; !ok {
+			return fmt.Errorf("toolset %s names unknown preset %q; known presets: %s", ts, name, strings.Join(r.Names(), ", "))
+		}
+	}
+	return nil
+}

--- a/internal/toolset/preset_test.go
+++ b/internal/toolset/preset_test.go
@@ -1,0 +1,104 @@
+package toolset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/yaml.v3"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestNewRegistry_BuiltInsAlwaysPresent(t *testing.T) {
+	r := BuiltIns()
+	assert.Equal(t, []string{"read-only", "none", "full"}, r.Names())
+	infos := r.List()
+	require.Len(t, infos, 3)
+	for _, info := range infos {
+		assert.True(t, info.BuiltIn, info.Name)
+		assert.NotEmpty(t, info.Description, info.Name)
+	}
+}
+
+func TestNewRegistry_ConfiguredPresetsListedAfterBuiltInsSorted(t *testing.T) {
+	r, err := NewRegistry(PresetsConfig{
+		"infrastructure": {Description: "infra", Include: []Rule{{Server: "mcp-kubernetes"}}},
+		"agent-platform": {Description: "ap", Include: []Rule{{Server: "agent-manager"}, {Pattern: "core_*"}}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"read-only", "none", "full", "agent-platform", "infrastructure"}, r.Names())
+	infos := r.List()
+	assert.Equal(t, Info{Name: "agent-platform", Description: "ap", BuiltIn: false}, infos[3])
+}
+
+func TestNewRegistry_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  PresetsConfig
+		want string
+	}{
+		{"redefines built-in", PresetsConfig{"read-only": {Include: []Rule{{Pattern: "*"}}}}, `preset "read-only" is built in and cannot be redefined`},
+		{"redefines none", PresetsConfig{"none": {}}, `preset "none" is built in`},
+		{"bad name", PresetsConfig{"has space": {Include: []Rule{{Pattern: "*"}}}}, `preset name "has space" is invalid`},
+		{"empty rule", PresetsConfig{"x": {Include: []Rule{{}}}}, `preset "x" include[0] must set exactly one of tool, pattern, server, workflow, readOnly, preset`},
+		{"two keys", PresetsConfig{"x": {Include: []Rule{{Tool: "a", Server: "b"}}}}, `include[0] must set exactly one of`},
+		{"bad pattern", PresetsConfig{"x": {Include: []Rule{{Pattern: "[a"}}}}, `include[0] pattern "[a" is invalid`},
+		{"readOnly false", PresetsConfig{"x": {Include: []Rule{{ReadOnly: boolPtr(false)}}}}, `readOnly: false selects nothing`},
+		{"preset in exclude", PresetsConfig{"x": {Include: []Rule{{Pattern: "*"}}, Exclude: []Rule{{Preset: "none"}}}}, `exclude[0] cannot compose a preset in exclude`},
+		{"unknown composed preset", PresetsConfig{"x": {Include: []Rule{{Preset: "nope"}}}}, `preset "x" includes unknown preset "nope"; known presets: read-only, none, full, x`},
+		{"cycle", PresetsConfig{"a": {Include: []Rule{{Preset: "b"}}}, "b": {Include: []Rule{{Preset: "a"}}}}, `preset composition cycles: a -> b -> a`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewRegistry(tc.cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestRegistry_CheckNamesUnknownPreset(t *testing.T) {
+	r, err := NewRegistry(PresetsConfig{"infrastructure": {Include: []Rule{{Server: "k8s"}}}})
+	require.NoError(t, err)
+
+	ts, err := ParseHeader("preset:read-only,preset:foo")
+	require.NoError(t, err)
+	err = r.Check(ts)
+	require.Error(t, err)
+	assert.Equal(t, `toolset [preset:read-only,preset:foo] names unknown preset "foo"; known presets: read-only, none, full, infrastructure`, err.Error())
+
+	ok, _ := ParseHeader("preset:read-only,preset:infrastructure,preset:none,preset:full")
+	assert.NoError(t, r.Check(ok))
+}
+
+func TestPresetsConfig_YAMLShape(t *testing.T) {
+	src := `
+infrastructure:
+  description: Every infrastructure server
+  include:
+    - server: mcp-kubernetes
+    - pattern: x_mcp-prometheus_*
+    - workflow: incident-triage
+    - tool: core_workflow_list
+    - readOnly: true
+    - preset: none
+  exclude:
+    - tool: x_mcp-kubernetes_delete
+`
+	var cfg PresetsConfig
+	require.NoError(t, yaml.Unmarshal([]byte(src), &cfg))
+	p := cfg["infrastructure"]
+	assert.Equal(t, "Every infrastructure server", p.Description)
+	require.Len(t, p.Include, 6)
+	assert.Equal(t, "server: mcp-kubernetes", p.Include[0].String())
+	assert.Equal(t, "pattern: x_mcp-prometheus_*", p.Include[1].String())
+	assert.Equal(t, "workflow: incident-triage", p.Include[2].String())
+	assert.Equal(t, "tool: core_workflow_list", p.Include[3].String())
+	assert.Equal(t, "readOnly: true", p.Include[4].String())
+	assert.Equal(t, "preset: none", p.Include[5].String())
+	require.Len(t, p.Exclude, 1)
+	_, err := NewRegistry(cfg)
+	require.NoError(t, err)
+}

--- a/internal/toolset/resolve.go
+++ b/internal/toolset/resolve.go
@@ -1,0 +1,164 @@
+package toolset
+
+import (
+	"path/filepath"
+	"slices"
+	"sort"
+)
+
+// Resolution is the outcome of evaluating a toolset against a catalogue.
+type Resolution struct {
+	// Selected holds the exposed names of the tools the toolset resolves to.
+	Selected map[string]struct{}
+	// Unmatched lists the inline selectors (as written) that selected no
+	// tool in this catalogue. preset:none is empty by definition and is never
+	// reported.
+	Unmatched []string
+	// Servers holds every server that contributes at least one selected tool
+	// (family members included). Resource and prompt accessors use it to
+	// decide which servers are inside the toolset.
+	Servers map[string]struct{}
+}
+
+// Contains reports whether the exposed tool name is inside the resolution.
+func (r Resolution) Contains(name string) bool {
+	_, ok := r.Selected[name]
+	return ok
+}
+
+// ContainsServer reports whether a server contributes to the resolution.
+func (r Resolution) ContainsServer(server string) bool {
+	_, ok := r.Servers[server]
+	return ok
+}
+
+// Names returns the selected exposed names, sorted.
+func (r Resolution) Names() []string {
+	names := make([]string, 0, len(r.Selected))
+	for name := range r.Selected {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Resolve evaluates ts against entries. Inline selectors are unioned; each
+// preset resolves to its includes minus its excludes, recursively for
+// composed presets. Every preset the toolset names must exist (Check) or the
+// unknown-preset error is returned.
+func (r *Registry) Resolve(ts Toolset, entries []Entry) (Resolution, error) {
+	if err := r.Check(ts); err != nil {
+		return Resolution{}, err
+	}
+	res := Resolution{Selected: map[string]struct{}{}, Servers: map[string]struct{}{}}
+	for i, sel := range ts.Selectors {
+		var matched map[string]struct{}
+		switch sel.Kind {
+		case KindPreset:
+			matched = r.resolvePreset(sel.Name, entries, map[string]bool{})
+		default:
+			matched = matchInline(sel, entries)
+		}
+		isNone := sel.Kind == KindPreset && sel.Name == PresetNone
+		if len(matched) == 0 && !isNone {
+			res.Unmatched = append(res.Unmatched, ts.Raw[i])
+		}
+		for name := range matched {
+			res.Selected[name] = struct{}{}
+		}
+	}
+	for _, e := range entries {
+		if _, ok := res.Selected[e.Name]; !ok {
+			continue
+		}
+		if e.Server != "" {
+			res.Servers[e.Server] = struct{}{}
+		}
+		for _, s := range e.Servers {
+			res.Servers[s] = struct{}{}
+		}
+	}
+	return res, nil
+}
+
+// matchInline evaluates a server:, workflow: or tool: selector.
+func matchInline(sel Selector, entries []Entry) map[string]struct{} {
+	matched := map[string]struct{}{}
+	for _, e := range entries {
+		var ok bool
+		switch sel.Kind {
+		case KindTool:
+			ok = e.Name == sel.Name
+		case KindServer:
+			ok = entryServedBy(e, sel.Name)
+		case KindWorkflow:
+			ok = e.Kind == KindEntryWorkflow && e.Name == "workflow_"+sel.Name
+		}
+		if ok {
+			matched[e.Name] = struct{}{}
+		}
+	}
+	return matched
+}
+
+// entryServedBy reports whether server owns the entry: its server (or family)
+// name, or one of the family members providing it.
+func entryServedBy(e Entry, server string) bool {
+	if e.Kind != KindEntryTool {
+		return false
+	}
+	return e.Server == server || slices.Contains(e.Servers, server)
+}
+
+// resolvePreset returns the names a preset selects: includes minus excludes.
+// visiting guards against composition cycles (rejected at construction, but
+// the walk stays safe regardless).
+func (r *Registry) resolvePreset(name string, entries []Entry, visiting map[string]bool) map[string]struct{} {
+	matched := map[string]struct{}{}
+	p, ok := r.presets[name]
+	if !ok || visiting[name] {
+		return matched
+	}
+	visiting[name] = true
+	defer delete(visiting, name)
+
+	for _, rule := range p.Include {
+		if rule.Preset != "" {
+			for n := range r.resolvePreset(rule.Preset, entries, visiting) {
+				matched[n] = struct{}{}
+			}
+			continue
+		}
+		for _, e := range entries {
+			if ruleMatches(rule, e) {
+				matched[e.Name] = struct{}{}
+			}
+		}
+	}
+	for _, rule := range p.Exclude {
+		for _, e := range entries {
+			if ruleMatches(rule, e) {
+				delete(matched, e.Name)
+			}
+		}
+	}
+	return matched
+}
+
+// ruleMatches evaluates one preset rule against one entry.
+func ruleMatches(rule Rule, e Entry) bool {
+	switch {
+	case rule.Tool != "":
+		return e.Name == rule.Tool
+	case rule.Pattern != "":
+		ok, _ := filepath.Match(rule.Pattern, e.Name)
+		return ok
+	case rule.Server != "":
+		return entryServedBy(e, rule.Server)
+	case rule.Workflow != "":
+		return e.Kind == KindEntryWorkflow && e.Name == "workflow_"+rule.Workflow
+	case rule.ReadOnly != nil:
+		return *rule.ReadOnly && e.ReadOnly
+	}
+	return false
+}

--- a/internal/toolset/resolve_test.go
+++ b/internal/toolset/resolve_test.go
@@ -1,0 +1,187 @@
+package toolset
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func serverTool(name, server string, readOnly bool) mcp.Tool {
+	t := mcp.Tool{Name: name}
+	if readOnly {
+		t.Annotations.ReadOnlyHint = boolPtr(true)
+	}
+	SetToolOrigin(&t, ToolOrigin{Kind: OriginKindTool, Server: server})
+	return t
+}
+
+func familyTool(name, family string, members []string, readOnly bool) mcp.Tool {
+	t := mcp.Tool{Name: name}
+	if readOnly {
+		t.Annotations.ReadOnlyHint = boolPtr(true)
+	}
+	SetToolOrigin(&t, ToolOrigin{Kind: OriginKindTool, Server: family, Servers: members})
+	return t
+}
+
+func workflowTool(name string, readOnly bool) mcp.Tool {
+	t := mcp.Tool{Name: name}
+	if readOnly {
+		t.Annotations.ReadOnlyHint = boolPtr(true)
+	}
+	SetToolOrigin(&t, ToolOrigin{Kind: OriginKindWorkflow})
+	return t
+}
+
+func coreTool(name string) mcp.Tool {
+	t := mcp.Tool{Name: name}
+	SetToolOrigin(&t, ToolOrigin{Kind: OriginKindCore})
+	return t
+}
+
+// catalogue is the fixture every resolution test shares: a kubernetes server
+// with a read-only and a destructive tool, a prometheus family with two
+// members, a read-only and a read-write workflow, and two core tools.
+func catalogue() []mcp.Tool {
+	return []mcp.Tool{
+		serverTool("x_k8s_get", "k8s", true),
+		serverTool("x_k8s_delete", "k8s", false),
+		familyTool("x_prometheus_query", "prometheus", []string{"prom-a", "prom-b"}, true),
+		workflowTool("workflow_triage", true),
+		workflowTool("workflow_rollout", false),
+		coreTool("core_workflow_list"),
+		coreTool("core_auth_login"),
+	}
+}
+
+func resolve(t *testing.T, r *Registry, header string) Resolution {
+	t.Helper()
+	ts, err := ParseHeader(header)
+	require.NoError(t, err)
+	res, err := r.Resolve(ts, EntriesFromTools(catalogue(), nil))
+	require.NoError(t, err)
+	return res
+}
+
+func TestEntriesFromTools_ClassifiesByOriginThenPrefix(t *testing.T) {
+	entries := EntriesFromTools([]mcp.Tool{
+		serverTool("x_k8s_get", "k8s", true),
+		{Name: "workflow_untagged"},
+		{Name: "core_untagged"},
+		{Name: "x_plain_tool"},
+	}, nil)
+	assert.Equal(t, Entry{Name: "x_k8s_get", Kind: KindEntryTool, Server: "k8s", ReadOnly: true}, entries[0])
+	assert.Equal(t, KindEntryWorkflow, entries[1].Kind)
+	assert.Equal(t, KindEntryCore, entries[2].Kind)
+	assert.Equal(t, KindEntryTool, entries[3].Kind)
+}
+
+func TestEntriesFromTools_ServerLabels(t *testing.T) {
+	labels := func(server string) map[string]string {
+		if server == "k8s" {
+			return map[string]string{"tier": "infrastructure"}
+		}
+		return nil
+	}
+	entries := EntriesFromTools(catalogue(), labels)
+	assert.Equal(t, map[string]string{"tier": "infrastructure"}, entries[0].Labels)
+	assert.Nil(t, entries[2].Labels, "family tool has no label for the family name")
+	assert.Nil(t, entries[3].Labels, "workflows carry no server labels")
+}
+
+func TestResolve_InlineSelectors(t *testing.T) {
+	r := BuiltIns()
+
+	res := resolve(t, r, "tool:x_k8s_get")
+	assert.Equal(t, []string{"x_k8s_get"}, res.Names())
+	assert.Empty(t, res.Unmatched)
+	assert.True(t, res.ContainsServer("k8s"))
+
+	res = resolve(t, r, "server:k8s")
+	assert.Equal(t, []string{"x_k8s_delete", "x_k8s_get"}, res.Names())
+
+	// The family name selects the family surface; so does a member name.
+	res = resolve(t, r, "server:prometheus")
+	assert.Equal(t, []string{"x_prometheus_query"}, res.Names())
+	assert.True(t, res.ContainsServer("prom-a"))
+	assert.True(t, res.ContainsServer("prom-b"))
+	res = resolve(t, r, "server:prom-b")
+	assert.Equal(t, []string{"x_prometheus_query"}, res.Names())
+
+	res = resolve(t, r, "workflow:triage")
+	assert.Equal(t, []string{"workflow_triage"}, res.Names())
+	assert.False(t, res.ContainsServer("k8s"))
+
+	// Core tools only when named explicitly.
+	res = resolve(t, r, "tool:core_workflow_list")
+	assert.Equal(t, []string{"core_workflow_list"}, res.Names())
+}
+
+func TestResolve_UnmatchedSelectors(t *testing.T) {
+	res := resolve(t, BuiltIns(), "tool:x_k8s_get, server:nope ,workflow:missing,tool:x_k8s_nope,preset:none")
+	assert.Equal(t, []string{"x_k8s_get"}, res.Names())
+	assert.Equal(t, []string{"server:nope", "workflow:missing", "tool:x_k8s_nope"}, res.Unmatched, "preset:none is empty by definition and not reported")
+}
+
+func TestResolve_BuiltInPresets(t *testing.T) {
+	r := BuiltIns()
+
+	assert.Equal(t, []string{"workflow_triage", "x_k8s_get", "x_prometheus_query"}, resolve(t, r, "preset:read-only").Names(),
+		"read-only: annotated server tools plus the workflow with the derived hint; core tools carry no annotation")
+
+	res := resolve(t, r, "preset:none")
+	assert.Empty(t, res.Names())
+	assert.Empty(t, res.Unmatched)
+
+	assert.Len(t, resolve(t, r, "preset:full").Names(), len(catalogue()))
+
+	// Inline selectors add to a preset.
+	assert.Equal(t, []string{"workflow_rollout", "workflow_triage", "x_k8s_get", "x_prometheus_query"},
+		resolve(t, r, "preset:read-only,workflow:rollout").Names())
+}
+
+func TestResolve_ConfiguredPresets(t *testing.T) {
+	r, err := NewRegistry(PresetsConfig{
+		"infra": {Include: []Rule{{Server: "k8s"}, {Server: "prometheus"}}, Exclude: []Rule{{Pattern: "*_delete"}}},
+		"ops":   {Include: []Rule{{Preset: "infra"}, {Workflow: "rollout"}, {Tool: "core_workflow_list"}}},
+		"safe":  {Include: []Rule{{Preset: "ops"}, {ReadOnly: boolPtr(true)}}, Exclude: []Rule{{Workflow: "rollout"}}},
+		"core":  {Include: []Rule{{Pattern: "core_*"}}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"x_k8s_get", "x_prometheus_query"}, resolve(t, r, "preset:infra").Names(), "exclude removes the destructive tool")
+	assert.Equal(t, []string{"core_workflow_list", "workflow_rollout", "x_k8s_get", "x_prometheus_query"}, resolve(t, r, "preset:ops").Names(), "composition")
+	assert.Equal(t, []string{"core_workflow_list", "workflow_triage", "x_k8s_get", "x_prometheus_query"}, resolve(t, r, "preset:safe").Names(), "composition plus readOnly, exclude applied last")
+	assert.Equal(t, []string{"core_auth_login", "core_workflow_list"}, resolve(t, r, "preset:core").Names(), "core tools via pattern")
+}
+
+func TestResolve_UnknownPresetIsAnError(t *testing.T) {
+	ts, _ := ParseHeader("preset:foo")
+	_, err := BuiltIns().Resolve(ts, EntriesFromTools(catalogue(), nil))
+	require.Error(t, err)
+	assert.Equal(t, `toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full`, err.Error())
+}
+
+func TestFilter_PreservesCatalogueOrder(t *testing.T) {
+	res := resolve(t, BuiltIns(), "tool:core_auth_login,tool:x_k8s_get")
+	filtered := Filter(catalogue(), res)
+	require.Len(t, filtered, 2)
+	assert.Equal(t, "x_k8s_get", filtered[0].Name)
+	assert.Equal(t, "core_auth_login", filtered[1].Name)
+}
+
+func TestSetToolOrigin_ClonesMeta(t *testing.T) {
+	shared := &mcp.Meta{AdditionalFields: map[string]any{MetaKeyLabels: map[string]string{"a": "b"}}}
+	downstream := mcp.Tool{Name: "get", Meta: shared}
+	exposed := downstream
+	SetToolOrigin(&exposed, ToolOrigin{Kind: OriginKindTool, Server: "k8s"})
+
+	_, hasOrigin := shared.AdditionalFields[MetaKeyOrigin]
+	assert.False(t, hasOrigin, "the downstream tool's meta must not be mutated")
+	origin, ok := ToolOriginOf(exposed)
+	require.True(t, ok)
+	assert.Equal(t, "k8s", origin.Server)
+	assert.Equal(t, map[string]string{"a": "b"}, exposed.Meta.AdditionalFields[MetaKeyLabels], "existing meta keys are kept")
+}

--- a/internal/toolset/selector.go
+++ b/internal/toolset/selector.go
@@ -1,0 +1,107 @@
+package toolset
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// HeaderName is the request header that carries an agent's declared toolset.
+const HeaderName = "X-Muster-Toolset"
+
+// MaxInlineSelectors caps the number of selectors a toolset may carry inline
+// (in the header or the filter_tools argument). Larger selections are presets.
+const MaxInlineSelectors = 32
+
+// Inline selector kinds.
+const (
+	KindPreset   = "preset"
+	KindServer   = "server"
+	KindWorkflow = "workflow"
+	KindTool     = "tool"
+
+	// kindToolset is reserved for the shared-toolset follow-up and rejected.
+	kindToolset = "toolset"
+	// kindLabel exists inside presets only (#1168) and is rejected inline.
+	kindLabel = "label"
+)
+
+// selectorPattern is the inline grammar: exact names, no whitespace or commas.
+var selectorPattern = regexp.MustCompile(`^(preset|server|workflow|tool):[^\s,]+$`)
+
+// Selector is one inline selector, e.g. preset:read-only or tool:x_k8s_get.
+type Selector struct {
+	Kind string
+	Name string
+}
+
+// String renders the selector in its inline form.
+func (s Selector) String() string { return s.Kind + ":" + s.Name }
+
+// Toolset is a parsed inline toolset: the selectors as given (trimmed) and
+// their parsed form. Raw is kept for echoing and for naming the toolset in
+// errors exactly as the caller wrote it.
+type Toolset struct {
+	Raw       []string
+	Selectors []Selector
+}
+
+// String renders the toolset as it appears in errors and log lines.
+func (t Toolset) String() string { return "[" + strings.Join(t.Raw, ",") + "]" }
+
+// Presets returns the names of the presets the toolset references, in order.
+func (t Toolset) Presets() []string {
+	var names []string
+	for _, s := range t.Selectors {
+		if s.Kind == KindPreset {
+			names = append(names, s.Name)
+		}
+	}
+	return names
+}
+
+// ParseHeader parses the value of the X-Muster-Toolset header: a comma-separated
+// list of inline selectors with whitespace around each selector trimmed. The
+// caller decides whether the header was present; a present-but-empty value is
+// an error here, never "no toolset".
+func ParseHeader(value string) (Toolset, error) {
+	if strings.TrimSpace(value) == "" {
+		return ParseInline(nil)
+	}
+	parts := strings.Split(value, ",")
+	list := make([]string, 0, len(parts))
+	for _, p := range parts {
+		list = append(list, strings.TrimSpace(p))
+	}
+	return ParseInline(list)
+}
+
+// ParseInline parses a list of inline selectors (the filter_tools "toolset"
+// argument, or a header already split on commas). Every error names the
+// toolset and the offending selector so the caller can relay it verbatim.
+func ParseInline(list []string) (Toolset, error) {
+	ts := Toolset{Raw: make([]string, 0, len(list))}
+	for _, s := range list {
+		ts.Raw = append(ts.Raw, strings.TrimSpace(s))
+	}
+	if len(ts.Raw) == 0 {
+		return Toolset{}, fmt.Errorf("toolset [] is empty; use %q for an agent without tools", KindPreset+":"+PresetNone)
+	}
+	if len(ts.Raw) > MaxInlineSelectors {
+		return Toolset{}, fmt.Errorf("toolset %s has %d selectors, more than the %d allowed inline; define a preset",
+			ts, len(ts.Raw), MaxInlineSelectors)
+	}
+	for _, raw := range ts.Raw {
+		kind, name, hasColon := strings.Cut(raw, ":")
+		switch {
+		case hasColon && kind == kindToolset:
+			return Toolset{}, fmt.Errorf("toolset %s selector %q is reserved for shared toolsets", ts, raw)
+		case hasColon && kind == kindLabel:
+			return Toolset{}, fmt.Errorf("toolset %s selector %q is allowed inside presets only", ts, raw)
+		case !selectorPattern.MatchString(raw):
+			return Toolset{}, fmt.Errorf("toolset %s selector %q is malformed; expected preset:<name>, server:<name>, workflow:<name> or tool:<name>", ts, raw)
+		}
+		ts.Selectors = append(ts.Selectors, Selector{Kind: kind, Name: name})
+	}
+	return ts, nil
+}

--- a/internal/toolset/selector_test.go
+++ b/internal/toolset/selector_test.go
@@ -1,0 +1,69 @@
+package toolset
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHeader_TrimsAndSplits(t *testing.T) {
+	ts, err := ParseHeader(" preset:read-only , workflow:incident-triage ,tool:x_k8s_get")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"preset:read-only", "workflow:incident-triage", "tool:x_k8s_get"}, ts.Raw)
+	require.Len(t, ts.Selectors, 3)
+	assert.Equal(t, Selector{Kind: KindPreset, Name: "read-only"}, ts.Selectors[0])
+	assert.Equal(t, Selector{Kind: KindWorkflow, Name: "incident-triage"}, ts.Selectors[1])
+	assert.Equal(t, Selector{Kind: KindTool, Name: "x_k8s_get"}, ts.Selectors[2])
+	assert.Equal(t, "[preset:read-only,workflow:incident-triage,tool:x_k8s_get]", ts.String())
+	assert.Equal(t, []string{"read-only"}, ts.Presets())
+}
+
+func TestParseHeader_Errors(t *testing.T) {
+	tooMany := make([]string, MaxInlineSelectors+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("tool:t%d", i)
+	}
+
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"empty", "", `toolset [] is empty; use "preset:none"`},
+		{"whitespace only", "   ", `toolset [] is empty`},
+		{"reserved", "preset:read-only,toolset:shared", `toolset [preset:read-only,toolset:shared] selector "toolset:shared" is reserved for shared toolsets`},
+		{"inline label", "label:a=b", `selector "label:a=b" is allowed inside presets only`},
+		{"unknown kind", "pattern:core_*", `selector "pattern:core_*" is malformed`},
+		{"no colon", "read-only", `selector "read-only" is malformed`},
+		{"empty name", "preset:", `selector "preset:" is malformed`},
+		{"trailing comma", "preset:none,", `selector "" is malformed`},
+		{"whitespace in name", "tool:x k8s", `selector "tool:x k8s" is malformed`},
+		{"too many", strings.Join(tooMany, ","), "has 33 selectors, more than the 32 allowed inline; define a preset"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseHeader(tc.header)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestParseInline_CapIsInclusive(t *testing.T) {
+	list := make([]string, MaxInlineSelectors)
+	for i := range list {
+		list[i] = fmt.Sprintf("tool:t%d", i)
+	}
+	_, err := ParseInline(list)
+	require.NoError(t, err)
+}
+
+func TestParseInline_NamesAreCaseSensitiveAndMayContainColons(t *testing.T) {
+	ts, err := ParseInline([]string{"tool:X_K8s_Get", "server:ns:name"})
+	require.NoError(t, err)
+	assert.Equal(t, "X_K8s_Get", ts.Selectors[0].Name)
+	assert.Equal(t, "ns:name", ts.Selectors[1].Name)
+}

--- a/internal/toolset/source.go
+++ b/internal/toolset/source.go
@@ -1,0 +1,63 @@
+package toolset
+
+import (
+	"context"
+	"net/http"
+)
+
+// Source is where a request's toolset came from, before parsing. Present is
+// false when the request declared no toolset at all (today's unscoped
+// behaviour); a present but empty value is a declared, invalid toolset.
+type Source struct {
+	Present bool
+	Raw     string
+}
+
+// SourceFromRequest is the single seam that decides which request attribute
+// carries the toolset. Today that is the X-Muster-Toolset header; an actor
+// claim from a future agent identity would be read here too, and nothing
+// downstream (parsing, resolution, refusal, scenarios) would change.
+func SourceFromRequest(r *http.Request) Source {
+	values, ok := r.Header[http.CanonicalHeaderKey(HeaderName)]
+	if !ok {
+		return Source{}
+	}
+	raw := ""
+	if len(values) > 0 {
+		raw = values[0]
+	}
+	return Source{Present: true, Raw: raw}
+}
+
+type sourceContextKey struct{}
+
+// ContextWithSource stores the request's toolset source in ctx.
+func ContextWithSource(ctx context.Context, src Source) context.Context {
+	return context.WithValue(ctx, sourceContextKey{}, src)
+}
+
+// SourceFromContext returns the toolset source stored by ContextWithSource.
+func SourceFromContext(ctx context.Context) Source {
+	src, _ := ctx.Value(sourceContextKey{}).(Source)
+	return src
+}
+
+// HTTPContextFunc has the shape of mcp-go's server.HTTPContextFunc /
+// SSEContextFunc: it stashes the request's toolset source in the context every
+// tool handler receives. Evaluation is per request by construction — nothing
+// is bound to the session.
+func HTTPContextFunc(ctx context.Context, r *http.Request) context.Context {
+	return ContextWithSource(ctx, SourceFromRequest(r))
+}
+
+// FromContext parses the toolset the request declared. present is false when
+// the request carried none. A present toolset that fails to parse returns the
+// error, which callers surface on every meta-tool call.
+func FromContext(ctx context.Context) (ts Toolset, present bool, err error) {
+	src := SourceFromContext(ctx)
+	if !src.Present {
+		return Toolset{}, false, nil
+	}
+	ts, err = ParseHeader(src.Raw)
+	return ts, true, err
+}


### PR DESCRIPTION
Closes #1169

Rollout step 1 of the tool-access plan ([bumblebee-plans/agent-tool-access](https://github.com/giantswarm/bumblebee-plans/blob/main/agent-tool-access/PRD.md), epic giantswarm/giantswarm#37435): an agent declares a **toolset** — a short list of selectors — and muster applies it **per request, statelessly**, as the third filter on the caller's catalogue (after server-auth visibility and workflow availability). Inert without the header.

## What

- **`X-Muster-Toolset` header**, read on every request through the transports' context funcs (`WithHTTPContextFunc` / `WithSSEContextFunc`), so both the OAuth-protected and the plain mux see it and nothing is bound to the MCP session. Grammar: `preset:<name>`, `server:<name>`, `workflow:<name>`, `tool:<name>`, exact names, ≤ 32 inline; `toolset:<name>` reserved, `label:` presets-only.
- **`toolsetPresets`** configuration (chart value `muster.toolsetPresets`, rendered into the ConfigMap): `description`, `include` / `exclude` rules — `tool`, `pattern`, `server`, `workflow`, `readOnly: true`, `preset` (composition, include only). **`read-only`, `none`, `full` are built in and cannot be redefined**; a config that tries, or that composes an unknown preset / cycles / sets a malformed rule, fails `muster serve` at startup naming the preset.
- **Errors on every meta-tool call** (D12): empty header, unknown preset (`toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full, …`), reserved `toolset:`, inline `label:`, > 32 selectors, malformed selector — never a silent fall-back, not sticky.
- **Refusal**: `call_tool` (workflow execution included) of a name outside the toolset → `tool "<name>" is outside the toolset [<selectors>]`, logged once at info with tool, toolset, session.
- **`filter_tools`** gains `toolset` (string[]) and `include_presets` (bool); the response adds `toolset` (echo), `toolset_unmatched` (selectors matching nothing for the caller) and `presets` (`{name, description, built_in}`). With the header also present the argument resolves within the header's toolset and never widens it.
- **`ToolInfo` / `describe_tool`** carry `server` (omitted for workflows/core), `kind` (`tool` | `workflow` | `core`) and `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, omitted when none). Downstream annotations were kept in memory but dropped on output until now.
- **Workflow read-only derivation** (D9): a workflow is read-only when every step tool (conditions, forEach/parallel sub-steps, onFailure, nested workflows) resolves in the caller's catalogue to a read-only tool; the derived hint fills the workflow tool's `readOnlyHint`, so `preset:read-only` includes pure-query workflows.
- **One scope-source seam**: `toolset.SourceFromRequest(*http.Request)` — header now, an actor claim later; parsing, resolution, refusal and scenarios do not change with the source.
- Chart: `muster.toolsetPresets` value (schema regenerated, README via helm-docs), configmap render, two helm-unittest cases. Docs: `docs/reference/toolsets.md`, configuration and meta-tools references, scenario authoring guide.

## Implementation choices (where the plan left them open)

- **Family members and `server:`**: a family tool's origin records the family as its owning server and the members providing it; `server:<family>` selects the family surface (what the exposed name carries) and `server:<member>` selects it too. Reported as `server: <family>` in ToolInfo.
- **Where the refusal lives**: at the meta-tool boundary (`call_tool`), not in the aggregator's `CallToolInternal`. The tools a workflow's steps call internally are the workflow author's composition, not the model's, so a workflow inside the toolset runs even when its step tools are outside it (composition, not authorization; proven in `toolset-header-filters-catalogue`).
- **Resources and prompts**: a server is inside the toolset when at least one of its tools is selected; `list_/filter_/describe_` hide the others, `get_resource` / `get_prompt` refuse them (`resource "<uri>" is outside the toolset […]`).
- **`servers_requiring_auth`** in `list_tools` is not narrowed: it tells the caller which sign-in would make more of the toolset resolve.
- **`describe_tool` of a visible-but-outside tool** answers the outside-toolset error (more honest than "not found"); an unknown name is still `Tool not found`.
- **`toolset_unmatched`** reports the argument's selectors when the argument is given, else the header's; `preset:none` is empty by definition and never reported. Fields are `omitempty`, so the no-header `filter_tools` payload is unchanged; `list_tools` / `filter_tools` entries gain `kind` (and `server`/`annotations` when present) for every caller — additive.
- **Core tools** get origin kind `core` and carry no annotations today, so they are outside `read-only` and selectable only via `tool:core_…` inline or `pattern: core_*` in a preset (D7).
- **Harness**: steps gain `headers:` (per-request, same client and session — the transport's `WithHTTPHeaderFunc` reads them from the step context, `wait_for_state` polls included); mock tools gain `annotations:` (`read_only_hint`, …) on both the stdio/HTTP and the OAuth-protected mock paths.

## Testing

Nine behavioural scenarios (`internal/testing/scenarios/toolset-*.yaml`, tag `1169`), every acceptance criterion covered; each **fails against a build of origin/main** (serve binary via PATH, the harness's new `headers:` reaching an aggregator that ignores them) and passes on this branch:

| Scenario | Proves | Fails on origin/main at |
|---|---|---|
| `toolset-header-filters-catalogue` | catalogue ∩ toolset on list/filter/describe/list_core_tools; in-toolset call unchanged; out-of-toolset call_tool and workflow refused, logged; core hidden; workflow inside runs | `list-tools-scoped` (header ignored, catalogue unfiltered) |
| `toolset-header-errors-every-meta-tool` | empty/unknown/reserved/label/33/malformed → error on all 13 meta-tools; 32 ok; not sticky | `unknown-preset-list-tools` (no error) |
| `toolset-per-request-same-session` | two headers on one session differ; no header unchanged | `agent-a-view` |
| `toolset-builtin-presets` | read-only (annotated + derived workflows, nested), none, full; describe carries derived hint | `read-only` |
| `toolset-configured-presets` | tool/pattern/server/workflow/readOnly/exclude/composition; include_presets; unknown-preset lists configured | `server-and-exclude` |
| `toolset-visibility-wins` | OAuth server: selector unmatched and tool refused before sign-in, resolves after | `before-login-unmatched` (no `toolset_unmatched`) |
| `toolset-filter-tools-argument` | resolution, unmatched, presets; never widens; argument errors | `resolution-unmatched-presets` |
| `toolset-annotations-forwarded` | server/kind/annotations on describe/filter/list; derived hint; core has none | `describe-read-only-tool` (no `server`/`kind`/`annotations`) |
| `toolset-resources-prompts-follow-servers` | resource/prompt accessors read the filtered catalogue; get_* refuse | `scoped-resources` |

Full suite: 225/225 scenarios pass (`muster test --parallel 12`). `go test ./...` green; golangci-lint clean; `helm unittest`: 127 passed.

## Lab (agentlab, dev image before merge)

Dev image `muster:dev-toolsets-54cb5590` (this branch's HEAD) swapped into agentlab (`kind-agentlab`, `agent-platform/muster`, `imagePullPolicy: Never`), proven headlessly through the edge `https://muster.127.0.0.1.nip.io/mcp` with a Dex id_token for `admin@lab.local` on **one** MCP session — headers varying per request:

```
PASS: every read-only tool carries readOnlyHint
PASS: same session, header server:agent-manager -> 10 tools, all from agent-manager
PASS: same session, header server:mcp-kubernetes -> 6 tools, all from mcp-kubernetes
PASS: same session, no header again -> 82 tools (unchanged)
PASS: in-toolset call_tool core_workflow_list succeeded
PASS: out-of-toolset call_tool refused: ERROR:tool "core_workflow_list" is outside the toolset [preset:none]
PASS: out-of-toolset server tool x_agent-manager_create_agent refused
PASS: unscoped call_tool core_workflow_list succeeded
PASS: unknown preset error: ERROR:toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full
PASS: reserved selector error
PASS: empty header errors on get_prompt too
PASS: filter_tools toolset arg: presets listed, server:nope unmatched
PASS: describe_tool carries server/kind: agent-manager tool {'readOnlyHint': False, 'destructiveHint': True, 'idempotentHint': False, 'openWorldHint': True}
```

- The unscoped lab catalogue is 82 tools (agent-manager, mcp-kubernetes, mcp-prometheus, model-manager + 29 core); `preset:read-only` resolves to 43, every one of them annotated `readOnlyHint: true`; `preset:none` to 0; `server:agent-manager` (10) and `server:mcp-kubernetes` (6) on the same session differ; the next request without the header sees all 82 again.
- Refusals are logged by the pod: `msg="call_tool refused: tool \"x_agent-manager_create_agent\" is outside the toolset [preset:none]" subsystem=metatools tool=… toolset="[preset:none]" session=ext-… transportSessionID=mcp-session-…`.
- The empty-header error was additionally sent both straight to muster's hostNetwork port (`localhost:8092`) and through the edge; both answer `toolset [] is empty; use "preset:none" for an agent without tools`.
- `agentlab platform-test`: all six checks PASS on the dev image and again after the restore to `gsoci.azurecr.io/giantswarm/muster:5.10.2` / `IfNotPresent` (verified with `/muster version`); lab lock released.
- Not lab-verified: `toolsetPresets` chart values (no preset shipped yet — #273 does), the OAuth visibility case (covered by the `toolset-visibility-wins` scenario against the harness's protected mock).
