### PR TITLE
fix(oauth): a pinned authorization server is the one key of a server's grants and its pin is released when the MCPServer changes

### DIFF
--- a/docs/contributing/testing/oauth-testing.md
+++ b/docs/contributing/testing/oauth-testing.md
@@ -111,6 +111,8 @@ The `test_simulate_oauth_callback` tool bridges these by completing the full OAu
 | `test_simulate_oauth_callback` | `internal/testing/test_tools.go` | Complete OAuth flow simulation |
 | `test_inject_token` | `internal/testing/test_tools.go` | Direct token injection |
 | `test_get_oauth_server_info` | `internal/testing/test_tools.go` | OAuth server state inspection |
+| `test_resolve_auth_redirect` | `internal/testing/test_tools_authorization_server.go` | `core_auth_login` challenge followed one hop: which mock AS the sign-in goes to |
+| `test_pin_mcpserver_authorization_server` | `internal/testing/test_tools_authorization_server.go` | Rewrite an MCPServer's `spec.auth.authorizationServer` at runtime (pin, re-pin, clear) |
 
 ## Current OAuth Scenarios
 
@@ -360,6 +362,30 @@ metadata: a bare `WWW-Authenticate: Bearer` on 401 and a 404 for
 server without an issuer and learns it only from the pin -- the state of a
 restarted muster before anyone logs in. See
 `oauth-subject-grant-logout-without-resource-metadata.yaml`.
+
+### Pinned authorization servers that differ from the advertised one
+
+`oauth.pin_authorization_server: true` pins `mock_oauth_server_ref` as the
+MCPServer's authorization server without a grant scope (`grant_scope` implies
+the pin). `oauth.pin_endpoints_ref` adds another mock server's `/authorize`
+and `/token` as `authorizationEndpoint`/`tokenEndpoint` -- the GitHub shape,
+explicit endpoints under the pinned issuer. `oauth.advertised_issuer_ref`
+makes the backend's RFC 9728 metadata name that mock server as its
+authorization server while tokens are still validated against
+`mock_oauth_server_ref`: a backend that accepts tokens from an authorization
+server other than the one it advertises (muster's own `/mcp` trusts its IdP's
+tokens but names muster's OAuth server). On a mock OAuth server,
+`omit_token_scope: true` leaves `scope` out of token responses, as Dex does.
+
+`test_resolve_auth_redirect` (`server`) runs `core_auth_login` and follows the
+challenge's start URL one hop; its result names the mock OAuth server the
+sign-in is sent to (`authorization_server`) plus `authorization_endpoint`,
+`client_id` and `scope`. `test_pin_mcpserver_authorization_server` (`server`,
+`issuer_ref`, optional `endpoints_ref`, `scopes`, `grant_scope`, or `clear:
+true`) rewrites the MCPServer's `spec.auth.authorizationServer` in the
+filesystem definition, which the reconciler applies like a CR update. See
+`oauth-pinned-issuer-is-the-grant-key.yaml` (muster#1174) and
+`oauth-pinned-authorization-server-change-takes-effect.yaml` (muster#1175).
 
 ## Debugging OAuth Tests
 

--- a/docs/how-to/connecting-non-rfc9728-mcp-servers.md
+++ b/docs/how-to/connecting-non-rfc9728-mcp-servers.md
@@ -32,6 +32,25 @@ directly from `<issuer>/.well-known/oauth-authorization-server`. The discovered
 — a typo or stale URL fails closed instead of driving an OAuth flow against
 the wrong AS.
 
+## Which issuer to pin
+
+The pinned `issuer` is the authorization server the sign-in runs against
+**and** the key the session's grant is filed under -- the browser flow, the
+token store, the connection and `core_auth_logout` all use it. It takes
+precedence over the authorization server the endpoint's own RFC 9728 metadata
+names, so an endpoint that accepts tokens from an authorization server other
+than the one it advertises is pinned by naming the accepting one. The issuer
+may be muster's own identity provider (an endpoint that trusts the same Dex as
+muster): muster keeps the session's login token apart from the grant, and a
+sign-in against such a pin makes the server's tools callable like any other.
+Name the `scopes` such an authorization server needs; a pin gets no default
+scope, and Dex refuses a request without `openid`.
+
+Changing `authorizationServer` -- another issuer, explicit endpoints added or
+removed, a rotated client Secret reference -- takes effect on the next
+`core_auth_login`. The description the MCPServer no longer carries is released
+when the change is reconciled; nothing has to be restarted.
+
 ## What you'll see in the UI
 
 The override applies only to `muster auth login --server <name>`

--- a/helm/muster-crds/files/crds/muster.giantswarm.io_mcpservers.yaml
+++ b/helm/muster-crds/files/crds/muster.giantswarm.io_mcpservers.yaml
@@ -153,11 +153,20 @@ spec:
                         type: string
                       issuer:
                         description: |-
-                          Issuer is the OAuth 2.0 / OIDC issuer URL.
+                          Issuer is the OAuth 2.0 / OIDC issuer URL of the authorization server
+                          the sign-in runs against, and the identity the session's grants are
+                          filed under. It takes precedence over the authorization server the
+                          endpoint's own RFC 9728 metadata names: the browser flow, the token
+                          store, the connection and core_auth_logout all use this issuer, so an
+                          endpoint that accepts tokens from an authorization server other than the
+                          one it advertises is pinned by naming the accepting one here. It may be
+                          muster's own identity provider; muster keeps the session's login token
+                          apart from the grant. A change to this field takes effect on the next
+                          core_auth_login, without a restart.
                           muster fetches AS metadata via the existing OAuth client, which performs
                           RFC 8414 / OIDC discovery against this issuer -- unless
-                          AuthorizationEndpoint and TokenEndpoint are set, in which case the issuer
-                          is only the identity the stored grants are filed under.
+                          AuthorizationEndpoint and TokenEndpoint are set, in which case no
+                          discovery happens and the issuer is only that identity.
                         pattern: ^https://[^/?#]+(/[^?#]*[^/?#])?$
                         type: string
                       scopes:

--- a/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
+++ b/helm/muster/crds/muster.giantswarm.io_mcpservers.yaml
@@ -154,11 +154,20 @@ spec:
                         type: string
                       issuer:
                         description: |-
-                          Issuer is the OAuth 2.0 / OIDC issuer URL.
+                          Issuer is the OAuth 2.0 / OIDC issuer URL of the authorization server
+                          the sign-in runs against, and the identity the session's grants are
+                          filed under. It takes precedence over the authorization server the
+                          endpoint's own RFC 9728 metadata names: the browser flow, the token
+                          store, the connection and core_auth_logout all use this issuer, so an
+                          endpoint that accepts tokens from an authorization server other than the
+                          one it advertises is pinned by naming the accepting one here. It may be
+                          muster's own identity provider; muster keeps the session's login token
+                          apart from the grant. A change to this field takes effect on the next
+                          core_auth_login, without a restart.
                           muster fetches AS metadata via the existing OAuth client, which performs
                           RFC 8414 / OIDC discovery against this issuer -- unless
-                          AuthorizationEndpoint and TokenEndpoint are set, in which case the issuer
-                          is only the identity the stored grants are filed under.
+                          AuthorizationEndpoint and TokenEndpoint are set, in which case no
+                          discovery happens and the issuer is only that identity.
                         pattern: ^https://[^/?#]+(/[^?#]*[^/?#])?$
                         type: string
                       scopes:

--- a/internal/aggregator/auth_info_resolve.go
+++ b/internal/aggregator/auth_info_resolve.go
@@ -54,7 +54,11 @@ func (a *AggregatorServer) resolveServerAuthInfo(ctx context.Context, serverInfo
 		copied := *current
 		authInfo = &copied
 	}
+	changed := applyAuthorizationServerPin(authInfo, serverInfo.AuthConfig)
 	if !needsResourceMetadata(authInfo, serverInfo.URL) {
+		if changed {
+			serverInfo.SetAuthInfo(authInfo)
+		}
 		return authInfo, nil
 	}
 
@@ -71,7 +75,6 @@ func (a *AggregatorServer) resolveServerAuthInfo(ctx context.Context, serverInfo
 		return authInfo, nil
 	}
 
-	changed := false
 	if authInfo.Issuer == "" && metadata.Issuer != "" {
 		authInfo.Issuer = metadata.Issuer
 		changed = true
@@ -90,4 +93,30 @@ func (a *AggregatorServer) resolveServerAuthInfo(ctx context.Context, serverInfo
 		serverInfo.SetAuthInfo(authInfo)
 	}
 	return authInfo, nil
+}
+
+// applyAuthorizationServerPin makes an operator's pin
+// (spec.auth.authorizationServer) the authority on a server's authorization
+// server: its issuer -- and its scopes, when it names any -- replace what the
+// 401 probe learned from the endpoint's own RFC 9728 metadata. The issuer is
+// the key everything files or looks the session's grant up under (the
+// challenge, the token store, the connection, the logout), so there must be
+// exactly one, and the operator's declaration wins over an endpoint that
+// advertises a different authorization server (giantswarm/muster#1174).
+// Reports whether authInfo changed.
+func applyAuthorizationServerPin(authInfo *AuthInfo, auth *api.MCPServerAuth) bool {
+	as := authorizationServerOf(auth)
+	if as == nil || authInfo == nil {
+		return false
+	}
+	changed := false
+	if issuer := strings.TrimSuffix(as.Issuer, "/"); authInfo.Issuer != issuer {
+		authInfo.Issuer = issuer
+		changed = true
+	}
+	if as.Scopes != "" && authInfo.Scope != as.Scopes {
+		authInfo.Scope = as.Scopes
+		changed = true
+	}
+	return changed
 }

--- a/internal/aggregator/auth_resource.go
+++ b/internal/aggregator/auth_resource.go
@@ -253,10 +253,7 @@ func (a *AggregatorServer) storeIDTokenForSSO(familyID, userID, idToken string) 
 		return
 	}
 	if oh := api.GetOAuthHandler(); oh != nil && oh.IsEnabled() {
-		oh.StoreToken(familyID, userID, musterIssuer, &api.OAuthToken{
-			IDToken:   idToken,
-			ExpiresAt: exp,
-		})
+		api.StoreLoginIDToken(oh, familyID, userID, musterIssuer, idToken, exp)
 	}
 }
 

--- a/internal/aggregator/auth_tools.go
+++ b/internal/aggregator/auth_tools.go
@@ -554,18 +554,19 @@ func (p *AuthToolProvider) isIssuerExclusiveToServer(sessionID, serverName, issu
 }
 
 // knownServerIssuer returns the OAuth issuer the registry knows for a server
-// without a network round trip: what the 401 probe or a login recorded in
-// AuthInfo, else the operator's pin (spec.auth.authorizationServer.issuer).
-// Empty when neither says.
+// without a network round trip: the operator's pin
+// (spec.auth.authorizationServer.issuer) when there is one -- the key the
+// server's grants are filed under, whatever the endpoint advertises -- else
+// what the 401 probe or a login recorded in AuthInfo. Empty when neither says.
 func knownServerIssuer(info *ServerInfo) string {
 	if info == nil {
 		return ""
 	}
+	if as := authorizationServerOf(info.AuthConfig); as != nil {
+		return strings.TrimSuffix(as.Issuer, "/")
+	}
 	if info.AuthInfo != nil && info.AuthInfo.Issuer != "" {
 		return info.AuthInfo.Issuer
-	}
-	if info.AuthConfig != nil && info.AuthConfig.AuthorizationServer != nil && info.AuthConfig.AuthorizationServer.Issuer != "" {
-		return strings.TrimSuffix(info.AuthConfig.AuthorizationServer.Issuer, "/")
 	}
 	return ""
 }

--- a/internal/aggregator/auth_tools_logout_test.go
+++ b/internal/aggregator/auth_tools_logout_test.go
@@ -356,5 +356,5 @@ func TestKnownServerIssuer(t *testing.T) {
 	pinned := &ServerInfo{AuthConfig: &api.MCPServerAuth{AuthorizationServer: &api.MCPServerAuthAuthorizationServer{Issuer: "https://b.example.com/"}}}
 	assert.Equal(t, "https://b.example.com", knownServerIssuer(pinned), "the pin is trimmed like PinIssuer does")
 	both := &ServerInfo{AuthInfo: &AuthInfo{Issuer: "https://a.example.com"}, AuthConfig: pinned.AuthConfig}
-	assert.Equal(t, "https://a.example.com", knownServerIssuer(both), "AuthInfo wins over the pin")
+	assert.Equal(t, "https://b.example.com", knownServerIssuer(both), "the pin wins over what the probe recorded: it is the key the grants are filed under (#1174)")
 }

