### PR TITLE
feat(toolset): label: preset selector — presets select MCPServers by resource label, read live in both storage modes

### DIFF
--- a/docs/contributing/testing/scenarios.md
+++ b/docs/contributing/testing/scenarios.md
@@ -548,6 +548,29 @@ steps:
 Regular tool steps (`tool: x_server_tool`) carry the headers too, since they go through
 `call_tool` on the same client.
 
+### MCPServer labels
+
+`pre_configuration.mcp_servers[].labels` writes `metadata.labels` on the server's MCPServer
+definition — the way a chart labels the resources it ships — and
+`test_set_mcpserver_labels {server, labels}` replaces them while muster runs (an empty `labels`
+removes them). Together they exercise label-based toolset presets, including "a server gaining
+or losing the label changes the resolution without a restart":
+
+```yaml
+pre_configuration:
+  mcp_servers:
+    - name: "k8s"
+      labels:
+        agent-platform.giantswarm.io/tool-group: infrastructure
+      config:
+        tools: [ ... ]
+steps:
+  - id: relabel
+    tool: test_set_mcpserver_labels
+    args: { server: "k8s", labels: { tier: "gold" } }
+    expected: { success: true }
+```
+
 ## Multi-User Testing
 
 The test framework supports multi-user scenarios to verify session isolation and per-user tool visibility. This is critical for testing OAuth-protected MCP servers where different users may have access to different tools.

--- a/docs/reference/toolsets.md
+++ b/docs/reference/toolsets.md
@@ -98,7 +98,25 @@ includes minus its excludes. Every rule sets **exactly one** key:
 | `workflow: <name>` | The workflow's execution tool. |
 | `readOnly: true` | Every tool annotated `readOnlyHint: true`, including workflows carrying the derived hint (below). |
 | `preset: <name>` | Composition: everything another preset selects. `include` only. |
-| `label: <key>=<value>` / `label: <key>` | Tools of every MCPServer carrying that label (value match or presence). Presets only; see #1168. |
+| `label: <key>=<value>` / `label: <key>` | Tools of every MCPServer whose resource carries that label — `metadata.labels` in both storage modes, read live on each request, so a server gaining or losing the label changes the resolution on the next request without a restart. `<key>=<value>` matches the value, `<key>` alone matches presence, `<key>=` matches an empty value. A family tool joins when any member providing it carries the label. Presets only — inline `label:` is rejected. |
+
+The two platform presets are defined by the tool-group label every platform-shipped MCPServer
+carries (`agent-platform.giantswarm.io/tool-group: infrastructure | agent-platform`; see the
+fleet chart), so a new manager or a fourth infrastructure family joins its preset with no values
+change:
+
+```yaml
+toolsetPresets:
+  infrastructure:
+    description: The servers for the infrastructure underneath the platform
+    include:
+      - label: agent-platform.giantswarm.io/tool-group=infrastructure
+  agent-platform:
+    description: The platform's own management surface, including muster's core tools
+    include:
+      - label: agent-platform.giantswarm.io/tool-group=agent-platform
+      - pattern: core_*
+```
 
 ### Built-in presets
 

