### PR TITLE
docs(toolsets): safe-ops example narrows by exclude — include rules are a union, not an intersection

### DIFF
--- a/docs/reference/toolsets.md
+++ b/docs/reference/toolsets.md
@@ -77,18 +77,23 @@ toolsetPresets:
     exclude:
       - pattern: "*_delete"
   safe-ops:
-    description: infrastructure narrowed to read-only, plus one workflow
+    description: The infrastructure preset without its writes, plus one workflow
     include:
       - preset: infrastructure
-      - readOnly: true
       - workflow: incident-triage
     exclude:
-      - workflow: rollout
+      - pattern: "*_apply"
+      - pattern: "*_patch"
 ```
 
 Each preset has an optional `description` (shown by `filter_tools` with `include_presets`),
 an `include` list and an optional `exclude` list. A preset resolves to the union of its
-includes minus its excludes. Every rule sets **exactly one** key:
+includes minus its excludes. `include` rules are a **union, never an intersection**: a preset
+that includes `preset: infrastructure` and `readOnly: true` resolves to every infrastructure tool
+*plus* every read-only tool in the catalogue, not to the infrastructure's read-only tools. To
+narrow a server set, include it and `exclude` the tools you do not want by `pattern:` or `tool:`,
+as `safe-ops` does above (`readOnly: false` is not a rule; muster rejects it at startup). Every
+rule sets **exactly one** key:
 
 | Rule | Selects |
 |---|---|


### PR DESCRIPTION
Follow-up to #1170 / #1171 (toolset docs).

**What:** `docs/reference/toolsets.md` showed a `safe-ops` preset built from `preset: infrastructure` + `readOnly: true`, described as "infrastructure narrowed to read-only". That is not what it resolves to.

**Why:** `include` rules are a union. `Registry.resolvePreset` (`internal/toolset/resolve.go:134-146`) adds every entry matched by *any* include rule to one `matched` set and only then removes the `exclude` matches (`resolve.go:147-153`); `preset.go:95-96` documents the type the same way ("the union of its include rules minus its exclude rules"). So the old example resolved to every infrastructure tool **plus** every read-only tool in the catalogue. There is no intersection rule either: `readOnly: false` is rejected at startup (`preset.go:198`, "selects nothing; omit the rule") and `ruleMatches` only ever matches `readOnly: true` (`resolve.go:169-170`).

**Change:**
- `safe-ops` now includes the `infrastructure` preset plus one workflow and `exclude`s the writes by `pattern:` — an example that actually narrows.
- One explicit sentence on the union semantics next to the rule table, with the pointer to `exclude` and the note that `readOnly: false` is not a rule.

Docs only; `pre-commit run --files docs/reference/toolsets.md` clean. `cliff.toml` skips `docs` commits, so this does not cut a release (5.12.0 stays current).