--- a/internal/aggregator/authorization_server_pin.go
+++ b/internal/aggregator/authorization_server_pin.go
@@ -65,3 +65,95 @@ func pinAuthorizationServer(ctx context.Context, serverInfo *ServerInfo) error {
 		slog.Bool("subjectScoped", pin.SubjectScoped))
 	return nil
 }
+
+// authorizationServerOf returns the authorization server an MCPServer's auth
+// config describes (spec.auth.authorizationServer with an issuer), or nil.
+func authorizationServerOf(auth *api.MCPServerAuth) *api.MCPServerAuthAuthorizationServer {
+	if auth == nil || auth.AuthorizationServer == nil || auth.AuthorizationServer.Issuer == "" {
+		return nil
+	}
+	return auth.AuthorizationServer
+}
+
+// sameAuthorizationServer reports whether two descriptions of an authorization
+// server are the same: issuer, endpoints, client Secret reference, grant scope
+// and scopes. A rotated Secret behind an unchanged reference is not a change
+// here; the re-pin every login performs picks that up.
+func sameAuthorizationServer(a, b *api.MCPServerAuthAuthorizationServer) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if strings.TrimSuffix(a.Issuer, "/") != strings.TrimSuffix(b.Issuer, "/") ||
+		a.AuthorizationEndpoint != b.AuthorizationEndpoint ||
+		a.TokenEndpoint != b.TokenEndpoint ||
+		a.GrantScope != b.GrantScope ||
+		a.Scopes != b.Scopes {
+		return false
+	}
+	ra, rb := a.ClientCredentialsSecretRef, b.ClientCredentialsSecretRef
+	if ra == nil || rb == nil {
+		return ra == rb
+	}
+	return *ra == *rb
+}
+
+// releaseAuthorizationServerPin runs when a server's registration is replaced
+// or removed; previous is the auth config the registry held for the server
+// before. When that configuration described an authorization server and the
+// server's current registration (if any) describes it differently or not at
+// all, the description is released: replaced by another server's description
+// of the same issuer, or forgotten by the OAuth handler. The caller applies
+// the server's current description afterwards (pinAuthorizationServer).
+//
+// Without this a pin outlives the MCPServer that placed it -- the OAuth
+// handler keeps identifying with the old client, and metadata pinned with
+// explicit endpoints keeps standing in for discovery -- until the process
+// restarts (giantswarm/muster#1175).
+func (a *AggregatorServer) releaseAuthorizationServerPin(ctx context.Context, name string, previous *api.MCPServerAuth) {
+	prev := authorizationServerOf(previous)
+	if prev == nil {
+		return
+	}
+	var current *api.MCPServerAuthAuthorizationServer
+	if info, ok := a.registry.GetServerInfo(name); ok {
+		current = authorizationServerOf(info.AuthConfig)
+	}
+	if sameAuthorizationServer(prev, current) {
+		return
+	}
+	handler := api.GetOAuthHandler()
+	if handler == nil {
+		return
+	}
+	pinner, ok := handler.(api.IssuerPinner)
+	if !ok {
+		return
+	}
+	issuer := strings.TrimSuffix(prev.Issuer, "/")
+
+	// Another server may still describe the issuer; its description takes
+	// over. This server's own current description is applied by the caller.
+	for other, info := range a.registry.GetAllServers() {
+		if other == name {
+			continue
+		}
+		as := authorizationServerOf(info.AuthConfig)
+		if as == nil || strings.TrimSuffix(as.Issuer, "/") != issuer {
+			continue
+		}
+		pinner.UnpinIssuer(issuer)
+		if err := pinAuthorizationServer(ctx, info); err != nil {
+			logging.Warn("Aggregator", "Authorization server pin of %s could not be re-applied after %s changed: %v", other, name, err)
+		}
+		logging.InfoWithAttrs("Aggregator", "oauth_authorization_server_pin_replaced",
+			slog.String("server", name),
+			slog.String("issuer", issuer),
+			slog.String("replacedBy", other))
+		return
+	}
+
+	pinner.UnpinIssuer(issuer)
+	logging.InfoWithAttrs("Aggregator", "oauth_authorization_server_unpinned",
+		slog.String("server", name),
+		slog.String("issuer", issuer))
+}

--- a/internal/aggregator/authorization_server_pin_test.go
+++ b/internal/aggregator/authorization_server_pin_test.go
@@ -21,6 +21,10 @@ func (p *pinCaptureHandler) PinIssuer(issuer string, pin api.IssuerPin) {
 	p.pins[issuer] = pin
 }
 