--- a/internal/api/mcpserver.go
+++ b/internal/api/mcpserver.go
@@ -531,6 +531,11 @@ type MCPServerInfo struct {
 	// Empty in filesystem mode.
 	Namespace string `json:"namespace,omitempty"`
 
+	// Labels mirrors the MCPServer resource's metadata.labels in both storage
+	// modes. Toolset presets select servers by label (label: rules, #1168) —
+	// notably agent-platform.giantswarm.io/tool-group — and read this live.
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// Type indicates the execution model for this server (stdio, streamable-http, or sse).
 	Type string `json:"type"`
 

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -298,7 +298,7 @@ func InitializeServices(cfg *Config) (*Services, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid toolset presets: %w", err)
 		}
-		metaToolsAdapter := metatools.NewAdapter(metatools.WithPresets(toolsetPresets))
+		metaToolsAdapter := metatools.NewAdapter(metatools.WithPresets(toolsetPresets), metatools.WithServerLabels(metatools.MCPServerLabels))
 		metaToolsAdapter.Register()
 		logging.Info("Services", "Registered meta-tools adapter with toolset presets: %s", strings.Join(toolsetPresets.Names(), ", "))
 	}

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -316,6 +316,7 @@ func convertCRDToInfo(server *musterv1alpha1.MCPServer) api.MCPServerInfo {
 	info := api.MCPServerInfo{
 		Name:                  server.Name,
 		Namespace:             server.Namespace,
+		Labels:                server.Labels,
 		Type:                  server.Spec.Type,
 		Description:           server.Spec.Description,
 		ToolPrefix:            server.Spec.ToolPrefix,

--- a/internal/metatools/api_adapter.go
+++ b/internal/metatools/api_adapter.go
@@ -36,11 +36,13 @@ func WithPresets(presets *toolset.Registry) AdapterOption {
 	}
 }
 
-// WithServerLabels supplies the MCPServer label lookup the label: preset
-// selector resolves through (#1168).
-func WithServerLabels(labels toolset.ServerLabels) AdapterOption {
+// WithServerLabels supplies the per-request MCPServer label lookup the label:
+// preset selector resolves through (#1168). The source is invoked once per
+// meta-tool call and the lookup it returns is consulted lazily, so requests
+// whose presets carry no label rule never list the MCPServers.
+func WithServerLabels(source ServerLabelsSource) AdapterOption {
 	return func(p *Provider) {
-		p.serverLabels = labels
+		p.serverLabels = source
 	}
 }
 

--- a/internal/metatools/handlers.go
+++ b/internal/metatools/handlers.go
@@ -332,7 +332,7 @@ func (p *Provider) filterToolsWithOptions(ctx context.Context, opts filterToolsO
 		if err != nil {
 			return errorResult(err.Error()), nil
 		}
-		res, err := p.presets.Resolve(ts, toolset.EntriesFromTools(tools, p.serverLabels))
+		res, err := p.presets.ResolveWith(ts, toolset.EntriesFromTools(tools), p.labelsFor(ctx))
 		if err != nil {
 			return errorResult(err.Error()), nil
 		}

--- a/internal/metatools/provider.go
+++ b/internal/metatools/provider.go
@@ -20,7 +20,7 @@ type Provider struct {
 	presets *toolset.Registry
 	// serverLabels resolves an MCPServer name to its resource labels for the
 	// label: preset selector (#1168); nil when unavailable.
-	serverLabels toolset.ServerLabels
+	serverLabels ServerLabelsSource
 }
 
 // NewProvider creates a new meta-tools provider instance knowing the built-in

--- a/internal/metatools/scope.go
+++ b/internal/metatools/scope.go
@@ -48,7 +48,7 @@ func (p *Provider) catalogue(ctx context.Context, handler api.MetaToolsHandler) 
 	if !present {
 		return cat, nil
 	}
-	res, err := p.presets.Resolve(ts, toolset.EntriesFromTools(tools, p.serverLabels))
+	res, err := p.presets.ResolveWith(ts, toolset.EntriesFromTools(tools), p.labelsFor(ctx))
 	if err != nil {
 		return nil, errorResult(err.Error())
 	}

--- a/internal/metatools/server_labels.go
+++ b/internal/metatools/server_labels.go
@@ -1,0 +1,57 @@
+package metatools
+
+import (
+	"context"
+	"sync"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/toolset"
+	"github.com/giantswarm/muster/pkg/logging"
+)
+
+// ServerLabelsSource builds, for one request, the lookup that resolves an
+// MCPServer name to its resource labels. The lookup is consulted lazily by
+// label: preset rules only, so the source must defer any listing until the
+// first call.
+type ServerLabelsSource func(ctx context.Context) toolset.ServerLabels
+
+// MCPServerLabels is the ServerLabelsSource backed by the MCPServer manager:
+// the first label lookup of a request lists the MCPServer resources once
+// (live, in both storage modes — a server gaining or losing a label changes
+// the next request's resolution without a restart) and every further lookup
+// in that request reads the memoised map. A failed listing is logged and
+// resolves every server to no labels, so a label rule then selects nothing —
+// the closed failure mode, never a wider one.
+func MCPServerLabels(ctx context.Context) toolset.ServerLabels {
+	var (
+		once   sync.Once
+		labels map[string]map[string]string
+	)
+	return func(server string) map[string]string {
+		once.Do(func() {
+			labels = map[string]map[string]string{}
+			manager := api.GetMCPServerManager()
+			if manager == nil {
+				return
+			}
+			servers, err := manager.ListMCPServers(ctx)
+			if err != nil {
+				logging.Warn("metatools", "toolset label rules resolve to nothing: listing MCPServers failed: %v", err)
+				return
+			}
+			for _, s := range servers {
+				labels[s.Name] = s.Labels
+			}
+		})
+		return labels[server]
+	}
+}
+
+// labelsFor returns the request's label lookup, or nil when no source is
+// configured (label rules then select nothing).
+func (p *Provider) labelsFor(ctx context.Context) toolset.ServerLabels {
+	if p.serverLabels == nil {
+		return nil
+	}
+	return p.serverLabels(ctx)
+}

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -1823,11 +1823,8 @@ func (m *musterInstanceManager) generateConfigFilesWithMocks(configPath string, 
 					mcpServerCRD := map[string]interface{}{
 						"apiVersion": "muster.giantswarm.io/v1alpha1",
 						"kind":       "MCPServer",
-						"metadata": map[string]interface{}{
-							"name":      mcpServer.Name,
-							"namespace": "default",
-						},
-						"spec": spec,
+						"metadata":   mcpServerMetadata(mcpServer),
+						"spec":       spec,
 					}
 
 					if m.debug {
@@ -1870,11 +1867,8 @@ func (m *musterInstanceManager) generateConfigFilesWithMocks(configPath string, 
 					mcpServerCRD := map[string]interface{}{
 						"apiVersion": "muster.giantswarm.io/v1alpha1",
 						"kind":       "MCPServer",
-						"metadata": map[string]interface{}{
-							"name":      mcpServer.Name,
-							"namespace": "default",
-						},
-						"spec": stdioSpec,
+						"metadata":   mcpServerMetadata(mcpServer),
+						"spec":       stdioSpec,
 					}
 
 					if m.debug {
@@ -1901,11 +1895,8 @@ func (m *musterInstanceManager) generateConfigFilesWithMocks(configPath string, 
 					mcpServerCRD := map[string]interface{}{
 						"apiVersion": "muster.giantswarm.io/v1alpha1",
 						"kind":       "MCPServer",
-						"metadata": map[string]interface{}{
-							"name":      mcpServer.Name,
-							"namespace": "default",
-						},
-						"spec": mcpServer.Config,
+						"metadata":   mcpServerMetadata(mcpServer),
+						"spec":       mcpServer.Config,
 					}
 
 					filename := filepath.Join(crdDir, mcpServer.Name+".yaml")
@@ -2370,4 +2361,24 @@ func (m *musterInstanceManager) convertWorkflowConfigToCRDSpec(config map[string
 	}
 
 	return spec
+}
+
+// mcpServerMetadata builds the metadata of a scenario's MCPServer definition:
+// the name, the default namespace and, when the scenario declares them, the
+// labels a chart would stamp on the resource (e.g.
+// agent-platform.giantswarm.io/tool-group), which label-based toolset presets
+// select by.
+func mcpServerMetadata(mcpServer MCPServerConfig) map[string]interface{} {
+	metadata := map[string]interface{}{
+		"name":      mcpServer.Name,
+		"namespace": "default",
+	}
+	if len(mcpServer.Labels) > 0 {
+		labels := make(map[string]interface{}, len(mcpServer.Labels))
+		for k, v := range mcpServer.Labels {
+			labels[k] = v
+		}
+		metadata["labels"] = labels
+	}
+	return metadata
 }

--- a/internal/testing/scenarios/toolset-label-preset-selector.yaml
+++ b/internal/testing/scenarios/toolset-label-preset-selector.yaml
@@ -1,0 +1,180 @@
+name: "toolset-label-preset-selector"
+description: "A preset with a label: rule resolves to the tools of every MCPServer whose resource carries that label (key=value, or key for presence), read live: a server gaining or losing the label changes the resolution on the next request without a restart; label: stays presets-only inline (#1168)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["toolset", "presets", "label", "tool-group", "1168"]
+timeout: "5m"
+
+# Given: three servers — k8s labelled agent-platform.giantswarm.io/tool-group=infrastructure,
+#        am labelled tool-group=agent-platform plus tier=gold, gh unlabelled — and
+#        the platform's two presets defined the way the fleet chart ships them.
+# When:  requests declare preset:infrastructure / preset:agent-platform / preset:gold,
+#        then gh gains the infrastructure label and k8s loses it.
+# Then:  each preset resolves to exactly the labelled servers' tools, core tools
+#        only where the preset adds them, and the resolution follows the label
+#        change on the very next request.
+
+pre_configuration:
+  main_config:
+    config:
+      toolsetPresets:
+        infrastructure:
+          description: "Every infrastructure server"
+          include:
+            - label: agent-platform.giantswarm.io/tool-group=infrastructure
+        agent-platform:
+          description: "The platform's own management surface"
+          include:
+            - label: agent-platform.giantswarm.io/tool-group=agent-platform
+            - pattern: "core_*"
+        gold:
+          description: "Presence match"
+          include:
+            - label: tier
+  mcp_servers:
+    - name: "k8s"
+      labels:
+        agent-platform.giantswarm.io/tool-group: infrastructure
+      config:
+        tools:
+          - name: "get_pods"
+            description: "List pods"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { pods: [] } }]
+    - name: "am"
+      labels:
+        agent-platform.giantswarm.io/tool-group: agent-platform
+        tier: gold
+      config:
+        tools:
+          - name: "list_agents"
+            description: "List agents"
+            annotations: { read_only_hint: true }
+            responses: [{ response: { agents: [] } }]
+    - name: "gh"
+      config:
+        tools:
+          - name: "issues"
+            description: "List issues"
+            responses: [{ response: { issues: [] } }]
+
+steps:
+  - id: "wait-for-servers"
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["k8s", "am", "gh"]
+
+  - id: "infrastructure-by-label"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:infrastructure" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      json_path:
+        total: 1
+        tools.0.name: "x_k8s_get_pods"
+        tools.0.server: "k8s"
+      not_contains: ["x_am_list_agents", "x_gh_issues", "core_", "toolset_unmatched"]
+
+  - id: "agent-platform-by-label-plus-core"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 100 } }
+    headers: { X-Muster-Toolset: "preset:agent-platform" }
+    expected:
+      success: true
+      contains: ["x_am_list_agents", "core_workflow_list", "core_auth_login"]
+      not_contains: ["x_k8s_get_pods", "x_gh_issues"]
+
+  - id: "presence-match"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:gold" }
+    expected:
+      success: true
+      json_path:
+        total: 1
+        tools.0.name: "x_am_list_agents"
+
+  - id: "label-gates-call-tool"
+    tool: "x_gh_issues"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:infrastructure" }
+    expected:
+      success: false
+      error_contains: ['tool "x_gh_issues" is outside the toolset [preset:infrastructure]']
+
+  - id: "inline-label-rejected"
+    description: "label: exists inside presets only"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    headers: { X-Muster-Toolset: "label:agent-platform.giantswarm.io/tool-group=infrastructure" }
+    expected:
+      success: false
+      error_contains: ['selector "label:agent-platform.giantswarm.io/tool-group=infrastructure" is allowed inside presets only']
+
+  - id: "gh-gains-the-label"
+    tool: "test_set_mcpserver_labels"
+    args:
+      server: "gh"
+      labels:
+        agent-platform.giantswarm.io/tool-group: infrastructure
+    expected:
+      success: true
+
+  - id: "infrastructure-follows-the-new-label"
+    description: "no restart, no reconcile: the next request resolves the label live"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:infrastructure" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      json_path:
+        total: 2
+      contains: ["x_k8s_get_pods", "x_gh_issues"]
+
+  - id: "gh-now-callable"
+    tool: "x_gh_issues"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:infrastructure" }
+    expected:
+      success: true
+
+  - id: "k8s-loses-the-label"
+    tool: "test_set_mcpserver_labels"
+    args:
+      server: "k8s"
+      labels: {}
+    expected:
+      success: true
+
+  - id: "infrastructure-drops-k8s"
+    tool: "test_call_meta_tool"
+    args: { tool: "filter_tools", arguments: { pattern: "*", limit: 50 } }
+    headers: { X-Muster-Toolset: "preset:infrastructure" }
+    expected:
+      success: true
+      wait_for_state: "20s"
+      json_path:
+        total: 1
+        tools.0.name: "x_gh_issues"
+      not_contains: ["x_k8s_get_pods"]
+
+  - id: "k8s-now-refused"
+    tool: "x_k8s_get_pods"
+    args: {}
+    headers: { X-Muster-Toolset: "preset:infrastructure" }
+    expected:
+      success: false
+      error_contains: ['tool "x_k8s_get_pods" is outside the toolset [preset:infrastructure]']
+
+  - id: "unscoped-unaffected"
+    tool: "test_call_meta_tool"
+    args: { tool: "list_tools" }
+    expected:
+      success: true
+      contains: ["x_k8s_get_pods", "x_am_list_agents", "x_gh_issues"]

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -11,8 +11,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 
@@ -94,6 +98,13 @@ const (
 	// "filter" argument narrows the body to lines containing that substring;
 	// without it the whole scrape is returned.
 	TestToolScrapeMetrics = "test_scrape_metrics"
+	// TestToolSetMCPServerLabels replaces the metadata.labels of an MCPServer
+	// definition in the instance's filesystem store while muster runs — what a
+	// chart upgrade or a kubectl label does to the resource — so a scenario
+	// can prove that label-based toolset presets follow the live labels
+	// without a restart. Args: "server" (required), "labels" (object; empty
+	// removes every label).
+	TestToolSetMCPServerLabels = "test_set_mcpserver_labels"
 )
 
 // TestToolsHandler handles test-specific tools that operate on mock infrastructure.
@@ -219,7 +230,8 @@ func IsTestTool(toolName string) bool {
 		TestToolBrokerTokenExchange,
 		TestToolCallProtectedMCP,
 		TestToolReconnectWithToken,
-		TestToolScrapeMetrics:
+		TestToolScrapeMetrics,
+		TestToolSetMCPServerLabels:
 		return true
 	}
 	return false
@@ -282,9 +294,69 @@ func (h *TestToolsHandler) HandleTestTool(ctx context.Context, toolName string, 
 		return h.handleCallProtectedMCP(ctx, args)
 	case TestToolReconnectWithToken:
 		return h.handleReconnectWithToken(ctx, args)
+	case TestToolSetMCPServerLabels:
+		return h.handleSetMCPServerLabels(ctx, args)
 	default:
 		return nil, fmt.Errorf("unknown test tool: %s", toolName)
 	}
+}
+
+// handleSetMCPServerLabels rewrites metadata.labels of the named MCPServer
+// definition file in the instance's config directory. The filesystem client
+// reads definitions from disk on every call, so the next request that
+// evaluates a label: preset rule sees the new labels — no restart, no
+// reconcile needed. Only the labels change; spec and status are left as they
+// are on disk.
+func (h *TestToolsHandler) handleSetMCPServerLabels(_ context.Context, args map[string]interface{}) (interface{}, error) {
+	serverName, ok := args["server"].(string)
+	if !ok || serverName == "" {
+		return nil, fmt.Errorf("server argument is required")
+	}
+	if h.currentInstance == nil {
+		return nil, fmt.Errorf("no muster instance available")
+	}
+	labels := map[string]interface{}{}
+	if raw, ok := args["labels"].(map[string]interface{}); ok {
+		for k, v := range raw {
+			labels[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	filename := filepath.Join(h.currentInstance.ConfigPath, "muster", "mcpservers", serverName+".yaml")
+	data, err := os.ReadFile(filename) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to read MCPServer definition %s: %w", filename, err)
+	}
+	var definition map[string]interface{}
+	if err := yaml.Unmarshal(data, &definition); err != nil {
+		return nil, fmt.Errorf("failed to parse MCPServer definition %s: %w", filename, err)
+	}
+	metadata, _ := definition["metadata"].(map[string]interface{})
+	if metadata == nil {
+		metadata = map[string]interface{}{"name": serverName}
+	}
+	if len(labels) == 0 {
+		delete(metadata, "labels")
+	} else {
+		metadata["labels"] = labels
+	}
+	definition["metadata"] = metadata
+	out, err := yaml.Marshal(definition)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render MCPServer definition %s: %w", filename, err)
+	}
+	if err := os.WriteFile(filename, out, 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write MCPServer definition %s: %w", filename, err)
+	}
+	if h.debug {
+		h.logger.Debug("Set labels of MCPServer '%s' to %v\n", serverName, labels)
+	}
+	return map[string]interface{}{
+		api.FieldSuccess: true,
+		api.FieldMessage: fmt.Sprintf("Labels of MCPServer '%s' replaced", serverName),
+		api.FieldServer:  serverName,
+		"labels":         labels,
+	}, nil
 }
 
 // handleSimulateOAuthCallback simulates a user completing the OAuth flow.

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -223,6 +223,11 @@ type BrokerTrustedIssuerConfig struct {
 type MCPServerConfig struct {
 	// Name is the unique identifier for the MCP server
 	Name string `yaml:"name"`
+	// Labels are written to the MCPServer definition's metadata.labels, the
+	// way a chart labels the resources it ships (e.g.
+	// agent-platform.giantswarm.io/tool-group), so scenarios can exercise
+	// label-based toolset presets.
+	Labels map[string]string `yaml:"labels,omitempty"`
 	// Config contains the server-specific configuration (can include tools for mock servers)
 	Config map[string]interface{} `yaml:"config"`
 }

--- a/internal/toolset/catalogue.go
+++ b/internal/toolset/catalogue.go
@@ -29,20 +29,19 @@ type Entry struct {
 	// ReadOnly is the tool's readOnlyHint annotation (for a workflow the
 	// derived hint the aggregator computed from its step tools).
 	ReadOnly bool
-	// Labels are the labels of the owning MCPServer resource (#1168). Nil
-	// when unknown.
-	Labels map[string]string
 }
 
-// ServerLabels resolves an MCPServer name to its resource labels. It is
-// consulted for server tools when non-nil; see #1168.
+// ServerLabels resolves an MCPServer name to its resource labels (nil when the
+// server is unknown). Label: preset rules consult it lazily, per request, so
+// a server gaining or losing a label changes the resolution on the next
+// request without a restart (#1168).
 type ServerLabels func(server string) map[string]string
 
 // EntriesFromTools projects exposed tools to resolution entries. Kind and
 // server come from the origin the aggregator stashed on the tool; tools
 // without one are classified by name prefix, which is how the aggregator
 // itself tells core and workflow tools apart.
-func EntriesFromTools(tools []mcp.Tool, labels ServerLabels) []Entry {
+func EntriesFromTools(tools []mcp.Tool) []Entry {
 	entries := make([]Entry, 0, len(tools))
 	for _, t := range tools {
 		e := Entry{Name: t.Name, Kind: KindOf(t)}
@@ -52,9 +51,6 @@ func EntriesFromTools(tools []mcp.Tool, labels ServerLabels) []Entry {
 		}
 		if t.Annotations.ReadOnlyHint != nil && *t.Annotations.ReadOnlyHint {
 			e.ReadOnly = true
-		}
-		if labels != nil && e.Kind == KindEntryTool && e.Server != "" {
-			e.Labels = labels(e.Server)
 		}
 		entries = append(entries, e)
 	}

--- a/internal/toolset/preset.go
+++ b/internal/toolset/preset.go
@@ -34,6 +34,8 @@ var presetNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 //   - readOnly: true                         (every tool annotated read-only,
 //     including the derived workflow hint)
 //   - preset: <name>                         (composition; include only)
+//   - label: <key>=<value> | <key>           (every tool of an MCPServer whose
+//     resource carries that label; #1168)
 type Rule struct {
 	Tool     string `yaml:"tool,omitempty" json:"tool,omitempty"`
 	Pattern  string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
@@ -41,10 +43,22 @@ type Rule struct {
 	Workflow string `yaml:"workflow,omitempty" json:"workflow,omitempty"`
 	ReadOnly *bool  `yaml:"readOnly,omitempty" json:"readOnly,omitempty"`
 	Preset   string `yaml:"preset,omitempty" json:"preset,omitempty"`
+	Label    string `yaml:"label,omitempty" json:"label,omitempty"`
 }
 
 // ruleKeys are the accepted rule keys, named in validation errors.
-const ruleKeys = "tool, pattern, server, workflow, readOnly, preset"
+const ruleKeys = "tool, pattern, server, workflow, readOnly, preset, label"
+
+// labelPattern is the label rule grammar: a key, optionally "=" and a value.
+// Keys follow Kubernetes label key syntax loosely (an optional DNS prefix and
+// a name); "key=" matches an empty value, "key" alone matches presence.
+var labelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*(=[A-Za-z0-9._-]*)?$`)
+
+// labelSelector splits a label rule into key, value and whether a value was
+// given (presence match otherwise).
+func labelSelector(rule string) (key, value string, hasValue bool) {
+	return strings.Cut(rule, "=")
+}
 
 // String renders the rule the way it is written in configuration.
 func (r Rule) String() string {
@@ -61,6 +75,8 @@ func (r Rule) String() string {
 		return fmt.Sprintf("readOnly: %t", *r.ReadOnly)
 	case r.Preset != "":
 		return "preset: " + r.Preset
+	case r.Label != "":
+		return "label: " + r.Label
 	}
 	return "{}"
 }
@@ -68,7 +84,7 @@ func (r Rule) String() string {
 // setKeys counts how many rule keys are set.
 func (r Rule) setKeys() int {
 	n := 0
-	for _, set := range []bool{r.Tool != "", r.Pattern != "", r.Server != "", r.Workflow != "", r.ReadOnly != nil, r.Preset != ""} {
+	for _, set := range []bool{r.Tool != "", r.Pattern != "", r.Server != "", r.Workflow != "", r.ReadOnly != nil, r.Preset != "", r.Label != ""} {
 		if set {
 			n++
 		}
@@ -182,6 +198,8 @@ func validateRules(preset, list string, rules []Rule, allowPreset bool) error {
 			return fmt.Errorf("%s readOnly: false selects nothing; omit the rule", at)
 		case rule.Preset != "" && !allowPreset:
 			return fmt.Errorf("%s cannot compose a preset in %s; only include may", at, list)
+		case rule.Label != "" && !labelPattern.MatchString(rule.Label):
+			return fmt.Errorf("%s label %q is invalid; expected <key>=<value> or <key>", at, rule.Label)
 		}
 	}
 	return nil

--- a/internal/toolset/resolve.go
+++ b/internal/toolset/resolve.go
@@ -42,11 +42,20 @@ func (r Resolution) Names() []string {
 	return names
 }
 
-// Resolve evaluates ts against entries. Inline selectors are unioned; each
+// Resolve evaluates ts against entries without a label lookup: label rules
+// select nothing. See ResolveWith.
+func (r *Registry) Resolve(ts Toolset, entries []Entry) (Resolution, error) {
+	return r.ResolveWith(ts, entries, nil)
+}
+
+// ResolveWith evaluates ts against entries. Inline selectors are unioned; each
 // preset resolves to its includes minus its excludes, recursively for
 // composed presets. Every preset the toolset names must exist (Check) or the
-// unknown-preset error is returned.
-func (r *Registry) Resolve(ts Toolset, entries []Entry) (Resolution, error) {
+// unknown-preset error is returned. labels resolves an MCPServer name to its
+// resource labels for label: rules and is consulted lazily — only when such a
+// rule is evaluated — so a request whose presets carry no label rule never
+// pays for the lookup; nil means no labels are known.
+func (r *Registry) ResolveWith(ts Toolset, entries []Entry, labels ServerLabels) (Resolution, error) {
 	if err := r.Check(ts); err != nil {
 		return Resolution{}, err
 	}
@@ -55,7 +64,7 @@ func (r *Registry) Resolve(ts Toolset, entries []Entry) (Resolution, error) {
 		var matched map[string]struct{}
 		switch sel.Kind {
 		case KindPreset:
-			matched = r.resolvePreset(sel.Name, entries, map[string]bool{})
+			matched = r.resolvePreset(sel.Name, entries, labels, map[string]bool{})
 		default:
 			matched = matchInline(sel, entries)
 		}
@@ -113,7 +122,7 @@ func entryServedBy(e Entry, server string) bool {
 // resolvePreset returns the names a preset selects: includes minus excludes.
 // visiting guards against composition cycles (rejected at construction, but
 // the walk stays safe regardless).
-func (r *Registry) resolvePreset(name string, entries []Entry, visiting map[string]bool) map[string]struct{} {
+func (r *Registry) resolvePreset(name string, entries []Entry, labels ServerLabels, visiting map[string]bool) map[string]struct{} {
 	matched := map[string]struct{}{}
 	p, ok := r.presets[name]
 	if !ok || visiting[name] {
@@ -124,20 +133,20 @@ func (r *Registry) resolvePreset(name string, entries []Entry, visiting map[stri
 
 	for _, rule := range p.Include {
 		if rule.Preset != "" {
-			for n := range r.resolvePreset(rule.Preset, entries, visiting) {
+			for n := range r.resolvePreset(rule.Preset, entries, labels, visiting) {
 				matched[n] = struct{}{}
 			}
 			continue
 		}
 		for _, e := range entries {
-			if ruleMatches(rule, e) {
+			if ruleMatches(rule, e, labels) {
 				matched[e.Name] = struct{}{}
 			}
 		}
 	}
 	for _, rule := range p.Exclude {
 		for _, e := range entries {
-			if ruleMatches(rule, e) {
+			if ruleMatches(rule, e, labels) {
 				delete(matched, e.Name)
 			}
 		}
@@ -146,7 +155,7 @@ func (r *Registry) resolvePreset(name string, entries []Entry, visiting map[stri
 }
 
 // ruleMatches evaluates one preset rule against one entry.
-func ruleMatches(rule Rule, e Entry) bool {
+func ruleMatches(rule Rule, e Entry, labels ServerLabels) bool {
 	switch {
 	case rule.Tool != "":
 		return e.Name == rule.Tool
@@ -159,6 +168,32 @@ func ruleMatches(rule Rule, e Entry) bool {
 		return e.Kind == KindEntryWorkflow && e.Name == "workflow_"+rule.Workflow
 	case rule.ReadOnly != nil:
 		return *rule.ReadOnly && e.ReadOnly
+	case rule.Label != "":
+		return entryLabelled(e, rule.Label, labels)
+	}
+	return false
+}
+
+// entryLabelled reports whether a server tool is served by an MCPServer whose
+// resource carries the label: the owning server, or — for a family tool — any
+// member providing it. Workflows and core tools are never labelled.
+func entryLabelled(e Entry, rule string, labels ServerLabels) bool {
+	if e.Kind != KindEntryTool || labels == nil {
+		return false
+	}
+	key, want, hasValue := labelSelector(rule)
+	servers := e.Servers
+	if e.Server != "" {
+		servers = append([]string{e.Server}, servers...)
+	}
+	for _, server := range servers {
+		have, ok := labels(server)[key]
+		if !ok {
+			continue
+		}
+		if !hasValue || have == want {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/toolset/resolve_test.go
+++ b/internal/toolset/resolve_test.go
@@ -60,7 +60,7 @@ func resolve(t *testing.T, r *Registry, header string) Resolution {
 	t.Helper()
 	ts, err := ParseHeader(header)
 	require.NoError(t, err)
-	res, err := r.Resolve(ts, EntriesFromTools(catalogue(), nil))
+	res, err := r.Resolve(ts, EntriesFromTools(catalogue()))
 	require.NoError(t, err)
 	return res
 }
@@ -71,24 +71,74 @@ func TestEntriesFromTools_ClassifiesByOriginThenPrefix(t *testing.T) {
 		{Name: "workflow_untagged"},
 		{Name: "core_untagged"},
 		{Name: "x_plain_tool"},
-	}, nil)
+	})
 	assert.Equal(t, Entry{Name: "x_k8s_get", Kind: KindEntryTool, Server: "k8s", ReadOnly: true}, entries[0])
 	assert.Equal(t, KindEntryWorkflow, entries[1].Kind)
 	assert.Equal(t, KindEntryCore, entries[2].Kind)
 	assert.Equal(t, KindEntryTool, entries[3].Kind)
 }
 
-func TestEntriesFromTools_ServerLabels(t *testing.T) {
+func TestResolveWith_LabelRules(t *testing.T) {
+	const group = "agent-platform.giantswarm.io/tool-group"
 	labels := func(server string) map[string]string {
-		if server == "k8s" {
-			return map[string]string{"tier": "infrastructure"}
+		switch server {
+		case "k8s":
+			return map[string]string{group: "infrastructure", "tier": ""}
+		case "prom-b": // one family member carries the label
+			return map[string]string{group: "infrastructure"}
 		}
 		return nil
 	}
-	entries := EntriesFromTools(catalogue(), labels)
-	assert.Equal(t, map[string]string{"tier": "infrastructure"}, entries[0].Labels)
-	assert.Nil(t, entries[2].Labels, "family tool has no label for the family name")
-	assert.Nil(t, entries[3].Labels, "workflows carry no server labels")
+	r, err := NewRegistry(PresetsConfig{
+		"infrastructure": {Include: []Rule{{Label: group + "=infrastructure"}}},
+		"agent-platform": {Include: []Rule{{Label: group + "=agent-platform"}, {Pattern: "core_*"}}},
+		"tiered":         {Include: []Rule{{Label: "tier"}}},
+		"empty-tier":     {Include: []Rule{{Label: "tier="}}},
+		"no-deletes":     {Include: []Rule{{Label: group}}, Exclude: []Rule{{Pattern: "*_delete"}}},
+	})
+	require.NoError(t, err)
+	entries := EntriesFromTools(catalogue())
+
+	res, err := r.ResolveWith(must(ParseHeader("preset:infrastructure")), entries, labels)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x_k8s_delete", "x_k8s_get", "x_prometheus_query"}, res.Names(), "value match; a family tool joins through a labelled member")
+
+	res, _ = r.ResolveWith(must(ParseHeader("preset:agent-platform")), entries, labels)
+	assert.Equal(t, []string{"core_auth_login", "core_workflow_list"}, res.Names(), "no server carries that value; core tools via the pattern")
+
+	res, _ = r.ResolveWith(must(ParseHeader("preset:tiered")), entries, labels)
+	assert.Equal(t, []string{"x_k8s_delete", "x_k8s_get"}, res.Names(), "presence match")
+	res, _ = r.ResolveWith(must(ParseHeader("preset:empty-tier")), entries, labels)
+	assert.Equal(t, []string{"x_k8s_delete", "x_k8s_get"}, res.Names(), "key= matches the empty value")
+
+	res, _ = r.ResolveWith(must(ParseHeader("preset:no-deletes")), entries, labels)
+	assert.Equal(t, []string{"x_k8s_get", "x_prometheus_query"}, res.Names(), "exclude applies after label includes")
+
+	res, _ = r.ResolveWith(must(ParseHeader("preset:infrastructure")), entries, nil)
+	assert.Empty(t, res.Names(), "without a label lookup label rules select nothing")
+	assert.Equal(t, []string{"preset:infrastructure"}, res.Unmatched)
+}
+
+func TestNewRegistry_LabelRuleValidation(t *testing.T) {
+	for _, bad := range []string{"=infra", "a b=c", "key=va lue", "-x"} {
+		_, err := NewRegistry(PresetsConfig{"x": {Include: []Rule{{Label: bad}}}})
+		require.Error(t, err, bad)
+		assert.Contains(t, err.Error(), `include[0] label "`+bad+`" is invalid; expected <key>=<value> or <key>`)
+	}
+	for _, ok := range []string{"tier", "tier=", "tier=gold", "agent-platform.giantswarm.io/tool-group=infrastructure"} {
+		_, err := NewRegistry(PresetsConfig{"x": {Include: []Rule{{Label: ok}}}})
+		require.NoError(t, err, ok)
+	}
+	_, err := NewRegistry(PresetsConfig{"x": {Include: []Rule{{Label: "tier", Server: "k8s"}}}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must set exactly one of tool, pattern, server, workflow, readOnly, preset, label")
+}
+
+func must(ts Toolset, err error) Toolset {
+	if err != nil {
+		panic(err)
+	}
+	return ts
 }
 
 func TestResolve_InlineSelectors(t *testing.T) {
@@ -159,7 +209,7 @@ func TestResolve_ConfiguredPresets(t *testing.T) {
 
 func TestResolve_UnknownPresetIsAnError(t *testing.T) {
 	ts, _ := ParseHeader("preset:foo")
-	_, err := BuiltIns().Resolve(ts, EntriesFromTools(catalogue(), nil))
+	_, err := BuiltIns().Resolve(ts, EntriesFromTools(catalogue()))
 	require.Error(t, err)
 	assert.Equal(t, `toolset [preset:foo] names unknown preset "foo"; known presets: read-only, none, full`, err.Error())
 }


### PR DESCRIPTION
Closes #1168

Builds on #1170 (toolset machinery, v5.11.0). Decision D8 of the tool-access plan ([PRD](https://github.com/giantswarm/bumblebee-plans/blob/main/agent-tool-access/PRD.md), epic giantswarm/giantswarm#37435): the platform's `infrastructure` and `agent-platform` presets select servers by the `agent-platform.giantswarm.io/tool-group` label their charts stamp on the MCPServer resource, so a new manager or a fourth infrastructure family joins its preset with no values change.

## What

- **`label:` preset rule** (`<key>=<value>` for a value match, `<key>` for presence, `<key>=` for an empty value): selects the tools of every MCPServer whose resource carries the label; a family tool joins when any member providing it is labelled. **Presets only** — inline `label:` keeps its `allowed inside presets only` error (from #1170). Validated at startup like every other rule (`label "…" is invalid; expected <key>=<value> or <key>`; exactly one key per rule).
- **Labels are read live, per request, in both storage modes**: `api.MCPServerInfo` gains `labels` (from `metadata.labels`, populated by `convertCRDToInfo`), and the meta-tools resolve label rules through a per-request, lazily memoised lookup over `ListMCPServers` — the first label rule evaluated in a request lists the servers once; requests whose presets carry no label rule never list them. A failed listing logs a warning and makes label rules select nothing (closed failure mode). A server gaining or losing the label therefore changes the resolution on the next request — no restart, no reconcile.
- Harness: `pre_configuration.mcp_servers[].labels` writes `metadata.labels` on the definition; `test_set_mcpserver_labels {server, labels}` replaces them on disk while muster runs.
- Docs: `docs/reference/toolsets.md` (rule semantics, the two platform presets as the fleet chart ships them), scenario authoring guide.

## Implementation choices

- The lookup lives behind `metatools.WithServerLabels(ServerLabelsSource)` and `toolset.ResolveWith(ts, entries, labels)`; `Resolve` (no labels) stays for callers without a source. Resolution cost without label rules is unchanged.
- Kubernetes mode lists MCPServers through the existing muster client (one LIST per request that evaluates a label rule); filesystem mode reads the definition files. Neither caches beyond the request, which is what makes "without a restart" true by construction. If the per-request LIST ever shows up in profiles, a short TTL cache is the follow-up — bounded staleness would be the trade.

## Testing

- Unit: label validation, value / presence / empty-value matching, family member labels, exclude after label includes, nil lookup ⇒ nothing.
- Behavioural scenario `toolset-label-preset-selector` (tag `1168`): presets `infrastructure` / `agent-platform` (label + `core_*`) / presence match; `call_tool` gated by the label preset; inline `label:` rejected; **gh gains the label ⇒ the next request's `preset:infrastructure` includes it and it becomes callable; k8s loses it ⇒ dropped and refused** — all on one running instance; unscoped view unaffected. Passes 13/13 here. Against a build of merged main (v5.11.0 code) the instance **refuses to start**: `invalid toolset presets: toolsetPresets: preset "agent-platform" include[0] must set exactly one of tool, pattern, server, workflow, readOnly, preset` — the unknown `label` shape is rejected loudly, never ignored.
- Full suite: 226/226 scenarios pass (`muster test --parallel 12`). `go test ./...` green; golangci-lint: 0 issues.

## Lab (agentlab, dev image before merge)

Dev image `muster:dev-toolsets-cb49b8ee` (this branch's HEAD) swapped into agentlab under the lab lock, with the two platform presets added to muster's ConfigMap exactly as the fleet chart will ship them (`infrastructure` = `label: agent-platform.giantswarm.io/tool-group=infrastructure`; `agent-platform` = that label `=agent-platform` + `pattern: core_*`). Startup log: `Registered meta-tools adapter with toolset presets: read-only, none, full, agent-platform, infrastructure`. Headless proof through the edge on one MCP session (`admin@lab.local`), the label applied live with `kubectl label` — no restart:

```
PASS: dex id_token
PASS: MCP session mcp-session-83703da6-adca-4ee0-adec-670f811e25cf
PASS: presets listed: ['read-only', 'none', 'full', 'agent-platform', 'infrastructure']
## before labelling (only the auth-required fake-fleet fixtures carry the label)
    |total 0 |unmatched ['preset:infrastructure']
PASS: preset:infrastructure resolves to nothing for this session (labelled fixtures need sign-in; visibility wins) and is reported unmatched
PASS: kubectl label mcp-kubernetes agent-platform.giantswarm.io/tool-group=infrastructure (no restart)
   mcp-kubernetes |total 6 |unmatched None
PASS: next request: preset:infrastructure = mcp-kubernetes tools only (6 tools)
PASS: agent-manager tool refused under preset:infrastructure
    |total 29 |unmatched None
PASS: preset:agent-platform = core_* only while no server carries tool-group=agent-platform (agent-manager unlabelled until its chart ships the label)
PASS: kubectl label mcp-kubernetes agent-platform.giantswarm.io/tool-group- (removed)
PASS: next request: preset:infrastructure back to nothing
PASS: x_mcp-kubernetes_api_resources refused again after the label was removed
PASS: inline label: rejected
```

- Before labelling, the only MCPServers carrying the label are the six auth-required fake-fleet fixtures, so `preset:infrastructure` resolves to nothing for a session that has not signed in to them and is reported in `toolset_unmatched` — visibility wins over the label.
- `kubectl label mcpservers.muster.giantswarm.io mcp-kubernetes agent-platform.giantswarm.io/tool-group=infrastructure` ⇒ the next request's `preset:infrastructure` is exactly the 6 `mcp-kubernetes` tools; removing the label ⇒ nothing again, and the read-only `x_mcp-kubernetes_api_resources` is refused as outside the toolset. Label removed afterwards (lab left as found).
- `agentlab platform-test`: green on the dev image and after the restore of the ConfigMap and the image (`gsoci.azurecr.io/giantswarm/muster:5.10.2` / `IfNotPresent`); lock released.
