### PR TITLE
test(orchestrator): scenarios reproducing the health-probe review findings

### DIFF
--- a/internal/testing/mock/outage.go
+++ b/internal/testing/mock/outage.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // outageGate makes a mock server answer a number of requests with a fixed HTTP
@@ -19,15 +21,22 @@ type outageGate struct {
 	mu        sync.Mutex
 	status    int
 	remaining int
+	// pings makes an armed gate answer MCP pings too. By default they pass
+	// through uncounted, see gates.
+	pings bool
 }
 
 // set arms the gate: the next requests requests are answered with status. A
-// requests of 0 disarms it.
-func (g *outageGate) set(status, requests int) {
+// requests of 0 disarms it. With pings, the orchestrator's health probes are
+// answered with the status as well, the way a gateway that fails every
+// request would answer them; without it they pass through, so an outage of N
+// requests fails exactly N connection attempts whatever the probe interval.
+func (g *outageGate) set(status, requests int, pings bool) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.status = status
 	g.remaining = requests
+	g.pings = pings
 }
 
 // take consumes one request from the gate and reports the status to answer
@@ -49,18 +58,33 @@ func (g *outageGate) remainingRequests() int {
 	return g.remaining
 }
 
-// wrap returns next guarded by the gate. Two requests pass through uncounted,
-// because neither is a connection attempt and counting either would make an
-// outage of N requests fail N-1 attempts: a session termination (HTTP
-// DELETE), which is the client tidying up the session it had before the
-// outage and which muster's client sends when the service restarts; and an
-// MCP ping, which the orchestrator's health probe sends to every connected
-// server on its interval (1s in the harness) and which would otherwise land
-// in the outage window of any scenario that arms the gate on a Connected
-// server.
+// gates reports whether an armed gate answers r. Two requests are never
+// connection attempts, and counting either would make an outage of N
+// requests fail N-1 attempts: a session termination (HTTP DELETE), which is
+// the client tidying up the session it had before the outage and which
+// muster's client sends when the service restarts; and, unless the gate was
+// armed with pings, an MCP ping, which the orchestrator's health probe sends
+// to every connected server on its interval (1s in the harness) and which
+// would otherwise land in the outage window of any scenario that arms the
+// gate on a Connected server. The body is inspected only while the gate is
+// armed.
+func (g *outageGate) gates(r *http.Request) bool {
+	if r.Method == http.MethodDelete {
+		return false
+	}
+	g.mu.Lock()
+	armed, pings := g.remaining > 0, g.pings
+	g.mu.Unlock()
+	if !armed {
+		return false
+	}
+	return pings || !isMCPPing(r)
+}
+
+// wrap returns next guarded by the gate.
 func (g *outageGate) wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete && !isMCPPing(r) {
+		if g.gates(r) {
 			if status := g.take(); status != 0 {
 				http.Error(w, http.StatusText(status), status)
 				return
@@ -85,15 +109,16 @@ func isMCPPing(r *http.Request) bool {
 	var rpc struct {
 		Method string `json:"method"`
 	}
-	return json.Unmarshal(body, &rpc) == nil && rpc.Method == "ping"
+	return json.Unmarshal(body, &rpc) == nil && rpc.Method == string(mcp.MethodPing)
 }
 
 // SetOutage makes the server answer its next requests requests with the given
 // HTTP status and serve normally afterwards; requests of 0 ends an outage
 // early. The server keeps listening, so muster sees an HTTP response, not a
-// refused connection.
-func (s *HTTPServer) SetOutage(status, requests int) {
-	s.outage.set(status, requests)
+// refused connection. With pings the orchestrator's health probes are answered
+// with the status too; without, they pass through uncounted.
+func (s *HTTPServer) SetOutage(status, requests int, pings bool) {
+	s.outage.set(status, requests, pings)
 }
 
 // OutageRemaining reports how many requests the current outage still covers.
@@ -103,9 +128,10 @@ func (s *HTTPServer) OutageRemaining() int {
 
 // SetOutage makes the server answer its next requests requests with the given
 // HTTP status -- before the OAuth middleware, so no 401 challenge is sent --
-// and serve normally afterwards; requests of 0 ends an outage early.
-func (s *ProtectedMCPServer) SetOutage(status, requests int) {
-	s.outage.set(status, requests)
+// and serve normally afterwards; requests of 0 ends an outage early. With
+// pings the orchestrator's health probes are answered with the status too.
+func (s *ProtectedMCPServer) SetOutage(status, requests int, pings bool) {
+	s.outage.set(status, requests, pings)
 }
 
 // OutageRemaining reports how many requests the current outage still covers.

--- a/internal/testing/mock/outage_test.go
+++ b/internal/testing/mock/outage_test.go
@@ -36,7 +36,7 @@ func TestOutageGateAnswersThenRecovers(t *testing.T) {
 		t.Fatalf("disarmed gate must be transparent, got %d", got)
 	}
 
-	gate.set(http.StatusGatewayTimeout, 2)
+	gate.set(http.StatusGatewayTimeout, 2, false)
 	for i := 0; i < 2; i++ {
 		if got := get(); got != http.StatusGatewayTimeout {
 			t.Fatalf("request %d during the outage: got %d, want 504", i+1, got)
@@ -53,8 +53,8 @@ func TestOutageGateAnswersThenRecovers(t *testing.T) {
 	}
 
 	// Ending an outage early.
-	gate.set(http.StatusServiceUnavailable, 5)
-	gate.set(0, 0)
+	gate.set(http.StatusServiceUnavailable, 5, false)
+	gate.set(0, 0, false)
 	if got := get(); got != http.StatusOK {
 		t.Fatalf("a cleared gate must be transparent, got %d", got)
 	}
@@ -88,7 +88,7 @@ func TestOutageGatePassesPingsThrough(t *testing.T) {
 	}
 
 	const ping = `{"jsonrpc":"2.0","id":7,"method":"ping"}`
-	gate.set(http.StatusGatewayTimeout, 1)
+	gate.set(http.StatusGatewayTimeout, 1, false)
 	if got := post(ping); got != http.StatusOK {
 		t.Fatalf("a ping during the outage must be served, got %d", got)
 	}
@@ -100,6 +100,44 @@ func TestOutageGatePassesPingsThrough(t *testing.T) {
 	}
 	if len(seen) != 1 || seen[0] != ping {
 		t.Fatalf("the handler must see the ping with its body intact, saw %q", seen)
+	}
+}
+
+// TestOutageGateCountsPingsWhenArmedWithPings: a gate armed with pings answers
+// the health probe's ping with the status and consumes the outage for it, the
+// way a gateway that fails every request would; the handler never sees it.
+func TestOutageGateCountsPingsWhenArmedWithPings(t *testing.T) {
+	var gate outageGate
+	served := 0
+	handler := gate.wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served++
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(body string) int {
+		resp, err := http.Post(srv.URL, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	const ping = `{"jsonrpc":"2.0","id":7,"method":"ping"}`
+	gate.set(http.StatusNotFound, 1, true)
+	if got := post(ping); got != http.StatusNotFound {
+		t.Fatalf("a ping during an outage armed with pings must get the status, got %d", got)
+	}
+	if got := gate.remainingRequests(); got != 0 {
+		t.Fatalf("the ping must consume the outage: remaining %d, want 0", got)
+	}
+	if got := post(ping); got != http.StatusOK {
+		t.Fatalf("after the outage the ping must be served, got %d", got)
+	}
+	if served != 1 {
+		t.Fatalf("the handler must not see the ping the gate answered: served %d, want 1", served)
 	}
 }
 
@@ -124,7 +162,7 @@ func TestHTTPServerOutageSurvivesRestart(t *testing.T) {
 		t.Fatalf("Stop: %v", err)
 	}
 
-	srv.SetOutage(http.StatusBadGateway, 1)
+	srv.SetOutage(http.StatusBadGateway, 1, false)
 	if err := srv.StartOnPort(t.Context(), port); err != nil {
 		t.Fatalf("StartOnPort: %v", err)
 	}

--- a/internal/testing/scenarios/mcpserver-health-probe-restart-failure-is-retried.yaml
+++ b/internal/testing/scenarios/mcpserver-health-probe-restart-failure-is-retried.yaml
@@ -1,0 +1,121 @@
+name: "mcpserver-health-probe-restart-failure-is-retried"
+description: "A connected MCPServer whose gateway starts answering every request, the health probe's pings included, with HTTP 404 is detected by the probe and restarted; the restart's initialize fails on the 404, which is not a transient connectivity error, and the server must still be retried and reconnect on its own once the gateway serves again (#1187 review)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["mcpserver", "health", "orchestrator", "recovery", "regression"]
+timeout: "3m"
+
+# Given: a plain streamable-http MCPServer, connected. The harness probes
+#        every connected server every 1s with a 1s initial backoff, a 3s
+#        backoff cap and a 1s retry tick (production: 30s, 30s, 2m, 30s).
+# When:  its gateway answers every request -- the probe's pings included --
+#        with HTTP 404 (a route reprogrammed during a rollout, an auth proxy
+#        that lost its upstream).
+# Then:  the third failed probe turns the server unhealthy and the
+#        orchestrator restarts it; the restart's initialize gets the 404,
+#        which the client reports as "returned 4xx for initialize POST" and
+#        muster does not classify as a transient connectivity error.
+# When:  the gateway serves again.
+# Then:  the server reconnects on its own and its tool answers.
+#
+# Before the fix a non-transient start error after a health-triggered restart
+# left the server failed with no nextRetryAfter: the reconnect loop skipped it
+# ("No retry backoff set ... skipping automatic retry") and the server stayed
+# failed with its tools withdrawn until an operator restarted it by hand --
+# whereas before the probe existed the connection stayed up and served again
+# as soon as the gateway did.
+
+pre_configuration:
+  main_config:
+    config:
+      events: true
+
+  mcp_servers:
+    - name: "behind-reprogrammed-route"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "probe"
+            description: "Answers when the route reaches the backend"
+            input_schema:
+              type: "object"
+              properties: {}
+            responses:
+              - response: { alive: true }
+
+steps:
+  - id: "connected"
+    tool: "core_service_status"
+    args:
+      name: "behind-reprogrammed-route"
+    expected:
+      success: true
+      wait_for_state: "30s"
+      json_path:
+        state: "connected"
+        health: "healthy"
+    timeout: "45s"
+
+  - id: "probe-works"
+    tool: "x_behind-reprogrammed-route_probe"
+    args: {}
+    expected:
+      success: true
+      contains: ["alive"]
+    timeout: "15s"
+
+  - id: "route-answers-404"
+    description: "The gateway answers everything, pings included, with 404 until told otherwise"
+    tool: "test_set_mock_server_outage"
+    args:
+      server: "behind-reprogrammed-route"
+      status: 404
+      requests: 1000
+      pings: true
+    expected:
+      success: true
+      contains: ["answers its next 1000 requests with HTTP 404"]
+
+  - id: "unhealthy-detected-and-reconnect-failed-on-the-404"
+    description: "Three failed pings turn the server unhealthy; the reconnect attempt that follows runs into the 404 on initialize"
+    tool: "core_events"
+    args:
+      resourceType: "MCPServer"
+      resourceName: "behind-reprogrammed-route"
+    expected:
+      success: true
+      wait_for_state: "45s"
+      contains:
+        - "health check failed: 3 consecutive failures: MCP ping failed"
+        - "4xx for initialize POST"
+    timeout: "60s"
+
+  - id: "route-serves-again"
+    tool: "test_set_mock_server_outage"
+    args:
+      server: "behind-reprogrammed-route"
+      requests: 0
+    expected:
+      success: true
+
+  - id: "reconnected-on-its-own"
+    description: "The server is retried and reconnects without an operator. Before the fix it stayed failed with no nextRetryAfter and was never retried"
+    tool: "core_service_status"
+    args:
+      name: "behind-reprogrammed-route"
+    expected:
+      success: true
+      wait_for_state: "45s"
+      json_path:
+        state: "connected"
+        health: "healthy"
+    timeout: "60s"
+
+  - id: "probe-works-again"
+    tool: "x_behind-reprogrammed-route_probe"
+    args: {}
+    expected:
+      success: true
+      wait_for_state: "20s"
+      contains: ["alive"]
+    timeout: "30s"

--- a/internal/testing/scenarios/mcpserver-health-probe-spares-per-session-oauth-server.yaml
+++ b/internal/testing/scenarios/mcpserver-health-probe-spares-per-session-oauth-server.yaml
@@ -1,0 +1,139 @@
+name: "mcpserver-health-probe-spares-per-session-oauth-server"
+description: "An OAuth-protected MCPServer that a session has authenticated to stays connected under the orchestrator's health probe: its connection is the session's own DynamicAuthClient and the service has no shared client to ping, so the probe must not count the missing client as a failure, turn the server unhealthy, or restart it into auth_required (#1187 review)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["mcpserver", "health", "orchestrator", "oauth", "auth-required", "regression"]
+timeout: "3m"
+
+# Given: a streamable-http MCPServer behind OAuth without token forwarding.
+#        Start's anonymous initialize gets a 401 and settles the service in
+#        auth_required with no client; the OAuth callback and core_auth_login
+#        pool a per-session DynamicAuthClient and the aggregator syncs the
+#        service to connected/healthy. The harness probes every connected
+#        server every 1s (production: 30s); three failed probes turn a server
+#        unhealthy.
+# When:  five probe intervals pass.
+# Then:  the server is still connected and healthy with no health-check
+#        failure counted, no MCPServerHealthCheckFailed and no recovery event
+#        was emitted, and the session's tool still answers.
+#
+# Before the fix the probe found no shared client, counted "MCP client not
+# available" on every tick, declared the server unhealthy on the third tick,
+# emitted MCPServerHealthCheckFailed and restarted it: Stop, Start -> 401 ->
+# auth_required, MCPServerRecoveryFailed -- 3s (production: 90s) after every
+# core_auth_login, undoing the login's state sync while the session kept
+# working.
+
+pre_configuration:
+  main_config:
+    config:
+      events: true
+
+  mock_oauth_servers:
+    - name: "probe-oauth-idp"
+      scopes: ["openid", "profile", "api:access"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "probe-oauth-client"
+
+  mcp_servers:
+    - name: "oauth-probed"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "probe-oauth-idp"
+          scope: "api:access"
+        tools:
+          - name: "get_protected_data"
+            description: "Answers through the session's OAuth token"
+            responses:
+              - response: { status: "success", message: "You have access to protected data" }
+
+    # A plain server whose tool takes five probe intervals to answer: calling
+    # it is how the scenario lets the probes run without a sleep step.
+    - name: "clock"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "wait"
+            description: "Answers after five health-probe intervals"
+            responses:
+              - response: { waited: "5s" }
+                delay: "5s"
+
+steps:
+  - id: "authenticate"
+    tool: "test_simulate_oauth_callback"
+    args:
+      server: "oauth-probed"
+    expected:
+      success: true
+      contains: ["success"]
+
+  - id: "establish-connection"
+    tool: "core_auth_login"
+    args:
+      server: "oauth-probed"
+    expected:
+      success: true
+
+  - id: "connected-after-login"
+    description: "The login syncs the service to connected/healthy although it has no shared client"
+    tool: "core_service_status"
+    args:
+      name: "oauth-probed"
+    expected:
+      success: true
+      wait_for_state: "15s"
+      json_path:
+        state: "connected"
+        health: "healthy"
+        metadata:
+          clientReady: false
+    timeout: "30s"
+
+  - id: "five-probe-intervals"
+    description: "Let the health loop probe five times"
+    tool: "x_clock_wait"
+    args: {}
+    expected:
+      success: true
+      contains: ["waited"]
+    timeout: "30s"
+
+  - id: "no-health-check-failure-emitted"
+    description: "No probe failure was counted against the session-served server. Before the fix: 'health check failed: 3 consecutive failures: MCP client not available' and 'automatic recovery process started' after three ticks"
+    tool: "core_events"
+    args:
+      resourceType: "MCPServer"
+      resourceName: "oauth-probed"
+    expected:
+      success: true
+      not_contains:
+        - "health check failed"
+        - "automatic recovery process started"
+    timeout: "15s"
+
+  - id: "still-connected"
+    description: "The state the login synced is intact and nothing was counted. Before the fix: auth_required after the health-triggered restart"
+    tool: "core_service_status"
+    args:
+      name: "oauth-probed"
+    expected:
+      success: true
+      json_path:
+        state: "connected"
+        health: "healthy"
+        metadata:
+          consecutiveHealthCheckFailures: 0
+    timeout: "15s"
+
+  - id: "session-tool-still-answers"
+    tool: "x_oauth-probed_get_protected_data"
+    args: {}
+    expected:
+      success: true
+      contains: ["You have access to protected data"]
+    timeout: "15s"

--- a/internal/testing/scenarios/mcpserver-health-probe-spares-session-auth-server.yaml
+++ b/internal/testing/scenarios/mcpserver-health-probe-spares-session-auth-server.yaml
@@ -1,0 +1,140 @@
+name: "mcpserver-health-probe-spares-session-auth-server"
+description: "A forwardToken (SSO) MCPServer that a session has logged into stays connected under the orchestrator's health probe: it is served per session and has no shared client to ping, so the probe must not count the missing client as a failure, turn the server unhealthy, or restart it into auth_required (#1187 review)"
+category: "behavioral"
+concept: "mcpserver"
+tags: ["mcpserver", "health", "orchestrator", "oauth", "sso", "token-forwarding", "regression"]
+timeout: "3m"
+
+# Given: a streamable-http MCPServer with forwardToken. Start settles it in
+#        auth_required with the anonymous probe client discarded; the login
+#        forwards muster's ID token over the session's own connection and the
+#        aggregator syncs the service to connected/healthy. The service has no
+#        shared client (clientReady false) -- its tools are served through the
+#        session. The harness probes every connected server every 1s
+#        (production: 30s); three failed probes turn a server unhealthy.
+# When:  five probe intervals pass.
+# Then:  the server is still connected and healthy with no health-check
+#        failure counted, no MCPServerHealthCheckFailed and no recovery event
+#        was emitted, and the session's tool still answers.
+#
+# Before the fix the probe pinged the missing shared client, counted "MCP
+# client not available" once per tick, declared the server unhealthy on the
+# third tick, emitted MCPServerHealthCheckFailed and restarted it: Stop, Start,
+# discardAnonymousProbe -> auth_required, MCPServerRecoveryFailed. The state
+# the login had synced was undone 3s (production: 90s) after every login, and
+# the cycle re-armed on the next session connect.
+
+pre_configuration:
+  main_config:
+    config:
+      events: true
+
+  mock_oauth_servers:
+    - name: "probe-idp"
+      scopes: ["openid", "profile", "mcp:admin"]
+      auto_approve: true
+      pkce_required: false
+      token_lifetime: "1h"
+      client_id: "muster-client"
+      client_secret: "muster-secret"
+      use_as_muster_oauth_server: true
+
+  mcp_servers:
+    - name: "sso-probed"
+      config:
+        type: "streamable-http"
+        oauth:
+          required: true
+          mock_oauth_server_ref: "probe-idp"
+          forward_token: true
+        tools:
+          - name: "downstream_op"
+            description: "Answers through the session's forwarded token"
+            responses:
+              - response: { source: "sso-probed", status: "authenticated-via-sso" }
+
+    # A plain server whose tool takes five probe intervals to answer: calling
+    # it is how the scenario lets the probes run without a sleep step.
+    - name: "clock"
+      config:
+        type: "streamable-http"
+        tools:
+          - name: "wait"
+            description: "Answers after five health-probe intervals"
+            responses:
+              - response: { waited: "5s" }
+                delay: "5s"
+
+steps:
+  - id: "muster-auth-login"
+    tool: "test_muster_auth_login"
+    args: {}
+    expected:
+      success: true
+      contains: ["success", "ID token stored"]
+
+  - id: "login-with-sso"
+    tool: "core_auth_login"
+    args:
+      server: "sso-probed"
+    expected:
+      success: true
+
+  - id: "connected-after-login"
+    description: "The login syncs the service to connected/healthy although it has no shared client"
+    tool: "core_service_status"
+    args:
+      name: "sso-probed"
+    expected:
+      success: true
+      wait_for_state: "15s"
+      json_path:
+        state: "connected"
+        health: "healthy"
+        metadata:
+          clientReady: false
+    timeout: "30s"
+
+  - id: "five-probe-intervals"
+    description: "Let the health loop probe five times"
+    tool: "x_clock_wait"
+    args: {}
+    expected:
+      success: true
+      contains: ["waited"]
+    timeout: "30s"
+
+  - id: "no-health-check-failure-emitted"
+    description: "No probe failure was counted against the session-served server. Before the fix: 'health check failed: 3 consecutive failures: MCP client not available' and 'automatic recovery process started' after three ticks"
+    tool: "core_events"
+    args:
+      resourceType: "MCPServer"
+      resourceName: "sso-probed"
+    expected:
+      success: true
+      not_contains:
+        - "health check failed"
+        - "automatic recovery process started"
+    timeout: "15s"
+
+  - id: "still-connected"
+    description: "The state the login synced is intact and nothing was counted. Before the fix: auth_required after the health-triggered restart"
+    tool: "core_service_status"
+    args:
+      name: "sso-probed"
+    expected:
+      success: true
+      json_path:
+        state: "connected"
+        health: "healthy"
+        metadata:
+          consecutiveHealthCheckFailures: 0
+    timeout: "15s"
+
+  - id: "session-tool-still-answers"
+    tool: "x_sso-probed_downstream_op"
+    args: {}
+    expected:
+      success: true
+      contains: ["authenticated-via-sso"]
+    timeout: "15s"

--- a/internal/testing/test_tools.go
+++ b/internal/testing/test_tools.go
@@ -2079,7 +2079,7 @@ func (h *TestToolsHandler) handleStartMockServer(ctx context.Context, args map[s
 // mockServerOutage is the part of a mock MCP HTTP server (plain or
 // OAuth-protected) that the outage test tool drives.
 type mockServerOutage interface {
-	SetOutage(status, requests int)
+	SetOutage(status, requests int, pings bool)
 	OutageRemaining() int
 }
 
@@ -2089,12 +2089,14 @@ type mockServerOutage interface {
 // default) rather than a refused connection -- the shape of a gateway or
 // tunnel in front of a healthy server failing for a while. One initialize
 // attempt is one request, so requests counts failed attempts; requests of 0
-// ends an outage early.
+// ends an outage early. The orchestrator's health-probe pings pass through
+// uncounted unless pings is set, in which case the gateway fails them too.
 //
 // Args:
 //   - server: Required. Name of the mock MCP server.
 //   - requests: Required. Number of requests to answer with the status (0 clears).
 //   - status: Optional. HTTP status to answer with (default 504).
+//   - pings: Optional. Answer MCP pings with the status as well (default false).
 func (h *TestToolsHandler) handleSetMockServerOutage(_ context.Context, args map[string]interface{}) (interface{}, error) {
 	serverName, ok := args["server"].(string)
 	if !ok || serverName == "" {
@@ -2119,9 +2121,10 @@ func (h *TestToolsHandler) handleSetMockServerOutage(_ context.Context, args map
 	if !ok {
 		return nil, fmt.Errorf("mock server %s does not support outages", serverName)
 	}
-	gate.SetOutage(status, requests)
+	pings, _ := args["pings"].(bool)
+	gate.SetOutage(status, requests, pings)
 	if h.debug {
-		h.logger.Debug("Mock server '%s' answers its next %d requests with HTTP %d\n", serverName, requests, status)
+		h.logger.Debug("Mock server '%s' answers its next %d requests with HTTP %d (pings included: %t)\n", serverName, requests, status, pings)
 	}
 	return map[string]interface{}{
 		api.FieldSuccess: true,
@@ -2129,6 +2132,7 @@ func (h *TestToolsHandler) handleSetMockServerOutage(_ context.Context, args map
 		api.FieldServer:  serverName,
 		"status":         status,
 		"requests":       requests,
+		"pings":          pings,
 	}, nil
 }
 


### PR DESCRIPTION
## What

Three behavioral scenarios that reproduce findings from the review of #1187, plus the one mock-server hook they need. The PR targets `feat-orchestrator-health-probing` so the scenarios can land inside #1187. On the current head (e02983af) all three fail at the step that names the defect; each goes green once the health loop behaves as the scenario's description says, whatever shape the fix takes.

| Scenario | Reproduces | Fails today at |
|---|---|---|
| `mcpserver-health-probe-spares-session-auth-server` | A forwardToken (SSO) server that a session logged into is synced to `connected` by the aggregator with no shared client. The probe pings the missing client, counts "MCP client not available" once per tick, declares the server unhealthy on the third tick, emits `MCPServerHealthCheckFailed` and restarts it into `auth_required` (Stop, Start, `discardAnonymousProbe`, `MCPServerRecoveryFailed`), undoing the login's state sync 3 s after every login (90 s in production) and re-arming on the next session connect. | `no-health-check-failure-emitted`: `core_events` carries `health check failed: 3 consecutive failures: MCP client not available`, `automatic recovery process started`, `automatic recovery failed: authentication required: server returned 401` |
| `mcpserver-health-probe-spares-per-session-oauth-server` | The same for an OAuth-protected server without token forwarding: the connection is the session's own `DynamicAuthClient`, the service has no shared client. | `no-health-check-failure-emitted`, same events |
| `mcpserver-health-probe-restart-failure-is-retried` | A connected server whose gateway answers every request, pings included, with HTTP 404. The probe detects it and the orchestrator restarts; the restart's initialize gets the 404 (`server returned 4xx for initialize POST, likely a legacy SSE server`), which `isTransientConnectivityError` does not classify as transient, so `Start` sets Failed with no `nextRetryAfter` and the reconnect loop skips the server forever. Before the probe existed the connection stayed up and served again as soon as the gateway did. | `reconnected-on-its-own`: `core_service_status` stays `failed` after the outage ends; instance log `No retry backoff set for behind-reprogrammed-route, skipping automatic retry` |

The two session-auth scenarios wait out five probe intervals by calling a tool on a plain mock server whose response carries `delay: "5s"`; the harness has no sleep step, and the plain server is unaffected by the restart of the server under test. Both assert `metadata.clientReady: false` on the connected server first, so the setup they rely on is visible in the step output.

## Mock change

`test_set_mock_server_outage` gains an optional `pings: true`. An outage armed with it answers the orchestrator's MCP pings with the status too, the way a gateway that fails every request would; without it pings pass through uncounted exactly as before, so an outage of N requests still fails N connection attempts and `mcpserver-remote-backoff-cap` is unchanged. The gate now inspects a request body only while it is armed, and names the ping method through `mcp.MethodPing`. Covered by `TestOutageGateCountsPingsWhenArmedWithPings`.

## Verified

Built from this branch and run against the current head with the repo's harness settings (1 s probe interval):

- the three new scenarios fail at the steps listed above (5.6 s, 5.5 s, 48.4 s);
- `mcpserver-health-probe-restarts-dead-backend`, `mcpserver-remote-backoff-cap` and `mcpserver-restart-request-endpoint-down` still pass with the gate change;
- `go test ./internal/testing/mock/`, `go vet` and `golangci-lint run ./internal/testing/...` are clean.

```bash
go build -o muster . && PATH=$PWD:$PATH ./muster test --scenario mcpserver-health-probe-spares-session-auth-server --verbose
```

## Review findings not covered by a scenario

These are unit-test territory; the harness cannot make their timing deterministic:

- `Start`/`Stop`/`Restart` have no mutual exclusion and `createAndInitializeClient` assigns `s.client` unconditionally, so a health-triggered restart racing an operator or reconciler restart leaves two Starts past the `IsRunning()` guard and the second client overwrites the first without closing it.
- The `isActiveState` re-check in `probeAndRecover` and `svc.Restart` are not atomic: a `RemoveService` (CR deleted) or a filesystem-mode `core_service_stop` landing in Restart's Stop -> 200 ms grace -> Start window is undone, and for `RemoveService` the Start completes on an unregistered service whose live client nothing can reach.
- After waiting for a restart slot only the state is re-checked, not the health, so a verdict up to ~35 s old restarts a server an operator or the reconciler already repaired.
- `HealthCheckTimeout` is a fixed 10 s that ignores the server's `spec.timeout`; a probe cancelled by orchestrator shutdown is counted as a failure; a JSON-RPC error answer to `ping` (a backend without ping) is counted as a dead connection, and mcp-go's `Ping` is a no-op on the 2026-07-28 protocol with no guard in `CheckHealth`.
- The Restart-failure branch, the `ctx.Done` slot wait and the `healthTicker` wiring in `probeAndRecover`/`retryFailedMCPServers` have no unit coverage; `mockService` already carries `restartErr`.


## CI on this PR

`go-build` runs the integration suite (`./muster test --parallel 50`), so this PR is red on purpose until the health loop is fixed: the three scenarios fail here exactly as they will on the PR branch. The intended flow is to merge it into `feat-orchestrator-health-probing` together with the fixes and treat the scenarios as the acceptance criteria.