+func (p *pinCaptureHandler) UnpinIssuer(issuer string) {
+	delete(p.pins, issuer)
+}
+
 var _ api.IssuerPinner = (*pinCaptureHandler)(nil)
 
 func githubStyleServer(secretRef *api.ClientCredentialsSecretRef, grantScope string) *ServerInfo {

--- a/internal/aggregator/authorization_server_release_test.go
+++ b/internal/aggregator/authorization_server_release_test.go
@@ -1,0 +1,160 @@
+package aggregator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+func pinnedAuth(issuer, authEP, tokenEP string) *api.MCPServerAuth {
+	return &api.MCPServerAuth{
+		Type: "oauth",
+		AuthorizationServer: &api.MCPServerAuthAuthorizationServer{
+			Issuer:                issuer,
+			AuthorizationEndpoint: authEP,
+			TokenEndpoint:         tokenEP,
+		},
+	}
+}
+
+func TestReleaseAuthorizationServerPin(t *testing.T) {
+	ctx := context.Background()
+	const issuer = "https://muster.example.com"
+	handler := &pinCaptureHandler{mockOAuthHandler: newMockOAuthHandler(true), pins: map[string]api.IssuerPin{}}
+	api.RegisterOAuthHandler(handler)
+	defer api.RegisterOAuthHandler(nil)
+
+	newServer := func(reg *ServerRegistry, name string, auth *api.MCPServerAuth) {
+		require.NoError(t, reg.RegisterPendingAuth(PendingAuthRegistration{
+			ServerRegistration: ServerRegistration{Name: name},
+			URL:                "http://" + name + ".local/mcp",
+			AuthInfo:           &AuthInfo{},
+			AuthConfig:         auth,
+		}))
+	}
+
+	t.Run("a pin the server no longer carries is forgotten", func(t *testing.T) {
+		a := &AggregatorServer{registry: NewServerRegistry("x")}
+		previous := pinnedAuth(issuer, "https://dex.example.com/auth", "https://dex.example.com/token")
+		handler.pins[issuer] = api.IssuerPin{AuthorizationEndpoint: "https://dex.example.com/auth"}
+		newServer(a.registry, "fixture", &api.MCPServerAuth{Type: "oauth"}) // re-registered without the pin
+
+		a.releaseAuthorizationServerPin(ctx, "fixture", previous)
+
+		_, still := handler.pins[issuer]
+		assert.False(t, still, "nobody describes the issuer any more")
+	})
+
+	t.Run("a changed description drops the old one before the caller applies the new", func(t *testing.T) {
+		a := &AggregatorServer{registry: NewServerRegistry("x")}
+		previous := pinnedAuth(issuer, "https://dex.example.com/auth", "https://dex.example.com/token")
+		handler.pins[issuer] = api.IssuerPin{AuthorizationEndpoint: "https://dex.example.com/auth"}
+		newServer(a.registry, "fixture", pinnedAuth(issuer, "", "")) // same issuer, discovery instead of endpoints
+
+		a.releaseAuthorizationServerPin(ctx, "fixture", previous)
+
+		_, still := handler.pins[issuer]
+		assert.False(t, still, "the endpoints of the old description must not survive")
+	})
+
+	t.Run("an unchanged description is left alone", func(t *testing.T) {
+		a := &AggregatorServer{registry: NewServerRegistry("x")}
+		previous := pinnedAuth(issuer, "https://dex.example.com/auth", "https://dex.example.com/token")
+		handler.pins[issuer] = api.IssuerPin{AuthorizationEndpoint: "https://dex.example.com/auth"}
+		newServer(a.registry, "fixture", pinnedAuth(issuer+"/", "https://dex.example.com/auth", "https://dex.example.com/token"))
+
+		a.releaseAuthorizationServerPin(ctx, "fixture", previous)
+
+		_, still := handler.pins[issuer]
+		assert.True(t, still, "the same description (modulo trailing slash) keeps its pin")
+	})
+
+	t.Run("another server's description of the issuer takes over", func(t *testing.T) {
+		a := &AggregatorServer{registry: NewServerRegistry("x")}
+		previous := pinnedAuth(issuer, "https://old.example.com/auth", "https://old.example.com/token")
+		handler.pins[issuer] = api.IssuerPin{AuthorizationEndpoint: "https://old.example.com/auth"}
+		newServer(a.registry, "fixture", &api.MCPServerAuth{Type: "oauth"})
+		newServer(a.registry, "sibling", pinnedAuth(issuer, "https://sibling.example.com/auth", "https://sibling.example.com/token"))
+
+		a.releaseAuthorizationServerPin(ctx, "fixture", previous)
+
+		pin, still := handler.pins[issuer]
+		require.True(t, still, "the sibling still describes the issuer")
+		assert.Equal(t, "https://sibling.example.com/auth", pin.AuthorizationEndpoint, "the sibling's description replaced the released one")
+	})
+
+	t.Run("nothing to release without a previous pin", func(t *testing.T) {
+		a := &AggregatorServer{registry: NewServerRegistry("x")}
+		handler.pins[issuer] = api.IssuerPin{ClientID: "keep"}
+		a.releaseAuthorizationServerPin(ctx, "fixture", &api.MCPServerAuth{Type: "oauth"})
+		a.releaseAuthorizationServerPin(ctx, "fixture", nil)
+		_, still := handler.pins[issuer]
+		assert.True(t, still)
+	})
+}
+
+func TestApplyAuthorizationServerPin(t *testing.T) {
+	pin := &api.MCPServerAuth{Type: "oauth", AuthorizationServer: &api.MCPServerAuthAuthorizationServer{
+		Issuer: "https://dex.example.com/", Scopes: "openid profile",
+	}}
+
+	t.Run("the pinned issuer replaces the advertised one", func(t *testing.T) {
+		info := &AuthInfo{Issuer: "https://muster.example.com", Scope: "mcp:read", Resource: "https://backend/mcp"}
+		assert.True(t, applyAuthorizationServerPin(info, pin))
+		assert.Equal(t, "https://dex.example.com", info.Issuer)
+		assert.Equal(t, "openid profile", info.Scope)
+		assert.Equal(t, "https://backend/mcp", info.Resource, "the resource is not the pin's business")
+	})
+
+	t.Run("a pin without scopes keeps the discovered scope", func(t *testing.T) {
+		info := &AuthInfo{Issuer: "", Scope: "mcp:read"}
+		assert.True(t, applyAuthorizationServerPin(info, &api.MCPServerAuth{AuthorizationServer: &api.MCPServerAuthAuthorizationServer{Issuer: "https://dex.example.com"}}))
+		assert.Equal(t, "https://dex.example.com", info.Issuer)
+		assert.Equal(t, "mcp:read", info.Scope)
+	})
+
+	t.Run("no pin, no change", func(t *testing.T) {
+		info := &AuthInfo{Issuer: "https://muster.example.com"}
+		assert.False(t, applyAuthorizationServerPin(info, &api.MCPServerAuth{Type: "oauth"}))
+		assert.False(t, applyAuthorizationServerPin(info, nil))
+		assert.False(t, applyAuthorizationServerPin(nil, pin))
+		assert.Equal(t, "https://muster.example.com", info.Issuer)
+	})
+
+	t.Run("already the pinned values", func(t *testing.T) {
+		info := &AuthInfo{Issuer: "https://dex.example.com", Scope: "openid profile"}
+		assert.False(t, applyAuthorizationServerPin(info, pin))
+	})
+}
+
+func TestRegisterPendingAuth_PinIsTheIssuer(t *testing.T) {
+	reg := NewServerRegistry("x")
+	probe := &AuthInfo{Issuer: "https://muster.example.com", Scope: "mcp:read", ResourceMetadataURL: "http://backend/.well-known/oauth-protected-resource"}
+	require.NoError(t, reg.RegisterPendingAuth(PendingAuthRegistration{
+		ServerRegistration: ServerRegistration{Name: "fixture"},
+		URL:                "http://backend/mcp",
+		AuthInfo:           probe,
+		AuthConfig:         &api.MCPServerAuth{Type: "oauth", AuthorizationServer: &api.MCPServerAuthAuthorizationServer{Issuer: "https://dex.example.com", Scopes: "openid"}},
+	}))
+	info, ok := reg.GetServerInfo("fixture")
+	require.True(t, ok)
+	assert.Equal(t, "https://dex.example.com", info.GetAuthInfo().Issuer, "the registry files the server under the pinned issuer")
+	assert.Equal(t, "openid", info.GetAuthInfo().Scope)
+	assert.Equal(t, probe.ResourceMetadataURL, info.GetAuthInfo().ResourceMetadataURL)
+	assert.Equal(t, "https://muster.example.com", probe.Issuer, "the caller's AuthInfo is not mutated")
+	assert.Equal(t, "https://dex.example.com", knownServerIssuer(info))
+
+	// Without a pin the probe's issuer stands.
+	require.NoError(t, reg.RegisterPendingAuth(PendingAuthRegistration{
+		ServerRegistration: ServerRegistration{Name: "plain"},
+		URL:                "http://plain/mcp",
+		AuthInfo:           &AuthInfo{Issuer: "https://as.example.com"},
+		AuthConfig:         &api.MCPServerAuth{Type: "oauth"},
+	}))
+	plain, _ := reg.GetServerInfo("plain")
+	assert.Equal(t, "https://as.example.com", knownServerIssuer(plain))
+}

--- a/internal/aggregator/connection_helper.go
+++ b/internal/aggregator/connection_helper.go
@@ -272,7 +272,7 @@ func getIDTokenForForwarding(ctx context.Context, sessionID, musterIssuer string
 
 	oauthHandler := api.GetOAuthHandler()
 	if oauthHandler != nil && oauthHandler.IsEnabled() && musterIssuer != "" {
-		fullToken := oauthHandler.GetFullTokenByIssuer(sessionID, musterIssuer)
+		fullToken := api.LoginIDToken(oauthHandler, sessionID, musterIssuer)
 		if fullToken != nil && fullToken.IDToken != "" {
 			logging.Debug("Connection", "Found ID token in OAuth proxy store for session %s, issuer %s",
 				logging.TruncateIdentifier(sessionID), musterIssuer)
@@ -286,7 +286,7 @@ func getIDTokenForForwarding(ctx context.Context, sessionID, musterIssuer string
 				logging.Debug("Connection", "Session refresh failed for %s: %v",
 					logging.TruncateIdentifier(sessionID), err)
 			} else {
-				fullToken = oauthHandler.GetFullTokenByIssuer(sessionID, musterIssuer)
+				fullToken = api.LoginIDToken(oauthHandler, sessionID, musterIssuer)
 				if fullToken != nil && fullToken.IDToken != "" {
 					logging.Info("Connection", "Recovered ID token via session refresh for session %s",
 						logging.TruncateIdentifier(sessionID))

--- a/internal/aggregator/manager.go
+++ b/internal/aggregator/manager.go
@@ -388,6 +388,14 @@ func (am *AggregatorManager) RegisterServerPendingAuth(registration PendingAuthR
 		return fmt.Errorf("aggregator server not available")
 	}
 
+	// The auth config the registry held for the server until now: a changed
+	// or removed authorization-server description is released below, before
+	// the new one is applied.
+	var previousAuth *api.MCPServerAuth
+	if previous, ok := am.aggregatorServer.GetRegistry().GetServerInfo(registration.Name); ok {
+		previousAuth = previous.AuthConfig
+	}
+
 	if err := am.aggregatorServer.GetRegistry().RegisterPendingAuth(registration); err != nil {
 		return err
 	}
@@ -398,6 +406,7 @@ func (am *AggregatorManager) RegisterServerPendingAuth(registration PendingAuthR
 	// round trip. Logins retry the pin, so a failure here only delays.
 	if info, ok := am.aggregatorServer.GetRegistry().GetServerInfo(registration.Name); ok {
 		pinCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		am.aggregatorServer.releaseAuthorizationServerPin(pinCtx, registration.Name, previousAuth)
 		if err := pinAuthorizationServer(pinCtx, info); err != nil {
 			logging.Warn("Aggregator", "Authorization server pin deferred for %s: %v", registration.Name, err)
 		}

--- a/internal/aggregator/registry.go
+++ b/internal/aggregator/registry.go
@@ -1432,13 +1432,23 @@ func (r *ServerRegistry) RegisterPendingAuth(registration PendingAuthRegistratio
 		authConfig = &api.MCPServerAuth{}
 	}
 
+	// The probe's view of the authorization server, corrected by the
+	// operator's pin: the pinned issuer is the one key for the server's
+	// grants, whatever the endpoint's metadata advertises.
+	authInfo := registration.AuthInfo
+	if authInfo != nil {
+		copied := *authInfo
+		applyAuthorizationServerPin(&copied, authConfig)
+		authInfo = &copied
+	}
+
 	info := &ServerInfo{
 		Name:         registration.Name,
 		Namespace:    registration.Namespace,
 		URL:          registration.URL,
 		ToolPrefix:   registration.ToolPrefix,
 		Family:       cloneFamily(registration.Family),
-		AuthInfo:     registration.AuthInfo,
+		AuthInfo:     authInfo,
 		AuthConfig:   authConfig,
 		Meta:         registration.Meta,
 		RegisteredAt: time.Now(),

--- a/internal/aggregator/server.go
+++ b/internal/aggregator/server.go
@@ -1298,10 +1298,26 @@ func (a *AggregatorServer) deregisterServer(name string, keepSessionAuth bool) (
 		a.connPool.EvictServer(name)
 	}
 
-	if keepSessionAuth {
-		return a.registry.DeregisterUnlessSessionAuth(name, requestedAt)
+	// The entry's auth config, read before the delete: a removed server
+	// releases the authorization server it described.
+	var previousAuth *api.MCPServerAuth
+	if info, ok := a.registry.GetServerInfo(name); ok {
+		previousAuth = info.AuthConfig
 	}
-	return true, a.registry.DeregisterRequestedAt(name, requestedAt)
+
+	removed := true
+	var err error
+	if keepSessionAuth {
+		removed, err = a.registry.DeregisterUnlessSessionAuth(name, requestedAt)
+	} else {
+		err = a.registry.DeregisterRequestedAt(name, requestedAt)
+	}
+	if err == nil && removed {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		a.releaseAuthorizationServerPin(releaseCtx, name, previousAuth)
+		cancel()
+	}
+	return removed, err
 }
 
 // GetRegistry returns the server registry for direct access to backend server information.

--- a/internal/api/mcpserver.go
+++ b/internal/api/mcpserver.go
@@ -194,7 +194,9 @@ type MCPServerSigV4 struct {
 // MCPServerAuthAuthorizationServer pins the OAuth authorization server for an
 // MCP server when RFC 9728 PRM discovery is unavailable.
 type MCPServerAuthAuthorizationServer struct {
-	// Issuer is the OAuth 2.0 / OIDC issuer URL.
+	// Issuer is the OAuth 2.0 / OIDC issuer URL: the authorization server the
+	// sign-in runs against and the key the session's grants are filed under,
+	// taking precedence over the one the endpoint's RFC 9728 metadata names.
 	// Normalized form: HTTPS, no trailing slash, no fragment, no query.
 	Issuer string `yaml:"issuer" json:"issuer"`
 

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/giantswarm/muster/pkg/logging"
 )
@@ -148,6 +149,13 @@ type IssuerPinner interface {
 	// PinIssuer records the pin for an issuer; calling it again replaces the
 	// previous pin (a rotated client secret takes effect that way).
 	PinIssuer(issuer string, pin IssuerPin)
+
+	// UnpinIssuer forgets the pin for an issuer -- client, grant scope and
+	// pinned endpoints alike -- so the next flow against it discovers the
+	// authorization server again. Called when no MCPServer describes the
+	// issuer any more, or before a changed description is recorded; a pin
+	// nobody owns would otherwise outlive its MCPServer until a restart.
+	UnpinIssuer(issuer string)
 }
 
 // SubjectGrantHandler is implemented by an OAuthHandler that files
@@ -167,6 +175,55 @@ type SubjectGrantHandler interface {
 	// with grantScope: subject). Signing out of such an issuer is signing
 	// the person out, whichever server the request names.
 	IssuerSubjectScoped(issuer string) bool
+}
+
+// LoginTokenMirror is implemented by an OAuthHandler that keeps the ID token
+// of the person's login at muster -- the credential SSO token forwarding hands
+// to backends that trust muster's IdP -- apart from the per-server grants the
+// OAuth proxy obtains. Both can come from the same issuer: an MCPServer may
+// pin muster's own IdP as its authorization server. Filed under one key, the
+// mirror of the login token, written on every request that carries an
+// externally issued bearer, overwrote the grant and the server's tools failed
+// with "no valid token available" right after a successful sign-in
+// (giantswarm/muster#1174).
+type LoginTokenMirror interface {
+	// StoreLoginIDToken records the session's login ID token under the
+	// issuer without touching any grant from that issuer.
+	StoreLoginIDToken(sessionID, userID, issuer, idToken string, expiresAt time.Time)
+
+	// LoginIDToken returns the session's login ID token for the issuer, or
+	// nil when none is recorded or it expired.
+	LoginIDToken(sessionID, issuer string) *OAuthToken
+}
+
+// StoreLoginIDToken files the login ID token through the handler's mirror
+// when it keeps one, and as the session's plain token for the issuer
+// otherwise.
+func StoreLoginIDToken(h OAuthHandler, sessionID, userID, issuer, idToken string, expiresAt time.Time) {
+	if h == nil {
+		return
+	}
+	if mirror, ok := h.(LoginTokenMirror); ok {
+		mirror.StoreLoginIDToken(sessionID, userID, issuer, idToken, expiresAt)
+		return
+	}
+	h.StoreToken(sessionID, userID, issuer, &OAuthToken{IDToken: idToken, ExpiresAt: expiresAt})
+}
+
+// LoginIDToken reads the login ID token through the handler's mirror when it
+// keeps one, falling back to the session's token for the issuer: the entry an
+// earlier muster wrote, still in the store until the session's next request
+// or login rewrites it.
+func LoginIDToken(h OAuthHandler, sessionID, issuer string) *OAuthToken {
+	if h == nil {
+		return nil
+	}
+	if mirror, ok := h.(LoginTokenMirror); ok {
+		if token := mirror.LoginIDToken(sessionID, issuer); token != nil && token.IDToken != "" {
+			return token
+		}
+	}
+	return h.GetFullTokenByIssuer(sessionID, issuer)
 }
 
 // GrantReleaser is implemented by an OAuthHandler that can hand a person's

--- a/internal/mcpserver/api_adapter.go
+++ b/internal/mcpserver/api_adapter.go
@@ -594,7 +594,7 @@ func mcpServerArgs(typeRequired bool) []api.ArgMetadata {
 					api.SchemaKeyProperties: map[string]interface{}{
 						"issuer": map[string]interface{}{
 							api.SchemaKeyType:        string(api.ArgTypeString),
-							api.SchemaKeyDescription: "OAuth 2.0 / OIDC issuer URL (HTTPS, no trailing slash)",
+							api.SchemaKeyDescription: "OAuth 2.0 / OIDC issuer URL (HTTPS, no trailing slash) of the authorization server the sign-in runs against and the grants are filed under; takes precedence over the one the endpoint's RFC 9728 metadata names",
 						},
 						"scopes": map[string]interface{}{
 							api.SchemaKeyType:        string(api.ArgTypeString),

--- a/internal/oauth/api_adapter.go
+++ b/internal/oauth/api_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
 
@@ -148,6 +149,39 @@ func (a *Adapter) PinIssuer(issuer string, pin api.IssuerPin) {
 	}, metadata)
 }
 
+// LoginIDTokenScope is the scope the session's login ID token is filed under
+// in the token store (see api.LoginTokenMirror): a scope token no
+// authorization server grants, so the entry never shares a key with a proxy
+// grant from the same issuer.
+const LoginIDTokenScope = "urn:muster:login-id-token" //nolint:gosec // G101: a scope token that names a slot, not a credential
+
+// StoreLoginIDToken implements api.LoginTokenMirror.
+func (a *Adapter) StoreLoginIDToken(sessionID, userID, issuer, idToken string, expiresAt time.Time) {
+	a.manager.StoreToken(sessionID, userID, issuer, &pkgoauth.Token{
+		IDToken:   idToken,
+		ExpiresAt: expiresAt,
+		Scope:     LoginIDTokenScope,
+		Issuer:    issuer,
+	})
+}
+
+// LoginIDToken implements api.LoginTokenMirror.
+func (a *Adapter) LoginIDToken(sessionID, issuer string) *api.OAuthToken {
+	if a.manager == nil || a.manager.client == nil || a.manager.client.tokenStore == nil {
+		return nil
+	}
+	return fullTokenToAPIToken(a.manager.client.tokenStore.Get(TokenKey{
+		SessionID: sessionID,
+		Issuer:    issuer,
+		Scope:     LoginIDTokenScope,
+	}))
+}
+
+// UnpinIssuer implements api.IssuerPinner.
+func (a *Adapter) UnpinIssuer(issuer string) {
+	a.manager.UnpinIssuer(issuer)
+}
+
 // GetFullTokenByIssuerForUser implements api.SubjectGrantHandler.
 func (a *Adapter) GetFullTokenByIssuerForUser(sessionID, userID, issuer string) *api.OAuthToken {
 	return fullTokenToAPIToken(a.manager.GetTokenByIssuerForUser(sessionID, userID, issuer))
@@ -172,6 +206,7 @@ var (
 	_ api.IssuerPinner        = (*Adapter)(nil)
 	_ api.SubjectGrantHandler = (*Adapter)(nil)
 	_ api.GrantReleaser       = (*Adapter)(nil)
+	_ api.LoginTokenMirror    = (*Adapter)(nil)
 )
 
 // DeleteTokensByUser removes all downstream tokens for a given user across all sessions.

--- a/internal/oauth/api_adapter_login_token_test.go
+++ b/internal/oauth/api_adapter_login_token_test.go
@@ -1,0 +1,110 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/muster/internal/api"
+	"github.com/giantswarm/muster/internal/config"
+	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
+)
+
+// The session's login ID token (what SSO forwarding hands to backends) and a
+// proxy grant from the same issuer must coexist: an MCPServer may pin muster's
+// own IdP as its authorization server (giantswarm/muster#1174).
+func TestAdapter_LoginIDToken_KeptApartFromGrantOfSameIssuer(t *testing.T) {
+	manager := NewManager(config.OAuthMCPClientConfig{
+		Enabled: true, PublicURL: "https://muster.example.com", ClientID: "client-id", CallbackPath: "/oauth/proxy/callback",
+	})
+	defer manager.Stop()
+	adapter := NewAdapter(manager)
+	const issuer = "https://dex.example.com/dex"
+	exp := time.Now().Add(time.Hour)
+
+	// The login token is mirrored on every request that carries an external
+	// bearer; the grant arrives from the proxy callback with the scope Dex
+	// omitted (an empty scope, before the RFC 6749 §5.1 fallback).
+	api.StoreLoginIDToken(adapter, "sess", "user", issuer, "login-id-token", exp)
+	manager.StoreToken("sess", "user", issuer, &pkgoauth.Token{AccessToken: "grant-at", TokenType: "Bearer", IDToken: "grant-id-token", ExpiresAt: exp, Issuer: issuer})
+	api.StoreLoginIDToken(adapter, "sess", "user", issuer, "login-id-token-2", exp)
+
+	// The per-server client finds the grant ...
+	got := api.FullTokenByIssuerForUser(adapter, "sess", "user", issuer)
+	if got == nil || got.AccessToken != "grant-at" {
+		t.Fatalf("grant lookup = %+v, want the grant's access token", got)
+	}
+	// ... and SSO forwarding finds the (latest) login token, not the grant's id_token.
+	if login := api.LoginIDToken(adapter, "sess", issuer); login == nil || login.IDToken != "login-id-token-2" {
+		t.Fatalf("login token = %+v, want the mirrored login ID token", login)
+	}
+
+	// A handler without the mirror falls back to the issuer lookup: the entry
+	// an earlier muster stored under the plain issuer.
+	plain := &api.OAuthToken{IDToken: "legacy-id-token", ExpiresAt: exp}
+	legacy := &legacyHandler{token: plain}
+	if got := api.LoginIDToken(legacy, "sess", issuer); got != plain {
+		t.Fatalf("fallback = %+v, want the plain issuer lookup", got)
+	}
+	api.StoreLoginIDToken(legacy, "sess", "user", issuer, "x", exp)
+	if legacy.stored == nil || legacy.stored.IDToken != "x" {
+		t.Fatalf("fallback store = %+v, want StoreToken", legacy.stored)
+	}
+}
+
+// legacyHandler is an api.OAuthHandler without the login-token mirror.
+type legacyHandler struct {
+	api.OAuthHandler
+	token  *api.OAuthToken
+	stored *api.OAuthToken
+}
+
+func (h *legacyHandler) GetFullTokenByIssuer(string, string) *api.OAuthToken { return h.token }
+func (h *legacyHandler) StoreToken(_, _, _ string, token *api.OAuthToken)    { h.stored = token }
+
+// RFC 6749 §5.1: a token response without `scope` granted the requested scope.
+func TestClient_ExchangeCode_ScopeFromRequestWhenOmitted(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                           server.URL,
+			"authorization_endpoint":           server.URL + "/authorize",
+			"token_endpoint":                   server.URL + "/token",
+			"response_types_supported":         []string{"code"},
+			"code_challenge_methods_supported": []string{"S256"},
+		})
+	})
+	var responseScope string
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]interface{}{"access_token": "at", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "rt"}
+		if responseScope != "" {
+			resp["scope"] = responseScope
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	client := NewClient("client-id", "https://muster.example.com", "/oauth/proxy/callback", "openid")
+	defer client.Stop()
+
+	token, err := client.ExchangeCode(context.Background(), "code", "verifier", server.URL, "", "openid profile email")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if token.Scope != "openid profile email" {
+		t.Errorf("scope = %q, want the requested scope when the response omits one", token.Scope)
+	}
+
+	responseScope = "openid"
+	token, err = client.ExchangeCode(context.Background(), "code", "verifier", server.URL, "", "openid profile email")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if token.Scope != "openid" {
+		t.Errorf("scope = %q, want the scope the response granted", token.Scope)
+	}
+}

--- a/internal/oauth/client.go
+++ b/internal/oauth/client.go
@@ -202,12 +202,35 @@ func (c *Client) PinIssuer(issuer string, pin IssuerPin, metadata *pkgoauth.Meta
 	issuer = strings.TrimSuffix(issuer, "/")
 	if metadata != nil {
 		c.oauthClient.PinMetadata(issuer, metadata)
+	} else {
+		// The pin describes the AS by its issuer alone now: a document
+		// pinned by an earlier description (explicit endpoints) must not
+		// keep standing in for discovery.
+		c.oauthClient.UnpinMetadata(issuer)
 	}
 	c.pinsMu.Lock()
 	c.pins[issuer] = &pin
 	c.pinsMu.Unlock()
 	logging.Info("OAuth", "Pinned authorization server issuer=%s preregisteredClient=%t subjectScoped=%t pinnedMetadata=%t",
 		issuer, pin.ClientID != "", pin.SubjectScoped, metadata != nil)
+}
+
+// UnpinIssuer forgets the operator's description of an authorization server:
+// the pre-registered client, the grant scope and any pinned metadata. The next
+// flow against the issuer discovers the AS again and identifies to it as it
+// would without a pin. Called when no MCPServer describes the issuer any more,
+// or before a changed description is recorded.
+func (c *Client) UnpinIssuer(issuer string) {
+	issuer = strings.TrimSuffix(issuer, "/")
+	c.pinsMu.Lock()
+	_, hadPin := c.pins[issuer]
+	delete(c.pins, issuer)
+	c.pinsMu.Unlock()
+	hadMetadata := c.oauthClient.UnpinMetadata(issuer)
+	if hadPin || hadMetadata {
+		logging.Info("OAuth", "Unpinned authorization server issuer=%s pin=%t pinnedMetadata=%t",
+			issuer, hadPin, hadMetadata)
+	}
 }
 
 // issuerPin returns the operator pin for an issuer, or nil.
@@ -369,6 +392,7 @@ func (c *Client) GenerateAuthURL(ctx context.Context, params AuthChallengeParams
 		ServerName:   params.ServerName,
 		Issuer:       issuer,
 		Resource:     params.Resource,
+		Scope:        params.Scope,
 		CodeVerifier: pkce.CodeVerifier,
 	}
 	state, err := c.stateStore.GenerateState(stateParams,
@@ -402,12 +426,18 @@ func (c *Client) GetStartURL(encodedState string) string {
 
 // ExchangeCode exchanges an authorization code for tokens. resource is the
 // RFC 8707 indicator recorded with the flow's state; it must match the value
-// sent on the authorization request.
+// sent on the authorization request. requestedScope is the scope the
+// authorization request asked for: an authorization server that omits
+// `scope` from its token response granted exactly that (RFC 6749 §5.1), so
+// the token is recorded with it. Dex omits the parameter; without this every
+// Dex grant was filed under an empty scope -- the token-store key of the
+// session's own login token when the pinned issuer is muster's IdP
+// (giantswarm/muster#1174).
 //
 // An invalid_client answer from the token endpoint means the AS no longer
 // accepts the DCR credentials the flow was started with; they are dropped so
 // the next sign-in registers muster again instead of failing the same way.
-func (c *Client) ExchangeCode(ctx context.Context, code, codeVerifier, issuer, resource string) (*pkgoauth.Token, error) {
+func (c *Client) ExchangeCode(ctx context.Context, code, codeVerifier, issuer, resource, requestedScope string) (*pkgoauth.Token, error) {
 	// Fetch OAuth metadata using shared client
 	metadata, err := c.oauthClient.DiscoverMetadata(ctx, issuer)
 	if err != nil {
@@ -439,9 +469,12 @@ func (c *Client) ExchangeCode(ctx context.Context, code, codeVerifier, issuer, r
 
 	// Set issuer on the token
 	token.Issuer = issuer
+	if token.Scope == "" {
+		token.Scope = requestedScope
+	}
 
-	logging.Debug("OAuth", "Successfully exchanged code for token (issuer=%s, expires_in=%d)",
-		issuer, token.ExpiresIn)
+	logging.Debug("OAuth", "Successfully exchanged code for token (issuer=%s, scope=%q, expires_in=%d)",
+		issuer, token.Scope, token.ExpiresIn)
 
 	return token, nil
 }

--- a/internal/oauth/client_dcr_test.go
+++ b/internal/oauth/client_dcr_test.go
@@ -330,7 +330,7 @@ func TestClient_ExchangeCode_UsesDCRCredentials(t *testing.T) {
 
 	// The code exchange must present the same registered credentials. The
 	// stub token endpoint echoes client_id|client_secret in the access token.
-	token, err := client.ExchangeCode(context.Background(), "code-1", "verifier-1", as.server.URL, "")
+	token, err := client.ExchangeCode(context.Background(), "code-1", "verifier-1", as.server.URL, "", "")
 	if err != nil {
 		t.Fatalf("ExchangeCode failed: %v", err)
 	}

--- a/internal/oauth/client_registration_test.go
+++ b/internal/oauth/client_registration_test.go
@@ -286,7 +286,7 @@ func TestClient_ExchangeCode_InvalidClientDropsRegistration(t *testing.T) {
 		t.Fatalf("probe cannot see the loss here; expected the stale client_id, got %q", got)
 	}
 
-	_, err := client.ExchangeCode(context.Background(), "code-1", "verifier-1", as.server.URL, "")
+	_, err := client.ExchangeCode(context.Background(), "code-1", "verifier-1", as.server.URL, "", "")
 	if err == nil || !pkgoauth.IsInvalidClientError(err) {
 		t.Fatalf("expected invalid_client from the token endpoint, got %v", err)
 	}
@@ -298,7 +298,7 @@ func TestClient_ExchangeCode_InvalidClientDropsRegistration(t *testing.T) {
 	if got := startFlow(t, client, as.server.URL); got != "dcr-2" {
 		t.Errorf("retry should use a fresh registration, got %q", got)
 	}
-	token, err := client.ExchangeCode(context.Background(), "code-2", "verifier-2", as.server.URL, "")
+	token, err := client.ExchangeCode(context.Background(), "code-2", "verifier-2", as.server.URL, "", "")
 	if err != nil {
 		t.Fatalf("exchange with the fresh registration failed: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestClient_ExchangeCode_OtherErrorsKeepRegistration(t *testing.T) {
 	}
 	metadata.TokenEndpoint = grantRejecting.URL + "/token"
 
-	_, err = client.ExchangeCode(context.Background(), "code-1", "verifier-1", as.server.URL, "")
+	_, err = client.ExchangeCode(context.Background(), "code-1", "verifier-1", as.server.URL, "", "")
 	if err == nil || pkgoauth.IsInvalidClientError(err) {
 		t.Fatalf("expected a non-invalid_client error, got %v", err)
 	}

--- a/internal/oauth/client_test.go
+++ b/internal/oauth/client_test.go
@@ -416,7 +416,7 @@ func TestClient_ExchangeCode(t *testing.T) {
 	defer client.Stop()
 
 	ctx := context.Background()
-	token, err := client.ExchangeCode(ctx, "auth-code", "code-verifier", server.URL, testResource)
+	token, err := client.ExchangeCode(ctx, "auth-code", "code-verifier", server.URL, testResource, "")
 	if err != nil {
 		t.Fatalf("Failed to exchange code: %v", err)
 	}
@@ -463,7 +463,7 @@ func TestClient_ExchangeCode_Error(t *testing.T) {
 	defer client.Stop()
 
 	ctx := context.Background()
-	_, err := client.ExchangeCode(ctx, "invalid-code", "code-verifier", server.URL, testResource)
+	_, err := client.ExchangeCode(ctx, "invalid-code", "code-verifier", server.URL, testResource, "")
 	if err == nil {
 		t.Fatal("Expected error for invalid code exchange")
 	}

--- a/internal/oauth/client_unpin_test.go
+++ b/internal/oauth/client_unpin_test.go
@@ -1,0 +1,69 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+
+	pkgoauth "github.com/giantswarm/muster/pkg/oauth"
+)
+
+// unreachableIssuer is an issuer nothing serves: discovery against it fails
+// at once, so a test can tell pinned metadata from a real fetch offline.
+const unreachableIssuer = "http://127.0.0.1:9/pinned-as"
+
+func unreachablePinnedMetadata() *pkgoauth.Metadata {
+	return &pkgoauth.Metadata{AuthorizationEndpoint: unreachableIssuer + "/authorize", TokenEndpoint: unreachableIssuer + "/token"}
+}
+
+func TestClient_UnpinIssuer_ForgetsClientAndMetadata(t *testing.T) {
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json", "https://muster.example.com", "/oauth/proxy/callback", "openid")
+	defer client.Stop()
+
+	client.PinIssuer(unreachableIssuer, IssuerPin{ClientID: "Iv23liPinned", ClientSecret: "s3cr3t", SubjectScoped: true}, unreachablePinnedMetadata())
+	if client.issuerPin(unreachableIssuer) == nil || !client.IssuerSubjectScoped(unreachableIssuer) {
+		t.Fatal("precondition: the issuer is pinned")
+	}
+	if _, _, err := client.GenerateAuthURL(context.Background(), AuthChallengeParams{
+		SessionID: testSubject, UserID: "u", ServerName: testServerName, Issuer: unreachableIssuer, Scope: "repo",
+	}); err != nil {
+		t.Fatalf("precondition: the pinned metadata carries the flow: %v", err)
+	}
+
+	client.UnpinIssuer(unreachableIssuer + "/")
+
+	if client.issuerPin(unreachableIssuer) != nil {
+		t.Error("the pre-registered client must be forgotten")
+	}
+	if client.IssuerSubjectScoped(unreachableIssuer) {
+		t.Error("the grant scope must be forgotten")
+	}
+	// The pinned document is gone: the flow has to discover the issuer again,
+	// which fails because nothing serves it.
+	if _, _, err := client.GenerateAuthURL(context.Background(), AuthChallengeParams{
+		SessionID: testSubject, UserID: "u", ServerName: testServerName, Issuer: unreachableIssuer, Scope: "repo",
+	}); err == nil {
+		t.Error("GenerateAuthURL should no longer be served from the pinned metadata")
+	}
+}
+
+func TestClient_PinIssuer_WithoutEndpointsDropsPinnedMetadata(t *testing.T) {
+	client := NewClient("https://muster.example.com/.well-known/oauth-client.json", "https://muster.example.com", "/oauth/proxy/callback", "openid")
+	defer client.Stop()
+
+	// An MCPServer first described the issuer with explicit endpoints ...
+	client.PinIssuer(unreachableIssuer, IssuerPin{ClientID: "c"}, unreachablePinnedMetadata())
+	if md, err := client.DiscoverMetadata(context.Background(), unreachableIssuer); err != nil || md.AuthorizationEndpoint != unreachableIssuer+"/authorize" {
+		t.Fatalf("precondition: pinned metadata serves discovery, got %v / %v", md, err)
+	}
+
+	// ... and is now described by the issuer alone: discovery must run again
+	// instead of answering from the document the earlier description pinned
+	// (giantswarm/muster#1175).
+	client.PinIssuer(unreachableIssuer, IssuerPin{ClientID: "c"}, nil)
+	if _, err := client.DiscoverMetadata(context.Background(), unreachableIssuer); err == nil {
+		t.Error("the endpoints pinned by the earlier description must not stand in for discovery")
+	}
+	if pin := client.issuerPin(unreachableIssuer); pin == nil || pin.ClientID != "c" {
+		t.Error("the client of the new description is kept")
+	}
+}

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -201,7 +201,7 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	ctx, cancelFlow := context.WithTimeout(context.WithoutCancel(r.Context()), 2*time.Minute)
 	defer cancelFlow()
 
-	token, err := h.client.ExchangeCode(ctx, code, state.CodeVerifier, state.Issuer, state.Resource)
+	token, err := h.client.ExchangeCode(ctx, code, state.CodeVerifier, state.Issuer, state.Resource, state.Scope)
 	if err != nil {
 		logging.Error("OAuth", err, "Failed to exchange authorization code")
 		h.renderErrorPage(w, "Failed to complete authentication. Please try again.")

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -298,6 +298,15 @@ func (m *Manager) PinIssuer(issuer string, pin IssuerPin, metadata *pkgoauth.Met
 	m.client.PinIssuer(issuer, pin, metadata)
 }
 
+// UnpinIssuer forgets an operator-configured authorization server, see
+// Client.UnpinIssuer.
+func (m *Manager) UnpinIssuer(issuer string) {
+	if m == nil {
+		return
+	}
+	m.client.UnpinIssuer(issuer)
+}
+
 // GetTokenByIssuerForUser is GetTokenByIssuer with the subject-scoped grant
 // fallback, see Client.GetByIssuerForUser.
 func (m *Manager) GetTokenByIssuerForUser(sessionID, userID, issuer string) *pkgoauth.Token {

--- a/internal/oauth/state_store.go
+++ b/internal/oauth/state_store.go
@@ -68,6 +68,12 @@ type StateParams struct {
 	// Resource is the canonical URI of the MCP server (RFC 8707).
 	Resource string
 
+	// Scope is the scope the authorization request asked for. RFC 6749 §5.1
+	// lets the authorization server omit `scope` from its token response
+	// when it granted exactly that, so the callback needs it to record the
+	// granted scope on the token.
+	Scope string
+
 	// CodeVerifier is the PKCE code verifier for this flow.
 	CodeVerifier string
 }
@@ -159,6 +165,7 @@ func (ss *StateStore) GenerateState(params StateParams,
 		CreatedAt:    time.Now(),
 		Issuer:       params.Issuer,
 		Resource:     params.Resource,
+		Scope:        params.Scope,
 		CodeVerifier: params.CodeVerifier,
 	}
 

--- a/internal/oauth/state_store_valkey.go
+++ b/internal/oauth/state_store_valkey.go
@@ -27,6 +27,7 @@ type valkeyStateEntry struct {
 	CreatedAt        time.Time `json:"ca"`
 	Issuer           string    `json:"iss,omitempty"`
 	Resource         string    `json:"res,omitempty"`
+	Scope            string    `json:"sc,omitempty"`
 	CodeVerifier     string    `json:"cv,omitempty"`
 	RedirectURI      string    `json:"ru,omitempty"`
 	AuthorizationURL string    `json:"aurl,omitempty"`
@@ -41,6 +42,7 @@ func (e *valkeyStateEntry) toState() *OAuthState {
 		CreatedAt:        e.CreatedAt,
 		Issuer:           e.Issuer,
 		Resource:         e.Resource,
+		Scope:            e.Scope,
 		CodeVerifier:     e.CodeVerifier,
 		RedirectURI:      e.RedirectURI,
 		AuthorizationURL: e.AuthorizationURL,
@@ -56,6 +58,7 @@ func stateToEntry(s *OAuthState) *valkeyStateEntry {
 		CreatedAt:        s.CreatedAt,
 		Issuer:           s.Issuer,
 		Resource:         s.Resource,
+		Scope:            s.Scope,
 		CodeVerifier:     s.CodeVerifier,
 		RedirectURI:      s.RedirectURI,
 		AuthorizationURL: s.AuthorizationURL,

--- a/internal/oauth/types.go
+++ b/internal/oauth/types.go
@@ -82,6 +82,10 @@ type OAuthState struct {
 	// request and on the token request.
 	Resource string `json:"resource,omitempty"`
 
+	// Scope is the scope the authorization request asked for; the granted
+	// scope when the token response omits one (RFC 6749 §5.1).
+	Scope string `json:"scope,omitempty"`
+
 	// CodeVerifier is the PKCE code verifier for this flow.
 	// Stored server-side only, not transmitted in the state parameter.
 	CodeVerifier string `json:"-"`

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -486,7 +486,10 @@ func (s *OAuthHTTPServer) injectExternalIDToken(
 	// context. The key MUST match the issuer the aggregator computes —
 	// mirror its resolution logic here. mcp-oauth's AcceptForwardedIDToken
 	// intentionally does NOT mirror into TokenStore, so this keying is
-	// muster's own responsibility.
+	// muster's own responsibility. The mirror has its own slot under the
+	// issuer (api.LoginTokenMirror): this runs on every request, and a grant
+	// the proxy obtained from the same issuer for one of the session's MCP
+	// servers must survive it (giantswarm/muster#1174).
 	if issuer := s.musterIssuer(); issuer != "" {
 		if oh := api.GetOAuthHandler(); oh != nil && oh.IsEnabled() {
 			exp, err := pkgoauth.Expiry(bearerToken)
@@ -495,10 +498,7 @@ func (s *OAuthHTTPServer) injectExternalIDToken(
 					"SSO: refusing to mirror forwarded ID token without parseable JWT exp (session=%s, issuer=%s): %v; re-auth required",
 					logging.TruncateIdentifier(acceptance.SessionID), issuer, err)
 			} else {
-				oh.StoreToken(acceptance.SessionID, acceptance.Subject, issuer, &api.OAuthToken{
-					IDToken:   bearerToken,
-					ExpiresAt: exp,
-				})
+				api.StoreLoginIDToken(oh, acceptance.SessionID, acceptance.Subject, issuer, bearerToken, exp)
 			}
 		}
 	}

--- a/internal/testing/mock/oauth_server.go
+++ b/internal/testing/mock/oauth_server.go
@@ -143,6 +143,11 @@ type OAuthServerConfig struct {
 	// client must refuse an authorization response that carries no RFC 9207
 	// `iss` parameter.
 	AdvertiseIssParameter bool
+
+	// OmitTokenScope leaves `scope` out of token responses, as Dex does: RFC
+	// 6749 §5.1 allows that when the granted scope equals the requested one,
+	// and the client has to remember what it asked for.
+	OmitTokenScope bool
 }
 
 // OAuthErrorSimulation allows simulating error conditions
@@ -1059,7 +1064,7 @@ func (s *OAuthServer) handleAuthCodeExchange(w http.ResponseWriter, r *http.Requ
 		RefreshToken: refreshToken,
 		TokenType:    pkgoauth.SchemeBearer,
 		ExpiresIn:    int(s.config.TokenLifetime.Seconds()),
-		Scope:        entry.Scope,
+		Scope:        s.responseScope(entry.Scope),
 		IDToken:      idToken,
 	}
 
@@ -1135,9 +1140,18 @@ func (s *OAuthServer) handleRefreshToken(w http.ResponseWriter, r *http.Request)
 		RefreshToken: newRefreshToken,
 		TokenType:    pkgoauth.SchemeBearer,
 		ExpiresIn:    int(s.config.TokenLifetime.Seconds()),
-		Scope:        originalToken.Scope,
+		Scope:        s.responseScope(originalToken.Scope),
 		IDToken:      newIDToken,
 	})
+}
+
+// responseScope is the `scope` a token response carries: the granted scope,
+// or nothing when the server is configured to omit it (OmitTokenScope).
+func (s *OAuthServer) responseScope(granted string) string {
+	if s.config.OmitTokenScope {
+		return ""
+	}
+	return granted
 }
 
 // handleTokenExchange implements RFC 8693 OAuth 2.0 Token Exchange.

--- a/internal/testing/mock/protected_mcp_server.go
+++ b/internal/testing/mock/protected_mcp_server.go
@@ -39,6 +39,12 @@ type ProtectedMCPServerConfig struct {
 	// implement resource metadata.
 	OmitResourceMetadata bool
 
+	// AdvertisedIssuer, when set, is the authorization server the RFC 9728
+	// metadata and the 401 challenge name instead of the one tokens are
+	// validated against: a backend that accepts tokens from an authorization
+	// server other than the one it advertises.
+	AdvertisedIssuer string
+
 	// Tools are the tools to expose when authenticated
 	Tools []ToolConfig
 
@@ -262,6 +268,16 @@ func (s *ProtectedMCPServer) Endpoint() string {
 	}
 }
 
+// advertisedIssuer is the authorization server the backend names in its
+// RFC 9728 metadata and 401 challenges: AdvertisedIssuer when set, else the
+// one it validates tokens against.
+func (s *ProtectedMCPServer) advertisedIssuer() string {
+	if s.config.AdvertisedIssuer != "" {
+		return s.config.AdvertisedIssuer
+	}
+	return s.GetIssuer()
+}
+
 // GetIssuer returns the OAuth issuer for this server
 func (s *ProtectedMCPServer) GetIssuer() string {
 	if s.config.Issuer != "" {
@@ -316,7 +332,7 @@ func (s *ProtectedMCPServer) createProtectedHandler() (http.Handler, error) {
 	protectedHandler := &oauthProtectionMiddleware{
 		handler:              underlyingHandler,
 		oauthServer:          s.config.OAuthServer,
-		issuer:               s.GetIssuer(),
+		issuer:               s.advertisedIssuer(),
 		requiredScope:        s.config.RequiredScope,
 		omitResourceMetadata: s.config.OmitResourceMetadata,
 		debug:                s.config.Debug,
@@ -336,7 +352,7 @@ func (s *ProtectedMCPServer) createProtectedHandler() (http.Handler, error) {
 		resourceURL := fmt.Sprintf("http://localhost:%d", s.port)
 		metadata := map[string]interface{}{
 			"resource":                 resourceURL,
-			"authorization_servers":    []string{s.GetIssuer()},
+			"authorization_servers":    []string{s.advertisedIssuer()},
 			"bearer_methods_supported": []string{"header"},
 		}
 		if s.config.RequiredScope != "" {

--- a/internal/testing/muster_manager.go
+++ b/internal/testing/muster_manager.go
@@ -1784,34 +1784,51 @@ func (m *musterInstanceManager) generateConfigFilesWithMocks(configPath string, 
 							}
 						}
 
-						// oauth.grant_scope pins the referenced mock OAuth server as the
-						// MCPServer's authorization server with that grant scope.
-						// "subject" files the grant under the person instead of the
-						// login session, which is how GitHub-style connectors are
-						// configured (spec.auth.authorizationServer.grantScope).
-						if grantScope, ok := oauthConfig["grant_scope"].(string); ok && grantScope != "" {
+						// oauth.pin_authorization_server / oauth.grant_scope pin the
+						// referenced mock OAuth server as the MCPServer's authorization
+						// server (spec.auth.authorizationServer). grant_scope "subject"
+						// files the grant under the person instead of the login
+						// session, which is how GitHub-style connectors are configured;
+						// pin_endpoints_ref adds another mock server's authorize and
+						// token endpoints (the GitHub shape: explicit endpoints, no
+						// discovery).
+						grantScope, _ := oauthConfig["grant_scope"].(string)
+						pinAS, _ := oauthConfig["pin_authorization_server"].(bool)
+						endpointsRef, _ := oauthConfig["pin_endpoints_ref"].(string)
+						if grantScope != "" || pinAS || endpointsRef != "" {
 							ref, _ := oauthConfig["mock_oauth_server_ref"].(string)
 							m.mu.RLock()
 							oauthServer, found := m.mockOAuthServers[instanceID][ref]
+							endpoints, endpointsFound := m.mockOAuthServers[instanceID][endpointsRef]
 							m.mu.RUnlock()
 							if !found {
-								return fmt.Errorf("mcp server %s: oauth.grant_scope needs oauth.mock_oauth_server_ref to name a running mock OAuth server, got %q",
+								return fmt.Errorf("mcp server %s: pinning the authorization server needs oauth.mock_oauth_server_ref to name a running mock OAuth server, got %q",
 									mcpServer.Name, ref)
 							}
 							// The pin opts out of RFC 9728 discovery, so the scope the
 							// backend requires has to travel with it.
 							authorizationServer := map[string]interface{}{
-								"issuer":     oauthServer.GetIssuerURL(),
-								"grantScope": grantScope,
+								"issuer": oauthServer.GetIssuerURL(),
+							}
+							if grantScope != "" {
+								authorizationServer["grantScope"] = grantScope
 							}
 							if scope, ok := oauthConfig["scope"].(string); ok && scope != "" {
 								authorizationServer["scopes"] = scope
 							}
+							if endpointsRef != "" {
+								if !endpointsFound {
+									return fmt.Errorf("mcp server %s: oauth.pin_endpoints_ref names no running mock OAuth server: %q",
+										mcpServer.Name, endpointsRef)
+								}
+								authorizationServer["authorizationEndpoint"] = endpoints.GetIssuerURL() + "/authorize"
+								authorizationServer["tokenEndpoint"] = endpoints.GetIssuerURL() + "/token"
+							}
 							authConfig["type"] = "oauth"
 							authConfig["authorizationServer"] = authorizationServer
 							if m.debug {
-								logger.Debug("🔐 Pinning authorization server %s with grantScope %s for MCPServer %s\n",
-									oauthServer.GetIssuerURL(), grantScope, mcpServer.Name)
+								logger.Debug("🔐 Pinning authorization server %s (grantScope=%q, endpoints from %q) for MCPServer %s\n",
+									oauthServer.GetIssuerURL(), grantScope, endpointsRef, mcpServer.Name)
 							}
 						}
 

--- a/internal/testing/muster_manager_oauth.go
+++ b/internal/testing/muster_manager_oauth.go
@@ -76,6 +76,7 @@ func (m *musterInstanceManager) startMockOAuthServers(
 			AuthorizeAcceptsAnyClient: oauthCfg.AuthorizeAcceptsAnyClient,
 			RejectRegistrationScope:   oauthCfg.RejectRegistrationScope,
 			AdvertiseIssParameter:     oauthCfg.AdvertiseIssParameter,
+			OmitTokenScope:            oauthCfg.OmitTokenScope,
 		}
 
 		// Use mock clock if configured (enables test_advance_oauth_clock tool)
@@ -336,6 +337,15 @@ func (m *musterInstanceManager) extractOAuthConfig(config map[string]interface{}
 	if omit, ok := oauthMap["omit_resource_metadata"].(bool); ok {
 		result.OmitResourceMetadata = omit
 	}
+	if ref, ok := oauthMap["advertised_issuer_ref"].(string); ok {
+		result.AdvertisedIssuerRef = ref
+	}
+	if pin, ok := oauthMap["pin_authorization_server"].(bool); ok {
+		result.PinAuthorizationServer = pin
+	}
+	if ref, ok := oauthMap["pin_endpoints_ref"].(string); ok {
+		result.PinEndpointsRef = ref
+	}
 
 	return result
 }
@@ -381,6 +391,17 @@ func (m *musterInstanceManager) startProtectedMCPServer(
 		Tools:                tools,
 		Transport:            transportType,
 		Debug:                m.debug,
+	}
+
+	// The backend may name an authorization server other than the one it
+	// validates tokens against (advertised_issuer_ref).
+	if oauthConfig.AdvertisedIssuerRef != "" {
+		advertised, ok := oauthServers[oauthConfig.AdvertisedIssuerRef]
+		if !ok {
+			return nil, fmt.Errorf("mcp server %s advertised_issuer_ref references unknown OAuth server %q",
+				mcpServer.Name, oauthConfig.AdvertisedIssuerRef)
+		}
+		config.AdvertisedIssuer = advertised.IssuerURL
 	}
 
 	// In trust-issuer mode the backend validates forwarded JWTs against the

--- a/internal/testing/scenarios/oauth-pinned-authorization-server-change-takes-effect.yaml
+++ b/internal/testing/scenarios/oauth-pinned-authorization-server-change-takes-effect.yaml
@@ -1,0 +1,159 @@
+name: "oauth-pinned-authorization-server-change-takes-effect"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  A change to an MCPServer's spec.auth.authorizationServer takes effect on the
+  next core_auth_login, without a restart of muster.
+
+  The server's authorization server is pinned three ways in a row, and after
+  every change the sign-in the challenge starts is followed one hop to see
+  which authorization server the browser would land on:
+
+    1. issuer of as-a with the explicit endpoints of as-b (the GitHub shape,
+       endpoints pinned under the issuer) -> the sign-in goes to as-b;
+    2. the pin removed -> discovery of the advertised authorization server
+       -> the sign-in goes to as-a;
+    3. issuer of as-a with the endpoints of as-b again -> as-b;
+    4. issuer of as-a alone, no endpoints -> discovery -> as-a.
+
+  Regression (giantswarm/muster#1175): metadata pinned with explicit endpoints
+  never expired and was never released when the MCPServer's description
+  changed, so after step 2 the challenge still sent the browser to as-b until
+  `kubectl rollout restart deploy/muster`.
+tags: ["oauth", "authorization-server", "pin", "update", "regression", "1175"]
+timeout: "3m"
+
+pre_configuration:
+  mock_oauth_servers:
+    - name: "as-a"
+      scopes: ["mcp:admin"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "client-a"
+
+    - name: "as-b"
+      scopes: ["mcp:admin"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "client-b"
+
+  mcp_servers:
+    - name: "svc"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "as-a"
+          pin_authorization_server: true
+          pin_endpoints_ref: "as-b"
+          scope: "mcp:admin"
+        tools:
+          - name: "op"
+            description: "An operation"
+            responses:
+              - response:
+                  source: "svc"
+
+steps:
+  - id: server-registered
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["svc"]
+
+  - id: pinned-endpoints-drive-the-sign-in
+    description: "Issuer of as-a, endpoints of as-b: the browser goes to as-b"
+    tool: "test_resolve_auth_redirect"
+    args:
+      server: "svc"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        authorization_server: "as-b"
+
+  - id: remove-the-pin
+    tool: "test_pin_mcpserver_authorization_server"
+    args:
+      server: "svc"
+      clear: true
+    expected:
+      success: true
+
+  - id: server-back-to-auth-required
+    tool: "core_mcpserver_get"
+    args:
+      name: "svc"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["Auth Required"]
+
+  - id: discovery-drives-the-sign-in
+    description: "Without the pin the advertised authorization server (as-a) is discovered; the old endpoints are gone"
+    tool: "test_resolve_auth_redirect"
+    args:
+      server: "svc"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        authorization_server: "as-a"
+
+  - id: pin-endpoints-again
+    tool: "test_pin_mcpserver_authorization_server"
+    args:
+      server: "svc"
+      issuer_ref: "as-a"
+      endpoints_ref: "as-b"
+      scopes: "mcp:admin"
+    expected:
+      success: true
+
+  - id: pinned-endpoints-drive-the-sign-in-again
+    tool: "test_resolve_auth_redirect"
+    args:
+      server: "svc"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        authorization_server: "as-b"
+
+  - id: pin-issuer-only
+    description: "Same issuer, endpoints dropped: discovery again, not the endpoints pinned a moment ago"
+    tool: "test_pin_mcpserver_authorization_server"
+    args:
+      server: "svc"
+      issuer_ref: "as-a"
+      scopes: "mcp:admin"
+    expected:
+      success: true
+
+  - id: discovery-drives-the-sign-in-again
+    tool: "test_resolve_auth_redirect"
+    args:
+      server: "svc"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        authorization_server: "as-a"
+
+  - id: sign-in-completes-against-discovered-as
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "svc"
+    expected:
+      success: true
+
+  - id: call-works
+    tool: "x_svc_op"
+    args: {}
+    expected:
+      success: true
+      contains: ["svc"]

--- a/internal/testing/scenarios/oauth-pinned-issuer-is-the-grant-key.yaml
+++ b/internal/testing/scenarios/oauth-pinned-issuer-is-the-grant-key.yaml
@@ -1,0 +1,217 @@
+name: "oauth-pinned-issuer-is-the-grant-key"
+category: "behavioral"
+concept: "mcpserver"
+description: |
+  A pinned authorization server (spec.auth.authorizationServer.issuer) whose
+  issuer differs from the one the endpoint's RFC 9728 metadata advertises is
+  the one key of the server's grants: the sign-in runs against it, the token
+  is filed under it, the connection and every later tool call find it there.
+
+  Two backends accept tokens from an authorization server other than the one
+  they advertise:
+
+    - platform-fixture validates tokens from muster's own identity provider
+      (the lab fixture: muster's protected /mcp trusts Dex's tokens but names
+      muster's OAuth server) and is pinned to that IdP. The IdP omits `scope`
+      from its token responses, as Dex does. The session is an externally
+      issued bearer, like a portal user's or an agent's -- muster mirrors that
+      login token into the token store on every request.
+    - other-pinned validates tokens from a plain authorization server and is
+      pinned to it, while advertising yet another one.
+
+  For both: core_auth_login answers a challenge that goes to the PINNED
+  authorization server; the completed sign-in connects the server; tool calls
+  succeed, on the next request and the one after.
+
+  Regression (giantswarm/muster#1174): the registry filed the server under the
+  advertised issuer the 401 probe learned, so the challenge went to the wrong
+  authorization server (other-pinned); and a grant from muster's own IdP was
+  filed under the same token-store key as the session's login token, which the
+  mirror of the next request overwrote -- "Authentication Successful", tools
+  listed, then every call failed with "no valid token available"
+  (platform-fixture).
+tags: ["oauth", "authorization-server", "pin", "issuer", "regression", "1174"]
+timeout: "3m"
+
+pre_configuration:
+  mock_oauth_servers:
+    # muster's own identity provider and the pinned authorization server of
+    # platform-fixture. Omits `scope` from token responses like Dex.
+    - name: "platform-idp"
+      scopes: ["openid", "profile", "email", "offline_access"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "platform-client"
+      client_secret: "platform-secret"
+      use_as_muster_oauth_server: true
+      omit_token_scope: true
+
+    # Issues the externally issued bearer the session presents to muster (a
+    # Dex-issued token muster trusts), like the lab's portal and agent tokens.
+    - name: "workload-idp"
+
+    # What both backends' resource metadata names as their authorization
+    # server -- not the one their tokens come from.
+    - name: "advertised-as"
+      scopes: ["mcp:admin", "openid", "profile", "email", "offline_access"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "advertised-client"
+
+    # The authorization server other-pinned really accepts tokens from.
+    - name: "pinned-as"
+      scopes: ["mcp:admin"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "pinned-client"
+
+  muster_broker:
+    trusted_issuers:
+      - oauth_server_ref: "workload-idp"
+        accepted_typ_headers: [""]
+
+  mcp_servers:
+    - name: "platform-fixture"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "platform-idp"
+          advertised_issuer_ref: "advertised-as"
+          pin_authorization_server: true
+          scope: "openid profile email offline_access"
+        tools:
+          - name: "whoami"
+            description: "Answers from the fixture"
+            responses:
+              - response:
+                  source: "platform-fixture"
+
+    - name: "other-pinned"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "pinned-as"
+          advertised_issuer_ref: "advertised-as"
+          pin_authorization_server: true
+          scope: "mcp:admin"
+        tools:
+          - name: "op"
+            description: "An operation on other-pinned"
+            responses:
+              - response:
+                  source: "other-pinned"
+
+steps:
+  - id: mint-external-bearer
+    description: "The session's bearer is an externally issued token muster trusts (portal/agent shape)"
+    tool: "test_mint_token"
+    args:
+      server: "workload-idp"
+      name: "person-token"
+      sub: "person@example.com"
+      email: "person@example.com"
+      email_verified: true
+    expected:
+      success: true
+
+  - id: connect-with-external-bearer
+    tool: "test_reconnect_with_token"
+    args:
+      token_ref: "person-token"
+    expected:
+      success: true
+      wait_for_state: "30s"
+
+  - id: servers-registered
+    tool: "core_mcpserver_list"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "30s"
+      contains: ["platform-fixture", "other-pinned"]
+
+  # ---------------------------------------------------------------------
+  # platform-fixture: pinned to muster's own IdP
+  # ---------------------------------------------------------------------
+
+  - id: fixture-challenge-goes-to-the-pinned-idp
+    description: "The sign-in is sent to the pinned authorization server, not the advertised one"
+    tool: "test_resolve_auth_redirect"
+    args:
+      server: "platform-fixture"
+    expected:
+      success: true
+      json_path:
+        authorization_server: "platform-idp"
+        scope: "openid profile email offline_access"
+
+  - id: fixture-sign-in
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "platform-fixture"
+    expected:
+      success: true
+
+  - id: fixture-call-after-sign-in
+    description: "The next request mirrors the login token again; the grant must survive it"
+    tool: "x_platform-fixture_whoami"
+    args: {}
+    expected:
+      success: true
+      contains: ["platform-fixture"]
+
+  - id: fixture-call-again
+    tool: "x_platform-fixture_whoami"
+    args: {}
+    expected:
+      success: true
+      contains: ["platform-fixture"]
+
+  - id: fixture-still-authenticated
+    tool: "core_auth_login"
+    args:
+      server: "platform-fixture"
+    expected:
+      success: true
+      contains: ["already authenticated"]
+
+  # ---------------------------------------------------------------------
+  # other-pinned: pinned to an authorization server the endpoint does not
+  # advertise
+  # ---------------------------------------------------------------------
+
+  - id: other-challenge-goes-to-the-pinned-as
+    tool: "test_resolve_auth_redirect"
+    args:
+      server: "other-pinned"
+    expected:
+      success: true
+      json_path:
+        authorization_server: "pinned-as"
+        scope: "mcp:admin"
+
+  - id: other-sign-in
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "other-pinned"
+    expected:
+      success: true
+
+  - id: other-call
+    tool: "x_other-pinned_op"
+    args: {}
+    expected:
+      success: true
+      contains: ["other-pinned"]
+
+  - id: other-call-again
+    tool: "x_other-pinned_op"
+    args: {}
+    expected:
+      success: true
+      contains: ["other-pinned"]

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -105,6 +105,16 @@ const (
 	// without a restart. Args: "server" (required), "labels" (object; empty
 	// removes every label).
 	TestToolSetMCPServerLabels = "test_set_mcpserver_labels"
+
+	// TestToolResolveAuthRedirect asks core_auth_login for a challenge and
+	// follows the muster-hosted start URL one hop, the way a browser would,
+	// reporting which mock authorization server the flow is sent to.
+	TestToolResolveAuthRedirect = "test_resolve_auth_redirect"
+	// TestToolPinMCPServerAuthorizationServer rewrites an MCPServer's
+	// spec.auth.authorizationServer in the filesystem definition (pin a mock
+	// server's issuer, optionally another's endpoints; or clear the pin) so
+	// the reconciler picks the change up like a CR update.
+	TestToolPinMCPServerAuthorizationServer = "test_pin_mcpserver_authorization_server"
 )
 
 // TestToolsHandler handles test-specific tools that operate on mock infrastructure.
@@ -231,7 +241,9 @@ func IsTestTool(toolName string) bool {
 		TestToolCallProtectedMCP,
 		TestToolReconnectWithToken,
 		TestToolScrapeMetrics,
-		TestToolSetMCPServerLabels:
+		TestToolSetMCPServerLabels,
+		TestToolResolveAuthRedirect,
+		TestToolPinMCPServerAuthorizationServer:
 		return true
 	}
 	return false
@@ -296,6 +308,10 @@ func (h *TestToolsHandler) HandleTestTool(ctx context.Context, toolName string, 
 		return h.handleReconnectWithToken(ctx, args)
 	case TestToolSetMCPServerLabels:
 		return h.handleSetMCPServerLabels(ctx, args)
+	case TestToolResolveAuthRedirect:
+		return h.handleResolveAuthRedirect(ctx, args)
+	case TestToolPinMCPServerAuthorizationServer:
+		return h.handlePinMCPServerAuthorizationServer(ctx, args)
 	default:
 		return nil, fmt.Errorf("unknown test tool: %s", toolName)
 	}

--- a/internal/testing/test_tools_authorization_server.go
+++ b/internal/testing/test_tools_authorization_server.go
@@ -1,0 +1,151 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/giantswarm/muster/internal/api"
+)
+
+// handleResolveAuthRedirect runs core_auth_login for a server and follows the
+// muster-hosted start URL of the challenge one hop, the way a browser would,
+// to see which authorization server the flow is sent to. args: server.
+//
+// The result names the mock OAuth server whose issuer the upstream
+// authorization URL belongs to (authorization_server), plus the endpoint,
+// client_id and scope on that URL, so a scenario can assert where a sign-in
+// goes without knowing the mock servers' ports.
+func (h *TestToolsHandler) handleResolveAuthRedirect(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	serverName, _ := args["server"].(string)
+	if serverName == "" {
+		return nil, fmt.Errorf("server argument is required")
+	}
+	if h.currentInstance == nil {
+		return nil, fmt.Errorf("current instance not available")
+	}
+
+	startURL, err := h.callAuthenticateTool(ctx, serverName)
+	if err != nil {
+		return nil, fmt.Errorf("core_auth_login for %s did not return an auth URL: %w", serverName, err)
+	}
+	upstream := startURL
+	if strings.Contains(startURL, "/oauth/proxy/start") {
+		if upstream, err = h.resolveStartRedirect(ctx, startURL); err != nil {
+			return nil, fmt.Errorf("failed to resolve start URL redirect: %w", err)
+		}
+	}
+	parsed, err := url.Parse(upstream)
+	if err != nil {
+		return nil, fmt.Errorf("upstream authorization URL %q: %w", upstream, err)
+	}
+	authHost := parsed.Scheme + "://" + parsed.Host
+	authorizationServer := ""
+	for name, info := range h.currentInstance.MockOAuthServers {
+		if strings.HasPrefix(info.IssuerURL, authHost) {
+			authorizationServer = name
+			break
+		}
+	}
+	return map[string]interface{}{
+		api.FieldSuccess:         true,
+		api.FieldServer:          serverName,
+		"start_url":              startURL,
+		"authorization_url":      upstream,
+		"authorization_endpoint": authHost + parsed.Path,
+		"authorization_server":   authorizationServer,
+		"client_id":              parsed.Query().Get("client_id"),
+		"scope":                  parsed.Query().Get("scope"),
+	}, nil
+}
+
+// handlePinMCPServerAuthorizationServer rewrites spec.auth.authorizationServer
+// of an MCPServer's filesystem definition: pins the issuer of the mock OAuth
+// server named by issuer_ref (with optional scopes and grant_scope), adds the
+// authorize/token endpoints of the mock server named by endpoints_ref, or
+// removes the pin (clear: true). The filesystem detector then reconciles the
+// change the way a CR update is reconciled. args: server, issuer_ref,
+// endpoints_ref, scopes, grant_scope, clear.
+func (h *TestToolsHandler) handlePinMCPServerAuthorizationServer(_ context.Context, args map[string]interface{}) (interface{}, error) {
+	serverName, _ := args["server"].(string)
+	if serverName == "" {
+		return nil, fmt.Errorf("server argument is required")
+	}
+	if h.currentInstance == nil {
+		return nil, fmt.Errorf("no muster instance available")
+	}
+	clear, _ := args["clear"].(bool)
+	issuerRef, _ := args["issuer_ref"].(string)
+	endpointsRef, _ := args["endpoints_ref"].(string)
+	if !clear && issuerRef == "" {
+		return nil, fmt.Errorf("issuer_ref is required unless clear is true")
+	}
+
+	filename := filepath.Join(h.currentInstance.ConfigPath, "muster", "mcpservers", serverName+".yaml")
+	data, err := os.ReadFile(filename) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to read MCPServer definition %s: %w", filename, err)
+	}
+	var definition map[string]interface{}
+	if err := yaml.Unmarshal(data, &definition); err != nil {
+		return nil, fmt.Errorf("failed to parse MCPServer definition %s: %w", filename, err)
+	}
+	spec, _ := definition["spec"].(map[string]interface{})
+	if spec == nil {
+		return nil, fmt.Errorf("MCPServer definition %s has no spec", filename)
+	}
+	auth, _ := spec["auth"].(map[string]interface{})
+	if auth == nil {
+		auth = map[string]interface{}{"type": "oauth"}
+	}
+
+	var pin map[string]interface{}
+	if clear {
+		delete(auth, "authorizationServer")
+	} else {
+		issuer, ok := h.currentInstance.MockOAuthServers[issuerRef]
+		if !ok {
+			return nil, fmt.Errorf("issuer_ref names no mock OAuth server: %q", issuerRef)
+		}
+		pin = map[string]interface{}{"issuer": issuer.IssuerURL}
+		if scopes, _ := args["scopes"].(string); scopes != "" {
+			pin["scopes"] = scopes
+		}
+		if grantScope, _ := args["grant_scope"].(string); grantScope != "" {
+			pin["grantScope"] = grantScope
+		}
+		if endpointsRef != "" {
+			endpoints, ok := h.currentInstance.MockOAuthServers[endpointsRef]
+			if !ok {
+				return nil, fmt.Errorf("endpoints_ref names no mock OAuth server: %q", endpointsRef)
+			}
+			pin["authorizationEndpoint"] = endpoints.IssuerURL + "/authorize"
+			pin["tokenEndpoint"] = endpoints.IssuerURL + "/token"
+		}
+		auth["authorizationServer"] = pin
+	}
+	spec["auth"] = auth
+	definition["spec"] = spec
+
+	out, err := yaml.Marshal(definition)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render MCPServer definition %s: %w", filename, err)
+	}
+	if err := os.WriteFile(filename, out, 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write MCPServer definition %s: %w", filename, err)
+	}
+	if h.debug {
+		h.logger.Debug("Set spec.auth.authorizationServer of MCPServer '%s' to %v\n", serverName, pin)
+	}
+	return map[string]interface{}{
+		api.FieldSuccess:      true,
+		api.FieldServer:       serverName,
+		"authorizationServer": pin,
+		"cleared":             clear,
+	}, nil
+}

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -401,6 +401,10 @@ type MockOAuthServerConfig struct {
 	// authorization_response_iss_parameter_supported in the AS metadata. A
 	// callback without an `iss` parameter must then be refused.
 	AdvertiseIssParameter bool `yaml:"advertise_iss_parameter,omitempty"`
+
+	// OmitTokenScope leaves `scope` out of the token responses, as Dex does
+	// (RFC 6749 §5.1 allows it when the granted scope is the requested one).
+	OmitTokenScope bool `yaml:"omit_token_scope,omitempty"`
 }
 
 // TrustedIssuerConfig defines a trusted issuer for RFC 8693 token exchange
@@ -434,6 +438,24 @@ type MCPServerOAuthConfig struct {
 	// aggregator learns the issuer only from the pin -- see
 	// mock.ProtectedMCPServerConfig.OmitResourceMetadata.
 	OmitResourceMetadata bool `yaml:"omit_resource_metadata,omitempty"`
+
+	// AdvertisedIssuerRef names the mock OAuth server the backend's RFC 9728
+	// metadata lists as its authorization server, while tokens are still
+	// validated against MockOAuthServerRef -- a backend that accepts tokens
+	// from an authorization server other than the one it advertises (muster's
+	// own /mcp trusts its IdP's tokens but names muster's OAuth server).
+	AdvertisedIssuerRef string `yaml:"advertised_issuer_ref,omitempty"`
+
+	// PinAuthorizationServer pins MockOAuthServerRef as the MCPServer's
+	// authorization server (spec.auth.authorizationServer.issuer, with Scope
+	// as scopes) without a grant scope; GrantScope implies it.
+	PinAuthorizationServer bool `yaml:"pin_authorization_server,omitempty"`
+
+	// PinEndpointsRef names the mock OAuth server whose authorize and token
+	// endpoints the pin carries as authorizationEndpoint/tokenEndpoint (the
+	// GitHub shape: explicit endpoints, no discovery) -- possibly a different
+	// server than the pinned issuer.
+	PinEndpointsRef string `yaml:"pin_endpoints_ref,omitempty"`
 
 	// Scope is the required OAuth scope
 	Scope string `yaml:"scope,omitempty"`

--- a/pkg/apis/muster/v1alpha1/mcpserver_types.go
+++ b/pkg/apis/muster/v1alpha1/mcpserver_types.go
@@ -299,11 +299,20 @@ type MCPServerSigV4 struct {
 //
 // +kubebuilder:validation:XValidation:rule="has(self.authorizationEndpoint) == has(self.tokenEndpoint)",message="authorizationEndpoint and tokenEndpoint must be set together"
 type MCPServerAuthAuthorizationServer struct {
-	// Issuer is the OAuth 2.0 / OIDC issuer URL.
+	// Issuer is the OAuth 2.0 / OIDC issuer URL of the authorization server
+	// the sign-in runs against, and the identity the session's grants are
+	// filed under. It takes precedence over the authorization server the
+	// endpoint's own RFC 9728 metadata names: the browser flow, the token
+	// store, the connection and core_auth_logout all use this issuer, so an
+	// endpoint that accepts tokens from an authorization server other than the
+	// one it advertises is pinned by naming the accepting one here. It may be
+	// muster's own identity provider; muster keeps the session's login token
+	// apart from the grant. A change to this field takes effect on the next
+	// core_auth_login, without a restart.
 	// muster fetches AS metadata via the existing OAuth client, which performs
 	// RFC 8414 / OIDC discovery against this issuer -- unless
-	// AuthorizationEndpoint and TokenEndpoint are set, in which case the issuer
-	// is only the identity the stored grants are filed under.
+	// AuthorizationEndpoint and TokenEndpoint are set, in which case no
+	// discovery happens and the issuer is only that identity.
 	// +kubebuilder:validation:Required
 	Issuer IssuerURL `json:"issuer" yaml:"issuer"`
 

--- a/pkg/oauth/client.go
+++ b/pkg/oauth/client.go
@@ -523,6 +523,34 @@ func (c *Client) BuildAuthorizationURL(request AuthorizationRequest) (string, er
 	return authURL.String(), nil
 }
 
+// UnpinMetadata drops the operator-pinned metadata for an issuer, so the
+// next DiscoverMetadata fetches the authorization server's own document
+// again. It reports whether a pinned entry was dropped. A discovered entry is
+// left alone: it came from the authorization server itself and expires with
+// the cache TTL.
+//
+// Pinned entries never expire, so without this a pin that an MCPServer no
+// longer carries -- removed, or changed to a different authorization server --
+// would keep answering every flow against the issuer until the process
+// restarts (giantswarm/muster#1175).
+func (c *Client) UnpinMetadata(issuer string) bool {
+	issuer = strings.TrimSuffix(issuer, "/")
+	c.metadataMu.Lock()
+	entry, ok := c.metadataCache[issuer]
+	if ok && entry.pinned {
+		delete(c.metadataCache, issuer)
+	}
+	c.metadataMu.Unlock()
+	if !ok || !entry.pinned {
+		return false
+	}
+	c.logger.Info("Dropped pinned OAuth metadata",
+		"issuer", issuer,
+		"authorization_endpoint", entry.metadata.AuthorizationEndpoint,
+		"token_endpoint", entry.metadata.TokenEndpoint)
+	return true
+}
+
 // ClearMetadataCache clears the metadata cache.
 // Useful for testing or when metadata needs to be refreshed immediately.
 func (c *Client) ClearMetadataCache() {

--- a/pkg/oauth/client_unpin_test.go
+++ b/pkg/oauth/client_unpin_test.go
@@ -1,0 +1,45 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestClient_UnpinMetadata(t *testing.T) {
+	client := NewClient()
+	pinned := "http://127.0.0.1:9/pinned-as" // nothing listens: a fetch fails at once
+	client.PinMetadata(pinned, &Metadata{AuthorizationEndpoint: pinned + "/authorize", TokenEndpoint: pinned + "/access_token"})
+
+	discovered := "https://dex.example.com"
+	client.cacheMetadata(discovered, &Metadata{Issuer: discovered, AuthorizationEndpoint: discovered + "/auth", TokenEndpoint: discovered + "/token"})
+
+	if !client.UnpinMetadata(pinned + "/") {
+		t.Fatal("UnpinMetadata should report the pinned entry it dropped")
+	}
+	if client.UnpinMetadata(pinned) {
+		t.Fatal("a second UnpinMetadata has nothing left to drop")
+	}
+	client.metadataMu.RLock()
+	_, stillPinned := client.metadataCache[pinned]
+	entry, kept := client.metadataCache[discovered]
+	client.metadataMu.RUnlock()
+	if stillPinned {
+		t.Error("the pinned document must be gone so the next DiscoverMetadata fetches again")
+	}
+	if !kept || entry.pinned {
+		t.Error("a discovered entry is left alone; it expires with the cache TTL")
+	}
+
+	// A discovered entry is not dropped by UnpinMetadata either.
+	if client.UnpinMetadata(discovered) {
+		t.Error("UnpinMetadata must not report a discovered entry as dropped")
+	}
+
+	// Without the pin, discovery for the issuer has to hit the network again.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, err := client.DiscoverMetadata(ctx, pinned); err == nil {
+		t.Error("DiscoverMetadata should fetch (and fail without a server) once the pin is gone")
+	}
+}


### PR DESCRIPTION
Fixes #1174, fixes #1175. Found while rolling the Agent Tool Access release into agentlab, where the lab's sign-in fixture (`lab-oauth-fixture`, target = muster's own protected `/mcp`) pins Dex as its authorization server.

## #1174 — pinned issuer ≠ advertised one: sign-in succeeds, every call fails

**Root cause** (reproduced in agentlab with `--debug`): muster mirrors the session's login `id_token` into the OAuth proxy token store on **every request** that carries an externally issued bearer (`internal/server/oauth_http.go`), under `{session, musterIssuer, scope ""}`. In the lab `musterIssuer` is Dex (`https://localhost:32000/dex`) — the very issuer the fixture pinned — and Dex omits `scope` from its token response, so the fixture's grant was stored under exactly that key at the callback and overwritten by the mirror on the next request (`ValkeyTokenStore: stored token … scope=` twice within 120 ms in the debug log). The DynamicAuthClient's token store then had no access token → `no valid token available` → auth-loss detector → `lost authentication (token no longer present in the token store)`.

A second, general inconsistency: the registry filed the server under the issuer the 401 probe learned from the endpoint's RFC 9728 metadata, and the pin only drove the challenge when the probe had learned nothing — a backend that accepts tokens from an AS other than the one it advertises got its challenge sent to the advertised one.

**Fix**
- The login `id_token` mirror gets its own token-store slot (`api.LoginTokenMirror`, scope `urn:muster:login-id-token`); SSO forwarding reads it there (fallback to the old plain-issuer entry during upgrades). A grant can never share the key again.
- A token response without `scope` records the requested scope (RFC 6749 §5.1) — the state now carries it.
- The pinned issuer (and `scopes`) replace what the probe recorded, at pending-auth registration and at login; `knownServerIssuer` prefers the pin. One key for challenge, token store, connection and logout.

## #1175 — changed/removed `authorizationServer` keeps redirecting to the old endpoint until restart

**Root cause**: `pkg/oauth`'s metadata cache marks operator-pinned documents `pinned`: they never expire, `ClearMetadataCache` keeps them, and nothing ever un-pinned an issuer (same for the OAuth client's `pins` map: client credentials, grant scope). The cache is keyed by issuer only, so a pin with explicit endpoints under the advertised issuer (`issuer: <muster>` + Dex endpoints) kept answering discovery for `<muster>` after the CR lost the pin.

**Fix**: `pkg/oauth.Client.UnpinMetadata`, `UnpinIssuer` through Client/Manager/Adapter (`api.IssuerPinner` grows `UnpinIssuer`); `PinIssuer` without endpoints drops a document an earlier description pinned; the aggregator releases a server's previous pin when its pending-auth registration is replaced with a different description or the server is deregistered — another server still describing the issuer takes over, otherwise the issuer is forgotten.

## Scenarios (both fail on origin/main, pass here)
- `oauth-pinned-issuer-is-the-grant-key` — main fails at `fixture-call-after-sign-in` with `no valid token available, authorization required` (the lab's exact failure).
- `oauth-pinned-authorization-server-change-takes-effect` — main fails at `discovery-drives-the-sign-in` (after removing the pin, `core_auth_login` still served the stale pinned endpoints / wedged).

Harness: `omit_token_scope` (mock AS, Dex-like), `advertised_issuer_ref`, `pin_authorization_server`, `pin_endpoints_ref`; test tools `test_resolve_auth_redirect`, `test_pin_mcpserver_authorization_server`. Full suite 228/228, `go test ./...`, golangci-lint clean.

## Docs
CRD field text (`authorizationServer.issuer`), API/schema descriptions, and `docs/how-to/connecting-non-rfc9728-mcp-servers.md` ("Which issuer to pin") say the pinned issuer is both the AS the sign-in runs against and the grant key, that it may be muster's own IdP, and that changes take effect on the next `core_auth_login` without a restart.

## Lab verification
agentlab with a dev image: shape `issuer: https://localhost:32000/dex` (the failing one) → sign-in, tools callable on subsequent requests; `authorizationServer` changed four times (Dex endpoints → none → Dex endpoints → Dex by discovery) → the challenge's redirect follows each time without a restart; `agentlab toolsets-test` + `platform-test` green. Details in the PR comments once the run completes.
